### PR TITLE
fix: honor PI_CODING_AGENT_DIR, drop createRequire, fix multi-cell prefix

### DIFF
--- a/.changeset/olive-donkeys-marry.md
+++ b/.changeset/olive-donkeys-marry.md
@@ -1,0 +1,11 @@
+---
+'@nicknisi/pi-artifacts': patch
+'@nicknisi/pi-chat-input': minor
+'@nicknisi/pi-llm-council': patch
+---
+
+Resolve user config through pi's `getAgentDir()` instead of hardcoding `~/.pi/agent`, so these extensions honor `PI_CODING_AGENT_DIR` and work under harnesses that relocate the agent dir. Behavior is unchanged when the variable is unset.
+
+`artifacts` resolves diff2html's stylesheet with a direct `import.meta.resolve(...)` call instead of `createRequire`, keeping it loadable under jiti and in single-file bundles.
+
+`chat-input` now supports prefixes of any cell width. The layout math previously assumed a 1-cell prefix, so a two-cell `prefix` (e.g. `❮❯`) overflowed the box by one cell and under-indented continuation lines. Rendering is unchanged for 1-cell prefixes.

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -101,6 +101,9 @@ One optional config file, read once at extension load (restart pi to apply chang
 ~/.pi/agent/configs/artifacts.json
 ```
 
+The path follows pi's agent dir, so it moves with `PI_CODING_AGENT_DIR` if you
+set it.
+
 Copy [`artifacts.example.json`](artifacts.example.json) there. All keys optional; invalid values fall back to defaults.
 
 | Key           | Type                        | Default   | Meaning                                                                         |

--- a/packages/artifacts/config.ts
+++ b/packages/artifacts/config.ts
@@ -1,8 +1,8 @@
 /** Config: storage paths, server constants, and user-tunable theme settings. */
 
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 /** Directory for artifact files, relative to project root (mirrors plan-mode's .pi/plans). */
 export const ARTIFACT_DIR = '.pi/artifacts';
@@ -33,7 +33,7 @@ const DEFAULTS: ArtifactsConfig = {
   maxWidth: 860,
 };
 
-const CONFIG_PATH = join(homedir(), '.pi', 'agent', 'configs', 'artifacts.json');
+const CONFIG_PATH = join(getAgentDir(), 'configs', 'artifacts.json');
 
 function loadConfig(): ArtifactsConfig {
   try {

--- a/packages/artifacts/styles.ts
+++ b/packages/artifacts/styles.ts
@@ -1,14 +1,28 @@
 /** Bespoke document stylesheet: design tokens, light/dark schemes, prose, chrome, diff + code theming. */
 
 import { readFileSync } from 'node:fs';
-import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 
 import { CONFIG } from './config.js';
 
-const require = createRequire(import.meta.url);
-
-/** diff2html base stylesheet, read from the installed package (stays in sync with its JS). */
-const D2H_BASE_CSS = readFileSync(require.resolve('diff2html/bundles/css/diff2html.min.css'), 'utf-8');
+/**
+ * diff2html base stylesheet, read from the installed package (stays in sync
+ * with its JS).
+ *
+ * Resolved with a *direct* `import.meta.resolve(...)` call rather than
+ * `createRequire`: pi loads extensions through jiti, which rewrites only
+ * call expressions, and hosts that bundle the extension into a single file
+ * have no on-disk node_modules for `createRequire` to walk. There the call
+ * throws, so the catch degrades to unstyled diffs rather than failing
+ * extension load.
+ */
+const D2H_BASE_CSS = (() => {
+  try {
+    return readFileSync(fileURLToPath(import.meta.resolve('diff2html/bundles/css/diff2html.min.css')), 'utf-8');
+  } catch {
+    return '';
+  }
+})();
 
 // ─── Design tokens ─────────────────────────────────────────────────────────────
 // One scheme = one flat token set. The accent is user-configurable; everything

--- a/packages/chat-input/README.md
+++ b/packages/chat-input/README.md
@@ -66,8 +66,9 @@ Layout (boxed):
 ## Configuration
 
 Config is read once at extension load from
-`~/.pi/agent/configs/chat-input.json` — restart pi to apply changes. Missing
-file or invalid JSON falls back to all defaults silently. Copy
+`~/.pi/agent/configs/chat-input.json` — restart pi to apply changes. The path
+follows pi's agent dir, so it moves with `PI_CODING_AGENT_DIR` if you set it.
+Missing file or invalid JSON falls back to all defaults silently. Copy
 `chat-input.example.json` from this package as a starting point.
 
 ```json

--- a/packages/chat-input/config.ts
+++ b/packages/chat-input/config.ts
@@ -1,8 +1,8 @@
-/** Config for chat-input — loaded once at extension load from ~/.pi/agent/configs/chat-input.json. */
+/** Config for chat-input — loaded once at extension load from <agent-dir>/configs/chat-input.json. */
 
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export const DEFAULT_CONFIG = {
   /** Full box with side borders, or top/bottom horizontal rules only. */
@@ -40,7 +40,7 @@ interface ChatInputUserConfig {
   focusedBorderColor?: string;
 }
 
-const CONFIG_PATH = join(homedir(), '.pi', 'agent', 'configs', 'chat-input.json');
+const CONFIG_PATH = join(getAgentDir(), 'configs', 'chat-input.json');
 
 function loadUserConfig(): ChatInputUserConfig {
   try {

--- a/packages/chat-input/index.ts
+++ b/packages/chat-input/index.ts
@@ -22,9 +22,9 @@
  *   ╰──────────────────────────╯
  *   <autocomplete menu>
  *
- * The prefix (default ❯) is shown only on the first body line; subsequent
- * lines get a space so content aligns. Autocomplete lines render below the
- * box, indented by `extraMenuIndent`.
+ * The prefix (default ❯, any cell width) is shown only on the first body line;
+ * subsequent lines are indented by the prefix's width so content aligns.
+ * Autocomplete lines render below the box, indented by `extraMenuIndent`.
  */
 
 // ─── Paste-again-to-expand ────────────────────────────────────────────────
@@ -97,6 +97,42 @@ function getScrollText(line: string): string | null {
 
 function isBorderLike(line: string): boolean {
   return isSolidBorder(line) || getScrollText(line) !== null;
+}
+
+/** Prefix width in terminal cells — layout math supports multi-cell prefixes. */
+const PREFIX_W = Math.max(1, visibleWidth(CONFIG.PREFIX));
+
+/** Locate pi's stock top/bottom borders and their scroll indicators in a render. */
+function scanBorders(stock: string[]): {
+  firstIdx: number;
+  lastIdx: number;
+  topScroll: string | null;
+  bottomScroll: string | null;
+} {
+  const firstIdx = stock.findIndex(isBorderLike);
+  let lastIdx = -1;
+  for (let i = stock.length - 1; i >= 0; i--) {
+    if (isBorderLike(stock[i]!)) {
+      lastIdx = i;
+      break;
+    }
+  }
+  const topScroll = firstIdx !== -1 ? getScrollText(stock[firstIdx]!) : null;
+  const bottomScroll = lastIdx !== -1 && lastIdx !== firstIdx ? getScrollText(stock[lastIdx]!) : null;
+  return { firstIdx, lastIdx, topScroll, bottomScroll };
+}
+
+/** Autocomplete-menu lines (after the last stock border), indented and padded to width. */
+function menuLines(stock: string[], lastIdx: number, width: number): string[] {
+  if (lastIdx === -1) return [];
+  const indent = ' '.repeat(CONFIG.EXTRA_MENU_INDENT);
+  const menu: string[] = [];
+  for (let i = lastIdx + 1; i < stock.length; i++) {
+    const vw = visibleWidth(stock[i]!);
+    const fill = vw + CONFIG.EXTRA_MENU_INDENT < width ? ' '.repeat(width - vw - CONFIG.EXTRA_MENU_INDENT) : '';
+    menu.push(indent + stock[i]! + fill);
+  }
+  return menu;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────
@@ -193,9 +229,11 @@ class ChatInput extends CustomEditor {
 
   render(width: number): string[] {
     const padMultiplier = CONFIG.BOXED_VIEW ? 3 : 1;
-    if (width < 5 + CONFIG.BOX_PAD_X * padMultiplier) return super.render(width);
+    if (width < 4 + PREFIX_W + CONFIG.BOX_PAD_X * padMultiplier) return super.render(width);
 
-    const contentWidth = CONFIG.BOXED_VIEW ? width - 3 - CONFIG.BOX_PAD_X * 3 : width - 2 * CONFIG.BOX_PAD_X - 1;
+    const contentWidth = CONFIG.BOXED_VIEW
+      ? width - 2 - CONFIG.BOX_PAD_X * 3 - PREFIX_W
+      : width - 2 * CONFIG.BOX_PAD_X - PREFIX_W;
     const stock = super.render(contentWidth);
     if (stock.length < 2) return super.render(width);
 
@@ -204,116 +242,65 @@ class ChatInput extends CustomEditor {
       : this.renderUnboxed(stock, contentWidth, width);
   }
 
+  /** A horizontal rule of `width` cells, with the scroll indicator inlaid when present. */
+  private rule(scroll: string | null, width: number): string {
+    if (!scroll) return this.border('─'.repeat(width));
+    const label = `── ${scroll} `;
+    return this.border(label) + this.border('─'.repeat(Math.max(0, width - visibleWidth(label))));
+  }
+
+  /** Body lines (between the stock borders): pad + prefix + content, then `wrap`. */
+  private bodyLines(
+    stock: string[],
+    firstIdx: number,
+    lastIdx: number,
+    contentWidth: number,
+    wrap: (inner: string) => string,
+  ): string[] {
+    const pad = ' '.repeat(CONFIG.BOX_PAD_X);
+    const body: string[] = [];
+    let isFirst = true;
+    for (let i = 0; i < stock.length; i++) {
+      if (i === firstIdx || i === lastIdx) continue;
+      if (lastIdx !== -1 && i > lastIdx) continue;
+      const vw = visibleWidth(stock[i]!);
+      const fill = vw < contentWidth ? ' '.repeat(contentWidth - vw) : '';
+      const prefixStr = isFirst ? this.accent(CONFIG.PREFIX) : ' '.repeat(PREFIX_W);
+      body.push(wrap(pad + prefixStr + pad + stock[i]! + fill));
+      isFirst = false;
+    }
+    return body;
+  }
+
   private renderBoxed(stock: string[], contentWidth: number, width: number): string[] {
     const c = this.corners;
     const innerWidth = width - 2;
-
-    const firstIdx = stock.findIndex(isBorderLike);
-    let lastIdx = -1;
-    for (let i = stock.length - 1; i >= 0; i--) {
-      if (isBorderLike(stock[i]!)) {
-        lastIdx = i;
-        break;
-      }
-    }
-
-    const buildTop = (scroll: string | null): string =>
-      scroll
-        ? this.border(c.tl) +
-          this.border(`── ${scroll} `) +
-          this.border('─'.repeat(Math.max(0, innerWidth - visibleWidth(`── ${scroll} `)))) +
-          this.border(c.tr)
-        : this.border(c.tl) + this.border('─'.repeat(innerWidth)) + this.border(c.tr);
-    const buildBottom = (scroll: string | null): string =>
-      scroll
-        ? this.border(c.bl) +
-          this.border(`── ${scroll} `) +
-          this.border('─'.repeat(Math.max(0, innerWidth - visibleWidth(`── ${scroll} `)))) +
-          this.border(c.br)
-        : this.border(c.bl) + this.border('─'.repeat(innerWidth)) + this.border(c.br);
-
-    const topScroll = firstIdx !== -1 ? getScrollText(stock[firstIdx]!) : null;
-    const bottomScroll = lastIdx !== -1 && lastIdx !== firstIdx ? getScrollText(stock[lastIdx]!) : null;
-    const top = buildTop(topScroll);
-    const bottom = buildBottom(bottomScroll);
-
+    const { firstIdx, lastIdx, topScroll, bottomScroll } = scanBorders(stock);
     const pad = ' '.repeat(CONFIG.BOX_PAD_X);
 
-    // Body lines (between first and last border).
-    const body: string[] = [];
-    let isFirst = true;
-    for (let i = 0; i < stock.length; i++) {
-      if (i === firstIdx || i === lastIdx) continue;
-      if (lastIdx !== -1 && i > lastIdx) continue;
-      const vw = visibleWidth(stock[i]!);
-      const fill = vw < contentWidth ? ' '.repeat(contentWidth - vw) : '';
-      const prefixStr = isFirst ? this.accent(CONFIG.PREFIX) : ' ';
-      body.push(this.border(c.side) + pad + prefixStr + pad + stock[i]! + fill + pad + this.border(c.side));
-      isFirst = false;
-    }
-
-    // Menu lines (after last border).
-    const menu: string[] = [];
-    if (lastIdx !== -1) {
-      for (let i = lastIdx + 1; i < stock.length; i++) {
-        const vw = visibleWidth(stock[i]!);
-        const indent = ' '.repeat(CONFIG.EXTRA_MENU_INDENT);
-        const fill = vw + CONFIG.EXTRA_MENU_INDENT < width ? ' '.repeat(width - vw - CONFIG.EXTRA_MENU_INDENT) : '';
-        menu.push(indent + stock[i]! + fill);
-      }
-    }
+    const top = this.border(c.tl) + this.rule(topScroll, innerWidth) + this.border(c.tr);
+    const bottom = this.border(c.bl) + this.rule(bottomScroll, innerWidth) + this.border(c.br);
+    const body = this.bodyLines(
+      stock,
+      firstIdx,
+      lastIdx,
+      contentWidth,
+      (inner) => this.border(c.side) + inner + pad + this.border(c.side),
+    );
 
     const gap = Array.from({ length: CONFIG.MENU_GAP }, () => '');
-    return [top, ...body, bottom, ...gap, ...menu];
+    return [top, ...body, bottom, ...gap, ...menuLines(stock, lastIdx, width)];
   }
 
   private renderUnboxed(stock: string[], contentWidth: number, width: number): string[] {
-    const firstIdx = stock.findIndex(isBorderLike);
-    let lastIdx = -1;
-    for (let i = stock.length - 1; i >= 0; i--) {
-      if (isBorderLike(stock[i]!)) {
-        lastIdx = i;
-        break;
-      }
-    }
+    const { firstIdx, lastIdx, topScroll, bottomScroll } = scanBorders(stock);
 
-    const buildTop = (scroll: string | null): string =>
-      scroll
-        ? this.border(`── ${scroll} `) + this.border('─'.repeat(Math.max(0, width - visibleWidth(`── ${scroll} `))))
-        : this.border('─'.repeat(width));
-    const buildBottom = buildTop; // identical for unboxed
-
-    const topScroll = firstIdx !== -1 ? getScrollText(stock[firstIdx]!) : null;
-    const bottomScroll = lastIdx !== -1 && lastIdx !== firstIdx ? getScrollText(stock[lastIdx]!) : null;
-    const top = buildTop(topScroll);
-    const bottom = buildBottom(bottomScroll);
-
-    const pad = ' '.repeat(CONFIG.BOX_PAD_X);
-
-    const body: string[] = [];
-    let isFirst = true;
-    for (let i = 0; i < stock.length; i++) {
-      if (i === firstIdx || i === lastIdx) continue;
-      if (lastIdx !== -1 && i > lastIdx) continue;
-      const vw = visibleWidth(stock[i]!);
-      const fill = vw < contentWidth ? ' '.repeat(contentWidth - vw) : '';
-      const prefixStr = isFirst ? this.accent(CONFIG.PREFIX) : ' ';
-      body.push(pad + prefixStr + pad + stock[i]! + fill);
-      isFirst = false;
-    }
-
-    const menu: string[] = [];
-    if (lastIdx !== -1) {
-      for (let i = lastIdx + 1; i < stock.length; i++) {
-        const vw = visibleWidth(stock[i]!);
-        const indent = ' '.repeat(CONFIG.EXTRA_MENU_INDENT);
-        const fill = vw + CONFIG.EXTRA_MENU_INDENT < width ? ' '.repeat(width - vw - CONFIG.EXTRA_MENU_INDENT) : '';
-        menu.push(indent + stock[i]! + fill);
-      }
-    }
+    const top = this.rule(topScroll, width);
+    const bottom = this.rule(bottomScroll, width);
+    const body = this.bodyLines(stock, firstIdx, lastIdx, contentWidth, (inner) => inner);
 
     const gap = Array.from({ length: CONFIG.MENU_GAP }, () => '');
-    return [top, ...body, bottom, ...gap, ...menu];
+    return [top, ...body, bottom, ...gap, ...menuLines(stock, lastIdx, width)];
   }
 }
 

--- a/packages/chat-input/utils.ts
+++ b/packages/chat-input/utils.ts
@@ -1,6 +1,6 @@
 import type { Theme, ThemeColor } from '@earendil-works/pi-coding-agent';
 
-const ANSI_RE = /\x1b\[[0-9;]*m|\x1b\[0?m/g;
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
 
 /** Strip ANSI escapes so we can inspect a rendered line's visible characters. */
 export function plainText(line: string): string {

--- a/packages/llm-council/README.md
+++ b/packages/llm-council/README.md
@@ -77,7 +77,7 @@ Or steer it directly: "use llm_council to compare these two designs". The tool r
 
 Two layers:
 
-1. **Global:** `~/.pi/agent/configs/llm-council.json` — copy [`llm-council.example.json`](llm-council.example.json). Loaded once at module load; this is the only source for `shared` (display) settings.
+1. **Global:** `~/.pi/agent/configs/llm-council.json` — copy [`llm-council.example.json`](llm-council.example.json). Loaded once at module load; this is the only source for `shared` (display) settings. The path follows pi's agent dir, so it moves with `PI_CODING_AGENT_DIR` if you set it.
 2. **Project-local:** `<cwd>/.pi/configs/llm-council.json` — copy [`llm-council.project.example.json`](llm-council.project.example.json). Deep-merged over the global file per tool call, so only differing keys are needed — typically `member.council` and `chairman.model` to give a work project a different lineup. Display (`shared`) settings do **not** apply from the project file.
 
 No environment variables are read for configuration. (`PI_SUBAGENT_DEPTH` is set internally to block recursion.)

--- a/packages/llm-council/config.ts
+++ b/packages/llm-council/config.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
 import type { CouncilMemberUserConfig, LlmCouncilUserConfig } from './types.js';
 
 // ── Defaults ───────────────────────────────────────────────────────────────
@@ -88,7 +88,7 @@ export const DEFAULT_CONFIG = {
 //           only the keys that differ need to be present — e.g. just
 //           member.council and chairman.model for a per-project lineup)
 
-const GLOBAL_CONFIG_PATH = join(homedir(), '.pi', 'agent', 'configs', 'llm-council.json');
+const GLOBAL_CONFIG_PATH = join(getAgentDir(), 'configs', 'llm-council.json');
 
 function projectConfigPath(cwd: string): string {
   return join(cwd, '.pi', 'configs', 'llm-council.json');

--- a/packages/llm-council/index.ts
+++ b/packages/llm-council/index.ts
@@ -16,7 +16,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtensionAPI, Theme } from '@earendil-works/pi-coding-agent';
-import { getMarkdownTheme } from '@earendil-works/pi-coding-agent';
+import { getAgentDir, getMarkdownTheme } from '@earendil-works/pi-coding-agent';
 import { Markdown, Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 import { CONFIG, loadCouncil, type ResolvedCouncil } from './config.js';
@@ -55,6 +55,61 @@ function toolHeader(label: string, summary: string, theme: Theme, dot?: string, 
   return `${d}${title} ${summary}`;
 }
 
+/** Status icon: ✓ / ✗ / spinner frame / waiting glyph. */
+function statusIcon(status: MemberResult['status'], theme: Theme, spinnerFrame: number): string {
+  switch (status) {
+    case 'done':
+      return applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.successPrefix.prefix);
+    case 'error':
+      return applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix);
+    case 'working':
+      return applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]);
+    default:
+      return applyColor(theme, CONFIG.shared.status.waitingIconColor, CONFIG.shared.status.waitingIcon);
+  }
+}
+
+/** `<icon> <label> <model>` member row. */
+function memberHeader(icon: string, m: Pick<MemberResult, 'label' | 'model' | 'displayName'>, theme: Theme): string {
+  return indentLine(
+    `${icon} ${applyColor(theme, CONFIG.member.display.labelColor, m.label)} ${applyColor(theme, CONFIG.member.display.modelColor, m.displayName ?? m.model)}`,
+  );
+}
+
+/** `<icon> [badge] Chairman <model>` row. */
+function chairmanHeader(icon: string, c: { model: string; displayName?: string }, theme: Theme): string {
+  const badge = CONFIG.chairman.display.icon ? `${CONFIG.chairman.display.icon} ` : '';
+  return indentLine(
+    `${icon} ${badge}${applyColor(theme, CONFIG.chairman.display.labelColor, 'Chairman')} ${applyColor(theme, CONFIG.chairman.display.modelColor, c.displayName ?? c.model)}`,
+  );
+}
+
+/** "done + elapsed" sub-line. */
+function doneLine(theme: Theme, m: { startedAt?: number; doneAt?: number }): string {
+  return `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`;
+}
+
+/** "error message (or label) + elapsed" sub-line. */
+function errorLine(theme: Theme, m: { error?: string; startedAt?: number; doneAt?: number }): string {
+  return `${applyColor(theme, CONFIG.shared.status.errorColor, m.error?.slice(0, 60) || CONFIG.shared.status.errorLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`;
+}
+
+function workingLine(theme: Theme): string {
+  return applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.workingLabel);
+}
+
+/** Sub-line while members may still be running: done/error show elapsed, else "working". */
+function memberLiveSubLine(m: MemberResult, theme: Theme): string {
+  if (m.status === 'done') return doneLine(theme, m);
+  if (m.status === 'error') return errorLine(theme, m);
+  return workingLine(theme);
+}
+
+/** Sub-line once members have settled (done or error only). */
+function memberFinalSubLine(m: MemberResult, theme: Theme): string {
+  return m.status === 'done' ? doneLine(theme, m) : errorLine(theme, m);
+}
+
 function makeText(lastComponent: any, text: string): Text {
   const comp = lastComponent instanceof Text ? lastComponent : new Text('', 0, 0);
   comp.setText(text);
@@ -73,36 +128,12 @@ function renderMemberTree(
 ): string[] {
   const lines: string[] = [];
   for (const m of details.members) {
-    const icon =
-      m.status === 'done'
-        ? applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.successPrefix.prefix)
-        : m.status === 'error'
-          ? applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix)
-          : m.status === 'working'
-            ? applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length])
-            : applyColor(theme, CONFIG.shared.status.waitingIconColor, CONFIG.shared.status.waitingIcon);
-    lines.push(
-      indentLine(
-        `${icon} ${applyColor(theme, CONFIG.member.display.labelColor, m.label)} ${applyColor(theme, CONFIG.member.display.modelColor, m.displayName ?? m.model)}`,
-      ),
-    );
+    lines.push(memberHeader(statusIcon(m.status, theme, spinnerFrame), m, theme));
     lines.push(indentLine(branchLine(opts.memberSubLine(m), theme)));
     lines.push('');
   }
   if (details.chairman) {
-    const cIcon =
-      details.chairman.status === 'done'
-        ? applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.successPrefix.prefix)
-        : details.chairman.status === 'error'
-          ? applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix)
-          : details.chairman.status === 'working'
-            ? applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length])
-            : applyColor(theme, CONFIG.shared.status.waitingIconColor, CONFIG.shared.status.waitingIcon);
-    lines.push(
-      indentLine(
-        `${cIcon} ${CONFIG.chairman.display.icon ? CONFIG.chairman.display.icon + ' ' : ''}${applyColor(theme, CONFIG.chairman.display.labelColor, 'Chairman')} ${applyColor(theme, CONFIG.chairman.display.modelColor, details.chairman.displayName ?? details.chairman.model)}`,
-      ),
-    );
+    lines.push(chairmanHeader(statusIcon(details.chairman.status, theme, spinnerFrame), details.chairman, theme));
     const suffix = opts.chairmanSubLineSuffix ?? '';
     lines.push(indentLine(branchLine(opts.chairmanSubLine + suffix, theme)));
   }
@@ -152,12 +183,9 @@ function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme
           m.status === 'error'
             ? applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix)
             : applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.successPrefix.prefix);
-        lines.push(
-          indentLine(
-            `${icon} ${applyColor(theme, CONFIG.member.display.labelColor, m.label)} ${applyColor(theme, CONFIG.member.display.modelColor, m.displayName ?? m.model)}`,
-          ),
-        );
+        lines.push(memberHeader(icon, m, theme));
         if (m.status === 'error') {
+          // Error label + elapsed only; the full error message gets its own line below.
           lines.push(
             indentLine(
               branchLine(
@@ -168,14 +196,7 @@ function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme
           );
           if (m.error) lines.push(indentLine(indentLine(applyColor(theme, CONFIG.shared.status.errorColor, m.error))));
         } else {
-          lines.push(
-            indentLine(
-              branchLine(
-                `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`,
-                theme,
-              ),
-            ),
-          );
+          lines.push(indentLine(branchLine(doneLine(theme, m), theme)));
           if (md) for (const l of md.render(cw)) lines.push(indentLine(indentLine(l)));
         }
         lines.push('');
@@ -190,11 +211,7 @@ function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme
           details.chairman.status === 'done'
             ? applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)
             : applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.status.errorLabel);
-        lines.push(
-          indentLine(
-            `${cIcon} ${CONFIG.chairman.display.icon ? CONFIG.chairman.display.icon + ' ' : ''}${applyColor(theme, CONFIG.chairman.display.labelColor, 'Chairman')} ${applyColor(theme, CONFIG.chairman.display.modelColor, details.chairman.displayName ?? details.chairman.model)}`,
-          ),
-        );
+        lines.push(chairmanHeader(cIcon, details.chairman, theme));
         lines.push(indentLine(branchLine(cStatus, theme)));
         if (details.chairman.status === 'error' && details.chairman.error) {
           lines.push(
@@ -286,7 +303,7 @@ function buildExecArgs(exec: ExecConfig): string[] {
   } else {
     args.push('--no-extensions');
     for (const name of exec.extensions) {
-      args.push('-e', path.join(os.homedir(), '.pi', 'agent', 'extensions', name, 'src', 'index.ts'));
+      args.push('-e', path.join(getAgentDir(), 'extensions', name, 'src', 'index.ts'));
     }
   }
 
@@ -298,7 +315,7 @@ function buildExecArgs(exec: ExecConfig): string[] {
   } else {
     args.push('--no-skills');
     for (const name of exec.skills) {
-      args.push('--skill', path.join(os.homedir(), '.pi', 'agent', 'skills', name, 'SKILL.md'));
+      args.push('--skill', path.join(getAgentDir(), 'skills', name, 'SKILL.md'));
     }
   }
 
@@ -645,14 +662,7 @@ export default function (pi: ExtensionAPI) {
       const details = liveDetails;
       lines.push(
         ...renderMemberTree(details, theme, frame, {
-          memberSubLine: (m) =>
-            m.status === 'done'
-              ? `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-              : m.status === 'working'
-                ? applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.workingLabel)
-                : m.status === 'error'
-                  ? `${applyColor(theme, CONFIG.shared.status.errorColor, m.error?.slice(0, 60) || CONFIG.shared.status.errorLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-                  : applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.workingLabel),
+          memberSubLine: (m) => memberLiveSubLine(m, theme),
           chairmanSubLine:
             details.stage === 'chairman' && details.chairman?.status === 'working'
               ? applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.synthesizingLabel)
@@ -694,14 +704,7 @@ export default function (pi: ExtensionAPI) {
       // ── Progress: members deliberating ─────────────────────────────────
       if (details.stage === 'members') {
         const lines = renderMemberTree(details, theme, frame, {
-          memberSubLine: (m) =>
-            m.status === 'done'
-              ? `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-              : m.status === 'working'
-                ? applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.workingLabel)
-                : m.status === 'error'
-                  ? `${applyColor(theme, CONFIG.shared.status.errorColor, m.error?.slice(0, 60) || CONFIG.shared.status.errorLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-                  : applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.workingLabel),
+          memberSubLine: (m) => memberLiveSubLine(m, theme),
           chairmanSubLine: applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.waitingLabel),
         });
         return makeText(ctx?.lastComponent, lines.join('\n'));
@@ -709,25 +712,29 @@ export default function (pi: ExtensionAPI) {
 
       // ── Progress: chairman synthesizing ────────────────────────────────
       if (details.stage === 'chairman') {
+        const c = details.chairman;
+        let chairmanSubLine: string;
+        if (c?.status === 'working')
+          chairmanSubLine = applyColor(
+            theme,
+            CONFIG.shared.status.workingColor,
+            CONFIG.shared.status.synthesizingLabel,
+          );
+        else if (c?.status === 'error')
+          chairmanSubLine = applyColor(
+            theme,
+            CONFIG.shared.status.errorColor,
+            c.error?.slice(0, 60) || CONFIG.shared.status.errorLabel,
+          );
+        else if (c?.status === 'done')
+          chairmanSubLine = applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel);
+        else chairmanSubLine = applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.waitingLabel);
+
         const lines = [
           '',
           ...renderMemberTree(details, theme, frame, {
-            memberSubLine: (m) =>
-              m.status === 'done'
-                ? `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-                : `${applyColor(theme, CONFIG.shared.status.errorColor, m.error?.slice(0, 60) || CONFIG.shared.status.errorLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`,
-            chairmanSubLine:
-              details.chairman?.status === 'working'
-                ? applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.synthesizingLabel)
-                : details.chairman?.status === 'error'
-                  ? applyColor(
-                      theme,
-                      CONFIG.shared.status.errorColor,
-                      details.chairman.error?.slice(0, 60) || CONFIG.shared.status.errorLabel,
-                    )
-                  : details.chairman?.status === 'done'
-                    ? applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)
-                    : applyColor(theme, CONFIG.shared.status.workingColor, CONFIG.shared.status.waitingLabel),
+            memberSubLine: (m) => memberFinalSubLine(m, theme),
+            chairmanSubLine,
           }),
         ];
         return makeText(ctx?.lastComponent, lines.join('\n'));
@@ -738,10 +745,7 @@ export default function (pi: ExtensionAPI) {
         const lines = [
           '',
           ...renderMemberTree(details, theme, 0, {
-            memberSubLine: (m) =>
-              m.status === 'done'
-                ? `${applyColor(theme, CONFIG.shared.status.doneColor, CONFIG.shared.status.doneLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`
-                : `${applyColor(theme, CONFIG.shared.status.errorColor, m.error?.slice(0, 60) || CONFIG.shared.status.errorLabel)} ${applyColor(theme, CONFIG.shared.status.elapsedColor, formatElapsed(m.startedAt, m.doneAt))}`,
+            memberSubLine: (m) => memberFinalSubLine(m, theme),
             chairmanSubLine:
               details.chairman?.status === 'error'
                 ? applyColor(


### PR DESCRIPTION
Three related portability/correctness fixes across `artifacts`, `chat-input`, and `llm-council`, plus the deduplication that fell out of them.

## 1. Config resolution ignored `PI_CODING_AGENT_DIR`

All three built config paths from `homedir() + ".pi/agent"`, so they silently read the wrong file under any harness that relocates pi's agent dir — the config the user actually edits never gets picked up.

Switched to pi's exported `getAgentDir()`, which returns `PI_CODING_AGENT_DIR` when set and `~/.pi/agent` otherwise, so **behavior is unchanged for ordinary pi installs**. `cloak` and `header` already do this, so it also makes the repo internally consistent.

`llm-council/buildExecArgs` had the same hardcode for its `--extension` / `--skill` subprocess paths.

## 2. `createRequire` in artifacts

`artifacts/styles.ts` read diff2html's stylesheet via `createRequire(import.meta.url)`, which fails on hosts that bundle the extension into a single file (no on-disk `node_modules` to walk) and takes extension load down with it.

Now a *direct* `import.meta.resolve(...)` call in a try/catch — jiti rewrites call expressions, so it keeps working the way pi actually loads extensions, and the catch degrades to unstyled diffs rather than a hard failure.

## 3. chat-input assumed a 1-cell prefix

`prefix` is a documented config option, but the layout math hardcoded a single cell:

| | before | after |
|---|---|---|
| min-width guard | `width < 5 + PAD*mult` | `width < 4 + PREFIX_W + PAD*mult` |
| boxed contentWidth | `width - 3 - PAD*3` | `width - 2 - PAD*3 - PREFIX_W` |
| unboxed contentWidth | `width - 2*PAD - 1` | `width - 2*PAD - PREFIX_W` |
| continuation indent | `' '` | `' '.repeat(PREFIX_W)` |

Every formula reduces to the old one at `PREFIX_W === 1`. With a two-cell prefix (`❮❯`) the old code overflows the box:

```
OLD (1-cell assumption):          NEW (prefix-width aware):
╭──────────────────────╮          ╭──────────────────────╮
│ ❮❯ first line         │ vw=41   │ ❮❯ first line        │ vw=40
│   second line        │ vw=40    │    second line       │ vw=40
╰──────────────────────╯          ╰──────────────────────╯
```

## 4. Deduplication (no behavior change)

- **chat-input** — `renderBoxed`/`renderUnboxed` each re-implemented border scanning, top/bottom construction, the body loop, and the menu loop (`buildBottom = buildTop` outright in the unboxed path). Extracted `scanBorders`, `rule`, `bodyLines`, `menuLines`; the `wrap` callback is the only genuine difference between the two.
- **llm-council** — a 4-branch status-icon ternary appeared **4x verbatim** and a `memberSubLine` ternary **4x more**. Extracted `statusIcon`, `memberHeader`, `chairmanHeader`, `doneLine`, `errorLine`, `memberLiveSubLine`, `memberFinalSubLine`.
- Dropped a dead alternation in chat-input's ANSI regex: `\x1b\[0?m` is already matched by `\x1b\[[0-9;]*m`.

## Verification

Refactoring render logic needs more than a typecheck, so both were checked for equivalence against the previous implementation:

- **chat-input** — old vs new layout across **1512 configurations** (boxed/unboxed x `boxPadX` x `menuGap` x `extraMenuIndent` x 7 widths x 6 stock-render scenarios incl. scroll indicators, menus, empty content, wide unicode): **0 mismatches** at a 1-cell prefix.
- **llm-council** — helper output vs the old inline ternaries across **360 combinations** of status / error / timing / spinner frame: **0 mismatches**.
- Config resolves from a temp dir under `PI_CODING_AGENT_DIR` and from `~/.pi/agent` when unset.
- All three extensions load under **jiti** with diff2html's CSS intact (20,022 chars, contains `d2h-`).

Changeset included — `minor` for chat-input (multi-cell prefixes now work), `patch` for the other two.

## Context

Motivated by wanting to consume these from [arc](https://github.com/workos/arc), which sets `PI_CODING_AGENT_DIR` to `~/.arc/agent`; arc's vendored forks are where the prefix fix and both refactors came from. All of it stands on its own for anyone relocating their agent dir or bundling these extensions.