### PR TITLE
fix(ci): run the version script, not pnpm's builtin version command

### DIFF
--- a/.changeset/olive-donkeys-marry.md
+++ b/.changeset/olive-donkeys-marry.md
@@ -1,6 +1,6 @@
 ---
 '@nicknisi/pi-artifacts': patch
-'@nicknisi/pi-chat-input': minor
+'@nicknisi/pi-chat-input': patch
 '@nicknisi/pi-llm-council': patch
 ---
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:
-          version: pnpm version
+          # `pnpm run version`, not `pnpm version` — the latter is pnpm's builtin
+          # version command (it requires a semver argument and never runs the
+          # package.json script of the same name).
+          version: pnpm run version
           publish: pnpm changeset publish
           title: 'chore: version packages'
           commit: 'chore: version packages'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Monorepo of Nick Nisi's pi extensions. Each `packages/<name>/` is an independent
 
 ## Hard rules
 
-- **Conventional commits are required** (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:` …). PR titles must be conventional — CI enforces it (`lint-pr-title`), and squash-merge titles become the main-branch history.
+- **Conventional commits are required** (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:` …). PR titles must be conventional — CI enforces it (`lint-pr-title`), and the PR title becomes the main-branch commit. Squash is the only merge method enabled and `main` requires linear history, so every PR lands as exactly one conventional commit; branch commits are free-form working history.
 - **Add a changeset for any user-facing change** to a package: run `pnpm changeset`, pick the packages + bump, and commit the generated file with your change. No changeset = no release. (Docs/config/CI-only changes don't need one.)
 - Never edit a package's behavior during a structural move or rename.
 


### PR DESCRIPTION
## The release pipeline has never worked

`.github/workflows/release.yml` passes `version: pnpm version` to `changesets/action`. But **`pnpm version` is pnpm's own builtin command** — it requires a semver argument and never runs the package.json script of the same name. Every release run has failed in ~15s:

```
[command] /home/runner/setup-pnpm/node_modules/.bin/pnpm version
[ERR_PNPM_INVALID_VERSION_BUMP] A version argument is required. Must be a valid
semver version (e.g. 1.2.3) or one of: major, minor, patch, premajor, ...
##[error]The process '.../pnpm' failed with exit code 1
```

Consequences: no `chore: version packages` PR has ever been opened, nothing has been released through the pipeline, and **three changesets are sitting unconsumed on main** (`eager-cows-battle`, `olive-donkeys-marry`, `tidy-brooms-apply`).

The fix is `pnpm run version`. `publish: pnpm changeset publish` was never affected — it invokes the `changeset` binary directly rather than colliding with a pnpm builtin.

### Verified on a scratch copy

```
$ pnpm version          → ERR_PNPM_INVALID_VERSION_BUMP   (reproduces CI exactly)
$ pnpm run version      → 🦋  All files have been updated.
                          chat-input  0.1.0 → 0.1.1
                          artifacts   1.0.0 → 1.0.1
                          llm-council 0.1.0 → 0.1.1
                          CHANGELOGs written, changesets consumed
```

## Also in this PR

**chat-input's pending changeset: `minor` → `patch`.** Changesets applies literal semver with no 0.x special-casing, so `minor` takes it 0.1.0 → 0.2.0 — and `^0.1.0` does **not** accept 0.2.0 (in 0.x, caret behaves like tilde). That would strand existing consumers from a change verified backward compatible at the default 1-cell prefix. `patch` → 0.1.1 reaches everyone on `^0.1.0`.

**AGENTS.md** now records that squash is the only enabled merge method and `main` requires linear history, so the conventional-commit rule is enforced structurally rather than by convention. Both PRs so far landed as `Merge pull request #N from ...` commits because all three merge methods were enabled and linear history was off; that is now fixed at the repo level.

## No changeset

CI, docs, and changeset-metadata only — no package behavior changes. Per AGENTS.md: *"Docs/config/CI-only changes don't need one."*

## After merge

The first Release run should finally open a `chore: version packages` PR consuming all three pending changesets. Worth watching that it gets past the version step and that npm trusted publishing is actually configured for each package — this fix unblocks the pipeline, but publishing has never been exercised end to end, so the `changeset publish` half is still unproven.
