### PR TITLE
fix(ci): skip the changeset check on the release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      # Skipped on the release PR: `chore: version packages` bumps every
+      # package.json and deletes the changesets it consumed, so it always
+      # looks like "packages changed, no changesets" and would never pass.
       - name: Changeset Status
         run: pnpm changeset status --since=origin/main
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'


### PR DESCRIPTION
## Problem

`changeset status --since=origin/main` asserts *"packages changed, so a changeset is required"*. The `chore: version packages` PR is the one PR that can never satisfy it — it bumps every package.json and **deletes** the changesets it just consumed, so it always looks like changes-without-a-changeset:

```
🦋  error Some packages have been changed but no changesets were found.
```

Since `Check` is a **required** status check on main, this made the release PR permanently unmergeable. [PR #4](https://github.com/nicknisi/pi-extensions/pull/4) hit it the moment the pipeline was unblocked — format, lint and typecheck all passed; only this step failed.

## Fix

Skip the step when the PR head branch is `changeset-release/main` (the branch `changesets/action` pushes). Every other PR still requires a changeset exactly as before.

## After merge

Merging this triggers Release on main, which resets `changeset-release/main` onto the new HEAD and re-opens/updates PR #4 — so #4 picks up the fixed workflow and should go green without manual intervention.