### PR TITLE
feat(mg): add @nicknisi/pi-mg 100% file completion animation

### DIFF
--- a/.changeset/clever-eagans-refine.md
+++ b/.changeset/clever-eagans-refine.md
@@ -1,5 +1,5 @@
 ---
-"@nicknisi/pi-mg": minor
+'@nicknisi/pi-mg': minor
 ---
 
 Add `@nicknisi/pi-mg`: a `/mg` command that plays a Severance-style "100% File Completion" animation starring a pixelated Michael Grinich — MDR grid, 100% burst, landscape reveal, spoken address, departure, and finale. macOS audio via `say`/`afplay`.

--- a/.changeset/clever-eagans-refine.md
+++ b/.changeset/clever-eagans-refine.md
@@ -1,0 +1,5 @@
+---
+"@nicknisi/pi-mg": minor
+---
+
+Add `@nicknisi/pi-mg`: a `/mg` command that plays a Severance-style "100% File Completion" animation starring a pixelated Michael Grinich — MDR grid, 100% burst, landscape reveal, spoken address, departure, and finale. macOS audio via `say`/`afplay`.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Local paths are added to pi's settings without copying — edits in the repo are
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
 | [chat-input](packages/chat-input/)           | Config-driven boxed input editor; paste-again-to-expand for collapsed paste markers; tmux focus-aware border | custom editor component                     |
 | [header](packages/header/)                   | Animated dashboard header (GIF-compiled truecolor frames or ASCII art) with session info, on fresh sessions  | `/nicknisi-header`, custom header           |
+| [mg](packages/mg/)                           | Severance-style "100% File Completion" animation starring a pixelated Michael Grinich, with macOS audio      | `/mg [name]`                                |
 | [pin-last-prompt](packages/pin-last-prompt/) | Sticky bar pinning the owning user prompt while scrolled back in fullscreen (pi ≥ 0.84)                      | scrollback overlay bar                      |
 | [recap](packages/recap/)                     | LLM "where was I" card injected into the transcript after idle minutes                                       | `/recap`, `/recap-idle`, `recap` entry type |
 | [spinner](packages/spinner/)                 | ~1000 rotating joke/meme phrases for the working spinner                                                     | —                                           |

--- a/packages/mg/README.md
+++ b/packages/mg/README.md
@@ -1,0 +1,63 @@
+# @nicknisi/pi-mg
+
+A **100% File Completion Animation** for the terminal — inspired by the Kier Eagan animation from _Severance_, but starring a pixelated **Michael Grinich** (CEO of WorkOS) instead. Run `/mg`, sit back, and receive your praise.
+
+## What it adds
+
+- **Slash command:** `/mg [name]` — plays the full animation. Defaults to `$USER`, falling back to `WorkOS employee`.
+- No tools, no widgets, no custom entry types, no event hooks.
+
+The animation takes over the screen via `ctx.ui.custom()`. Press **Escape** or **q** to bail out at any time; audio is killed on exit.
+
+## Usage
+
+```text
+/mg          # plays the animation with your $USER name
+/mg Nick     # plays the animation with a custom name
+```
+
+### The sequence
+
+1. **MDR grid** — green-on-black grid of shuffling numbers with a progress bar counting to 100%, with accelerating beeps
+2. **100% burst** — giant "100%" text explodes into colorful pixel particles over a noise burst
+3. **Landscape reveal** — a sunset mountain landscape paints in (violet→pink→orange sky, snow-capped peaks, clouds, a cliff) with a chiptune fanfare
+4. **Walk in** — a pixel guy walks in from the left along the cliff
+5. **The address** — Michael Grinich's pixelated face appears and delivers the monologue (macOS `say`, Daniel voice), mouth animating, with synced subtitles:
+
+   > _I knew you could do it, {name}. Even in your darkest moments, I could see you arriving here. In refining your code, you have brought glory to this company and to me. I, Michael Grinich, love you. But now I must away, for there are other developers who need me around the world. Goodbye, {name}. And thank you._
+
+6. **The departure** — the pixel guy spreads his arms and flies off across the landscape in an S-curve, shrinking into the distance with a whoosh
+7. **Finale** — "100% COMPLETE" with `File: {name} │ Status: REFINED │ WorkOS`
+
+Total runtime is roughly 30 seconds, driven by a 20fps (50ms) tick. The address phase ends when `say` exits, with a hard fallback timeout so a missing/silent `say` can't stall the sequence.
+
+## Files
+
+| File        | What's in it                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------ |
+| `index.ts`  | Animation component built on pi's `ctx.ui.custom()` TUI API — half-block rendering, ANSI truecolor     |
+| `sprite.ts` | Michael Grinich pixel art (32×32, 18-color palette extracted from a photo) + walking/flying sprites    |
+| `sound.ts`  | In-memory WAV generation for tones/noise/fanfare/whoosh, played through `afplay`; `say` for the speech |
+
+## Configuration
+
+None. No config file, no options, no environment variables (other than `$USER` for the default name).
+
+## Dependencies
+
+- **Peer:** `@earendil-works/pi-coding-agent` (`*`) for `pi.registerCommand` and `ctx.ui.custom`; `@earendil-works/pi-tui` (`*`) for `matchesKey`.
+- No runtime npm dependencies, no workspace deps.
+
+## Caveats
+
+- **macOS only for audio.** `sound.ts` shells out to `afplay` and `say`. On other platforms the animation still renders, but silently, and the address phase falls back to its fixed timeout instead of tracking speech.
+- Audio is written to temp WAV files (`os.tmpdir()`) and played as child processes; all spawned processes are killed on dispose/exit.
+- TUI-only: in non-`tui` modes the command notifies and returns.
+- Requires a truecolor terminal — the renderer emits 24-bit ANSI color with half-block characters. In 256-color terminals the palette will be approximated at best.
+- It's ~30 seconds of full-screen animation and noise. Do not run it on a shared screen share unless that is exactly what you want.
+
+## Install
+
+```bash
+pi install /Users/nicknisi/Developer/pi-extensions/packages/mg
+```

--- a/packages/mg/index.ts
+++ b/packages/mg/index.ts
@@ -1,0 +1,719 @@
+/**
+ * /mg — File Completion Animation
+ *
+ * A Severance-inspired 100% completion animation featuring a pixelated
+ * Michael Grinich instead of Kier Eagan. Plays an animated, audible
+ * sequence: MDR grid → 100% burst → landscape reveal → Michael's
+ * address → the departure → finale.
+ *
+ * Usage: /mg [name]
+ */
+
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { matchesKey } from '@earendil-works/pi-tui';
+import type { ChildProcess } from 'node:child_process';
+import type { RGB } from './sprite.ts';
+import { getSpriteGrid, stampFlyer, stampWalker, MG_TRANSPARENT, MG_PALETTE } from './sprite.ts';
+import { playTone, playNoise, playFanfare, playWhoosh, playClick, speak, killProc } from './sound.ts';
+
+// === Constants ===
+
+const TICK_MS = 50; // 20fps
+
+// Phase timings (ms)
+const T_MDR_END = 2500;
+const T_BURST_END = 3500;
+const T_LANDSCAPE_END = 4500;
+const T_WALK_END = 6500; // pixel guy walks in
+const T_ADDRESS_START = T_WALK_END;
+const T_ADDRESS_END = 26000; // fallback if `say` doesn't finish
+const T_DEPARTURE_END = 30000;
+const T_FINALE_END = 33000;
+
+const SPRITE_W = 32;
+const SPRITE_H = 32;
+
+// === Helpers ===
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function lerpRGB(a: RGB, b: RGB, t: number): RGB {
+  return [Math.round(lerp(a[0], b[0], t)), Math.round(lerp(a[1], b[1], t)), Math.round(lerp(a[2], b[2], t))];
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+/** Render an RGB pixel grid to terminal lines using half-block characters */
+function renderColorGrid(grid: RGB[][]): string[] {
+  const lines: string[] = [];
+  for (let y = 0; y < grid.length; y += 2) {
+    let line = '';
+    for (let x = 0; x < grid[0].length; x++) {
+      const top = grid[y][x];
+      const bot = y + 1 < grid.length ? grid[y + 1][x] : null;
+      if (!bot) {
+        line += `\x1b[38;2;${top[0]};${top[1]};${top[2]}m▀`;
+      } else if (top[0] === bot[0] && top[1] === bot[1] && top[2] === bot[2]) {
+        line += `\x1b[38;2;${top[0]};${top[1]};${top[2]}m█`;
+      } else {
+        line += `\x1b[38;2;${top[0]};${top[1]};${top[2]};48;2;${bot[0]};${bot[1]};${bot[2]}m▀`;
+      }
+    }
+    line += '\x1b[0m';
+    lines.push(line);
+  }
+  return lines;
+}
+
+/** Center lines horizontally in the given width */
+function centerLines(lines: string[], width: number): string[] {
+  // Calculate visible width of first line (strip ANSI)
+  const visibleLen = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '').length;
+  const maxLen = Math.max(...lines.map(visibleLen));
+  const pad = Math.max(0, Math.floor((width - maxLen) / 2));
+  return lines.map((l) => ' '.repeat(pad) + l);
+}
+
+// === Landscape generation ===
+
+function generateLandscape(pw: number, ph: number): RGB[][] {
+  const grid: RGB[][] = [];
+
+  for (let y = 0; y < ph; y++) {
+    const row: RGB[] = [];
+    const yr = y / ph;
+
+    for (let x = 0; x < pw; x++) {
+      const xr = x / pw;
+      let color: RGB;
+
+      // Sky gradient (sunset)
+      if (yr < 0.25) {
+        color = lerpRGB([18, 8, 38], [55, 18, 75], yr / 0.25);
+      } else if (yr < 0.45) {
+        color = lerpRGB([55, 18, 75], [160, 55, 95], (yr - 0.25) / 0.2);
+      } else if (yr < 0.6) {
+        color = lerpRGB([160, 55, 95], [230, 140, 85], (yr - 0.45) / 0.15);
+      } else if (yr < 0.72) {
+        color = lerpRGB([230, 140, 85], [248, 215, 130], (yr - 0.6) / 0.12);
+      } else {
+        color = [248, 215, 130];
+      }
+
+      // Mountains
+      const peaks = [
+        { cx: 0.12, ch: 0.32, cw: 0.1 },
+        { cx: 0.3, ch: 0.42, cw: 0.14 },
+        { cx: 0.52, ch: 0.5, cw: 0.16 },
+        { cx: 0.72, ch: 0.38, cw: 0.12 },
+        { cx: 0.9, ch: 0.35, cw: 0.1 },
+      ];
+
+      for (const m of peaks) {
+        const dist = Math.abs(xr - m.cx);
+        if (dist < m.cw) {
+          const mountainH = m.ch * (1 - (dist / m.cw) ** 1.5);
+          const mountainTop = 1 - mountainH - 0.28;
+          if (yr > mountainTop && yr < 0.72) {
+            const isSnow = dist < m.cw * 0.2 && yr < mountainTop + 0.04;
+            color = isSnow ? [235, 230, 240] : [42, 22, 55];
+          }
+        }
+      }
+
+      // Clouds (bottom area)
+      if (yr > 0.72) {
+        const n = (Math.sin(x * 0.15 + y * 0.3) * Math.cos(x * 0.4 + y * 0.1) + 1) / 2;
+        const cloudT = clamp((n - 0.35) / 0.3, 0, 1);
+        color = lerpRGB([195, 190, 220], [245, 242, 248], cloudT);
+      }
+
+      // Cliff (left side)
+      if (xr < 0.1 && yr > 0.62) {
+        const cliffNoise = Math.sin(y * 0.4) * 0.015;
+        const cliffEdge = 0.07 + cliffNoise;
+        if (xr < cliffEdge) {
+          color = [85, 62, 42];
+        } else if (xr < cliffEdge + 0.015) {
+          color = [55, 42, 28];
+        }
+      }
+
+      row.push(color);
+    }
+    grid.push(row);
+  }
+
+  return grid;
+}
+
+// === MDR Grid rendering ===
+
+function renderMDR(width: number, height: number, progress: number, tick: number): string[] {
+  const lines: string[] = [];
+  const green = '\x1b[38;2;0;200;80m';
+  const greenDim = '\x1b[38;2;0;130;50m';
+  const greenBright = '\x1b[38;2;80;255;120m';
+  const reset = '\x1b[0m';
+  const bg = '\x1b[48;2;8;12;8m';
+
+  // Fill with random numbers
+  const numCols = Math.floor((width - 2) / 3);
+  const numRows = Math.max(8, Math.min(height - 6, 16));
+
+  for (let r = 0; r < numRows; r++) {
+    let line = bg;
+    for (let c = 0; c < numCols; c++) {
+      const seed = (tick * 7 + r * 31 + c * 17) % 1000;
+      const num = ((Math.floor(Math.sin(seed) * 1000) % 100) + 100) % 100;
+      const isHighlighted = (tick + r + c) % 13 === 0;
+      const color = isHighlighted ? greenBright : c % 3 === 0 ? greenDim : green;
+      line += `${color}${String(num).padStart(2, '0')} `;
+    }
+    line += reset;
+    lines.push(line);
+  }
+
+  // Progress bar
+  lines.push('');
+  const barWidth = Math.min(40, width - 20);
+  const filled = Math.floor(barWidth * progress);
+  const bar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+  const pct = Math.floor(progress * 100);
+  const barLine = `${bg}${green} REFINING: ${greenBright}[${bar}] ${String(pct).padStart(3)}%${reset}`;
+  lines.push(barLine);
+  lines.push('');
+
+  // Bin numbers (like the show)
+  const bins = '  OH   WO   FC   DR   GA';
+  const binLine = `${bg}${greenDim}${bins}    WorkOS${reset}`;
+  lines.push(binLine);
+
+  return centerLines(lines, width);
+}
+
+// === 100% big text ===
+
+const FONT: Record<string, string[]> = {
+  '1': ['  ██  ', ' ███  ', '  ██  ', '  ██  ', '  ██  ', '  ██  ', '██████'],
+  '0': [' ████ ', '█  ██ ', '█  ███', '█ █ ██', '███  █', '██  █ ', ' ████ '],
+  '%': ['██  ██', '██ ██ ', '  ██  ', '  ██  ', '  ██  ', ' ██ ██', '██  ██'],
+};
+
+function renderBigText(text: string, r: number, g: number, b: number): string[] {
+  const chars = text.split('');
+  const lines: string[] = [];
+  const color = `\x1b[38;2;${r};${g};${b}m`;
+  const reset = '\x1b[0m';
+
+  for (let row = 0; row < 7; row++) {
+    let line = '';
+    for (const ch of chars) {
+      const glyph = FONT[ch] || FONT['0'];
+      line += color + glyph[row] + reset;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+// === Explosion particles ===
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  color: RGB;
+  life: number;
+}
+
+function createExplosion(pw: number, ph: number): Particle[] {
+  const particles: Particle[] = [];
+  const colors: RGB[] = [
+    [255, 100, 100],
+    [100, 255, 100],
+    [100, 100, 255],
+    [255, 200, 50],
+    [255, 50, 200],
+    [50, 255, 200],
+    [255, 255, 100],
+    [200, 100, 255],
+  ];
+  const cx = pw / 2;
+  const cy = ph / 2;
+  for (let i = 0; i < 60; i++) {
+    const angle = (i / 60) * Math.PI * 2 + Math.random() * 0.3;
+    const speed = 0.3 + Math.random() * 0.8;
+    particles.push({
+      x: cx,
+      y: cy,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed * 0.6,
+      color: colors[i % colors.length],
+      life: 1.0,
+    });
+  }
+  return particles;
+}
+
+function renderExplosion(particles: Particle[], pw: number, ph: number, progress: number): RGB[][] {
+  const grid: RGB[][] = [];
+  const bg: RGB = [8, 8, 16];
+  for (let y = 0; y < ph; y++) {
+    const row: RGB[] = [];
+    for (let x = 0; x < pw; x++) {
+      row.push([...bg]);
+    }
+    grid.push(row);
+  }
+  for (const p of particles) {
+    p.x += p.vx;
+    p.y += p.vy;
+    p.life = 1 - progress;
+    const px = Math.floor(p.x);
+    const py = Math.floor(p.y);
+    if (px >= 0 && px < pw && py >= 0 && py < ph && p.life > 0) {
+      grid[py][px] = [
+        Math.floor(p.color[0] * p.life),
+        Math.floor(p.color[1] * p.life),
+        Math.floor(p.color[2] * p.life),
+      ];
+    }
+  }
+  return grid;
+}
+
+// === Monologue ===
+
+const MONOLOGUE = (name: string) =>
+  `I knew you could do it, ${name}. ... Even in your darkest moments, I could see you arriving here. ... In refining your code, you have brought glory to this company and to me. ... I, Michael Grinich, love you. ... But now I must away, for there are other developers who need me around the world. ... Goodbye, ${name}. ... And thank you.`;
+
+const SUBTITLES = (name: string): { t: number; text: string }[] => [
+  { t: 0, text: `I knew you could do it, ${name}.` },
+  { t: 3500, text: `Even in your darkest moments, I could see you arriving here.` },
+  { t: 7500, text: `In refining your code, you have brought glory to this company and to me.` },
+  { t: 12500, text: `I, Michael Grinich, love you.` },
+  { t: 16000, text: `But now I must away, for there are others who need me around the world.` },
+  { t: 20000, text: `Goodbye, ${name}. And thank you.` },
+];
+
+// === Animation Component ===
+
+class HundredPercentComponent {
+  private startTime = Date.now();
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private procs: (ChildProcess | null)[] = [];
+  private onClose: () => void;
+  private tui: { requestRender: () => void };
+  private name: string;
+  private mouthOpen = false;
+  private sayProc: ChildProcess | null = null;
+  private sayDone = false;
+  private soundsTriggered = new Set<string>();
+  private particles: Particle[] = [];
+  private cachedLandscape: RGB[][] | null = null;
+  private cachedLandscapeW = 0;
+  private cachedLandscapeH = 0;
+  private disposed = false;
+  private clickTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(tui: { requestRender: () => void }, onClose: () => void, name: string) {
+    this.tui = tui;
+    this.onClose = onClose;
+    this.name = name;
+
+    this.interval = setInterval(() => this.tick(), TICK_MS);
+  }
+
+  private elapsed(): number {
+    return Date.now() - this.startTime;
+  }
+
+  private tick(): void {
+    if (this.disposed) return;
+    const t = this.elapsed();
+    this.tui.requestRender();
+
+    // Trigger sounds at specific times
+    if (!this.soundsTriggered.has('first_click') && t > 100) {
+      this.soundsTriggered.add('first_click');
+      // Start rapid clicks during MDR phase
+      this.clickTimer = setInterval(
+        () => {
+          if (this.disposed) return;
+          const e = this.elapsed();
+          if (e > T_MDR_END) {
+            if (this.clickTimer) {
+              clearInterval(this.clickTimer);
+              this.clickTimer = null;
+            }
+            return;
+          }
+          const progress = e / T_MDR_END;
+          const freq = 800 + progress * 600;
+          this.procs.push(playClick(freq, 30));
+        },
+        Math.max(30, 200 - (t / T_MDR_END) * 150),
+      );
+    }
+
+    if (!this.soundsTriggered.has('explosion') && t > T_MDR_END) {
+      this.soundsTriggered.add('explosion');
+      this.procs.push(playNoise(600, 0.25));
+      this.procs.push(playTone(80, 400, 0.4));
+      this.particles = createExplosion(50, 20);
+    }
+
+    if (!this.soundsTriggered.has('fanfare') && t > T_BURST_END) {
+      this.soundsTriggered.add('fanfare');
+      this.procs.push(playFanfare());
+    }
+
+    if (!this.soundsTriggered.has('speak') && t > T_ADDRESS_START) {
+      this.soundsTriggered.add('speak');
+      this.sayProc = speak(MONOLOGUE(this.name), 120, () => {
+        this.sayDone = true;
+      });
+      this.procs.push(this.sayProc);
+
+      // Mouth animation - toggle every 180ms
+      const mouthTimer = setInterval(() => {
+        if (this.disposed || this.sayDone) {
+          clearInterval(mouthTimer);
+          this.mouthOpen = false;
+          return;
+        }
+        this.mouthOpen = !this.mouthOpen;
+      }, 180);
+    }
+
+    if (!this.soundsTriggered.has('whoosh') && (this.sayDone || t > T_ADDRESS_END)) {
+      this.soundsTriggered.add('whoosh');
+      this.procs.push(playWhoosh());
+    }
+
+    if (!this.soundsTriggered.has('finale') && t > T_DEPARTURE_END) {
+      this.soundsTriggered.add('finale');
+      this.procs.push(playFanfare());
+      this.procs.push(playTone(523, 600, 0.3));
+    }
+
+    // Auto-end
+    if (t > T_FINALE_END + 2000) {
+      this.dispose();
+      this.onClose();
+    }
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, 'escape') || data === 'q' || data === 'Q' || data === '\x03') {
+      this.dispose();
+      this.onClose();
+    }
+  }
+
+  invalidate(): void {
+    this.cachedLandscape = null;
+  }
+
+  render(width: number): string[] {
+    if (this.disposed) return [''];
+
+    const t = this.elapsed();
+
+    // Determine terminal area (pixel dimensions for half-block rendering)
+    // Each terminal char = 1 pixel wide, 2 pixels tall (half-block)
+    const pw = Math.min(width, 80);
+    const ph = 30; // 30 pixels = 15 terminal lines
+    const contentWidth = pw; // visible chars per line
+
+    // Phase 1: MDR Grid
+    if (t < T_MDR_END) {
+      const progress = t / T_MDR_END;
+      // Ease the progress (slow start, fast end)
+      const eased = progress < 0.8 ? progress * 0.8 : 0.64 + (progress - 0.8) * 1.8;
+      return renderMDR(contentWidth, ph, clamp(eased, 0, 1), Math.floor(t / TICK_MS));
+    }
+
+    // Phase 2: 100% Burst
+    if (t < T_BURST_END) {
+      const burstProgress = (t - T_MDR_END) / (T_BURST_END - T_MDR_END);
+      if (burstProgress < 0.3) {
+        // Show "100%" text
+        const glow = 0.7 + 0.3 * Math.sin(t * 0.02);
+        const r = Math.floor(255 * glow);
+        const g = Math.floor(220 * glow);
+        const b = Math.floor(100 * glow);
+        const text = renderBigText('100%', r, g, b);
+        return centerLines(text, contentWidth);
+      } else {
+        // Explosion
+        const grid = renderExplosion(this.particles, pw, ph, (burstProgress - 0.3) / 0.7);
+        return centerLines(renderColorGrid(grid), contentWidth);
+      }
+    }
+
+    // Phase 3: Landscape Reveal
+    if (t < T_LANDSCAPE_END) {
+      const revealProgress = (t - T_BURST_END) / (T_LANDSCAPE_END - T_BURST_END);
+      const landscape = this.getLandscape(pw, ph);
+      // Paint in from top to bottom
+      const cutoff = Math.floor(ph * revealProgress);
+      const grid: RGB[][] = [];
+      for (let y = 0; y < ph; y++) {
+        const row: RGB[] = [];
+        for (let x = 0; x < pw; x++) {
+          if (y < cutoff) {
+            row.push(landscape[y][x]);
+          } else {
+            row.push([8, 8, 16]);
+          }
+        }
+        grid.push(row);
+      }
+      return centerLines(renderColorGrid(grid), contentWidth);
+    }
+
+    // Phase 3.5: Pixel guy walks in on the cliff
+    if (t < T_WALK_END) {
+      const walkProgress = (t - T_LANDSCAPE_END) / (T_WALK_END - T_LANDSCAPE_END);
+      return this.renderWalkIn(pw, ph, contentWidth, walkProgress, t);
+    }
+
+    // Phase 4: Michael's Address
+    // Ensure at least 5s of departure time after speaking finishes
+    const addressEnd = this.sayDone
+      ? Math.min(t, Math.max(T_ADDRESS_START + 1000, T_DEPARTURE_END - 5000))
+      : T_ADDRESS_END;
+    if (t < addressEnd) {
+      return this.renderAddress(pw, ph, contentWidth, t - T_ADDRESS_START);
+    }
+
+    // Phase 5: The Departure
+    if (t < T_DEPARTURE_END) {
+      const depProgress = (t - addressEnd) / (T_DEPARTURE_END - addressEnd);
+      return this.renderDeparture(pw, ph, contentWidth, depProgress, t);
+    }
+
+    // Phase 6: Finale
+    if (t < T_FINALE_END) {
+      const finProgress = (t - T_DEPARTURE_END) / (T_FINALE_END - T_DEPARTURE_END);
+      return this.renderFinale(contentWidth, finProgress, t);
+    }
+
+    return [''];
+  }
+
+  private getLandscape(pw: number, ph: number): RGB[][] {
+    if (!this.cachedLandscape || this.cachedLandscapeW !== pw || this.cachedLandscapeH !== ph) {
+      this.cachedLandscape = generateLandscape(pw, ph);
+      this.cachedLandscapeW = pw;
+      this.cachedLandscapeH = ph;
+    }
+    return this.cachedLandscape;
+  }
+
+  private renderWalkIn(pw: number, ph: number, contentWidth: number, progress: number, t: number): string[] {
+    const landscape = this.getLandscape(pw, ph);
+    const grid = landscape.map((row) => row.map((c) => [...c] as RGB));
+
+    // Pixel guy walks in from the left, stops at center
+    const startX = -2;
+    const endX = Math.floor(pw * 0.4) - 5;
+    const x = lerp(startX, endX, progress);
+    const y = Math.floor(ph * 0.55);
+
+    // Walk animation: cycle through frames
+    const frame = Math.floor(t / 180) % 4;
+    stampWalker(grid, Math.floor(x), y, 1.0, frame);
+
+    return centerLines(renderColorGrid(grid), contentWidth);
+  }
+
+  private renderAddress(pw: number, ph: number, contentWidth: number, at: number): string[] {
+    const landscape = this.getLandscape(pw, ph);
+    // Copy landscape
+    const grid = landscape.map((row) => row.map((c) => [...c] as RGB));
+
+    // Fade in the face sprite during first 500ms
+    const fadeIn = clamp(at / 500, 0, 1);
+    if (fadeIn > 0) {
+      const sprite = getSpriteGrid(this.mouthOpen);
+      const ox = Math.floor((pw - SPRITE_W) / 2);
+      const oy = Math.floor((ph - SPRITE_H) / 2 - 2); // slightly above center
+
+      // Stamp sprite with fade
+      const palette = MG_PALETTE;
+      for (let y = 0; y < sprite.length; y++) {
+        for (let x = 0; x < sprite[y].length; x++) {
+          const idx = (() => {
+            const code = sprite[y][x].charCodeAt(0);
+            if (code >= 48 && code <= 57) return code - 48;
+            if (code >= 97 && code <= 122) return code - 97 + 10;
+            return 0;
+          })();
+          if (MG_TRANSPARENT.has(idx)) continue;
+          const bx = ox + x;
+          const by = oy + y;
+          if (by >= 0 && by < grid.length && bx >= 0 && bx < grid[0].length) {
+            const spriteColor = palette[idx];
+            const bgColor = grid[by][bx];
+            grid[by][bx] = lerpRGB(bgColor, spriteColor, fadeIn);
+          }
+        }
+      }
+    }
+
+    const gridLines = renderColorGrid(grid);
+
+    // Subtitles
+    const subs = SUBTITLES(this.name);
+    let subtitle = '';
+    for (const s of subs) {
+      if (at >= s.t) subtitle = s.text;
+    }
+    if (subtitle) {
+      const subColor = '\x1b[38;2;240;240;250m';
+      const reset = '\x1b[0m';
+      const subLine = `${subColor}${subtitle}${reset}`;
+      gridLines.push('');
+      gridLines.push(centerLines([subLine], contentWidth)[0]);
+    }
+
+    return centerLines(gridLines, contentWidth);
+  }
+
+  private renderDeparture(pw: number, ph: number, contentWidth: number, progress: number, t: number): string[] {
+    const landscape = this.getLandscape(pw, ph);
+    const grid = landscape.map((row) => row.map((c) => [...c] as RGB));
+
+    const tt = progress;
+
+    // Start on the cliff (left), fly up and right in an S-curve, shrink into distance
+    const startX = pw * 0.08;
+    const startY = ph * 0.6;
+    const endX = pw * 0.88;
+    const endY = ph * 0.08;
+
+    // X: steady rightward
+    const x = lerp(startX, endX, tt);
+    // Y: S-curve arc — rise, dip, rise again
+    const baseY = lerp(startY, endY, tt);
+    const arc = Math.sin(tt * Math.PI * 2) * ph * 0.1;
+    const y = baseY - arc;
+
+    // Scale: start big, stay visible, then shrink rapidly at the end
+    // Use ease-out-cubic so he stays large for most of the flight
+    const scale = lerp(1.2, 0.05, Math.pow(tt, 1.5));
+
+    // Frame: cycle through poses for wing-flapping effect
+    const frame = Math.floor(t / 250) % 4;
+
+    // Only render if big enough to see
+    if (scale > 0.06) {
+      stampFlyer(grid, Math.floor(x), Math.floor(y), scale, frame);
+    }
+
+    // Motion trail — faint pixels behind the flyer
+    if (tt > 0.05 && tt < 0.95) {
+      const trailColor: RGB = [80, 90, 120];
+      for (let i = 1; i <= 5; i++) {
+        const trailT = Math.max(0, tt - i * 0.025);
+        const tx = Math.floor(lerp(startX, endX, trailT));
+        const ty = Math.floor(lerp(startY, endY, trailT) - Math.sin(trailT * Math.PI * 2) * ph * 0.1);
+        if (ty >= 0 && ty < grid.length && tx >= 0 && tx < grid[0].length) {
+          // Fade trail by distance
+          const alpha = 1 - i / 5;
+          const orig = grid[ty][tx];
+          grid[ty][tx] = [
+            Math.round(lerp(orig[0], trailColor[0], alpha * 0.5)),
+            Math.round(lerp(orig[1], trailColor[1], alpha * 0.5)),
+            Math.round(lerp(orig[2], trailColor[2], alpha * 0.5)),
+          ];
+        }
+      }
+    }
+
+    return centerLines(renderColorGrid(grid), contentWidth);
+  }
+
+  private renderFinale(contentWidth: number, progress: number, t: number): string[] {
+    const lines: string[] = [];
+
+    // Fade in "100% COMPLETE"
+    const fadeIn = clamp(progress * 3, 0, 1);
+    const glow = 0.7 + 0.3 * Math.sin(t * 0.005);
+    const r = Math.floor(255 * glow * fadeIn);
+    const g = Math.floor(220 * glow * fadeIn);
+    const b = Math.floor(100 * glow * fadeIn);
+
+    lines.push('');
+    lines.push('');
+
+    const text = renderBigText('100%', r, g, b);
+    const completeColor = `\x1b[38;2;${r};${g};${b}m`;
+    const reset = '\x1b[0m';
+
+    // Add "COMPLETE" below the big "100%"
+    for (let i = 0; i < text.length; i++) {
+      lines.push(text[i]);
+    }
+    lines.push('');
+    const completeLine = `${completeColor}     C O M P L E T E${reset}`;
+    lines.push(completeLine);
+    lines.push('');
+
+    // File info
+    const info = `\x1b[38;2;160;160;180m  File: ${this.name.padEnd(12)} │ Status: REFINED │ WorkOS${reset}`;
+    lines.push(info);
+
+    // Fade out at the end
+    if (progress > 0.7) {
+      const fadeOut = 1 - (progress - 0.7) / 0.3;
+      if (fadeOut < 0.1) return [''];
+    }
+
+    return centerLines(lines, contentWidth);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    if (this.clickTimer) {
+      clearInterval(this.clickTimer);
+      this.clickTimer = null;
+    }
+    for (const p of this.procs) killProc(p);
+    killProc(this.sayProc);
+  }
+}
+
+// === Extension ===
+
+export default function (pi: ExtensionAPI) {
+  pi.registerCommand('mg', {
+    description: '100% File Completion Animation (Severance-style, starring Michael Grinich)',
+
+    handler: async (args, ctx) => {
+      if (ctx.mode !== 'tui') {
+        ctx.ui.notify('100% animation requires interactive mode', 'error');
+        return;
+      }
+
+      const name = args.trim() || process.env.USER?.trim() || 'WorkOS employee';
+
+      await ctx.ui.custom((tui, _theme, _kb, done) => {
+        return new HundredPercentComponent(tui, () => done(undefined), name);
+      });
+    },
+  });
+}

--- a/packages/mg/package.json
+++ b/packages/mg/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@nicknisi/pi-mg",
+  "version": "0.1.0",
+  "description": "WorkOS 100% File Completion Animation — a Severance-inspired animation starring Michael Grinich",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/mg#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/mg"
+  },
+  "files": [
+    "index.ts",
+    "sound.ts",
+    "sprite.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/packages/mg/sound.ts
+++ b/packages/mg/sound.ts
@@ -1,0 +1,142 @@
+/**
+ * Sound utilities for the 100% animation.
+ * Generates WAV data in-memory and plays via afplay (macOS).
+ * Uses `say` for the spoken monologue.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const SAMPLE_RATE = 44100;
+
+function generateWav(samples: Float32Array): Buffer {
+  const dataLen = samples.length * 2;
+  const buf = Buffer.alloc(44 + dataLen);
+  buf.write('RIFF', 0);
+  buf.writeUInt32LE(36 + dataLen, 4);
+  buf.write('WAVE', 8);
+  buf.write('fmt ', 12);
+  buf.writeUInt32LE(16, 16);
+  buf.writeUInt16LE(1, 20);
+  buf.writeUInt16LE(1, 22);
+  buf.writeUInt32LE(SAMPLE_RATE, 24);
+  buf.writeUInt32LE(SAMPLE_RATE * 2, 28);
+  buf.writeUInt16LE(2, 32);
+  buf.writeUInt16LE(16, 34);
+  buf.write('data', 36);
+  buf.writeUInt32LE(dataLen, 40);
+  for (let i = 0; i < samples.length; i++) {
+    const v = Math.max(-1, Math.min(1, samples[i]));
+    buf.writeInt16LE(Math.floor(v * 32767), 44 + i * 2);
+  }
+  return buf;
+}
+
+function playWav(buf: Buffer): ChildProcess | null {
+  try {
+    const file = join(tmpdir(), `pi100_${Date.now()}_${Math.random().toString(36).slice(2)}.wav`);
+    writeFileSync(file, buf);
+    const proc = spawn('afplay', [file], { stdio: 'ignore' });
+    proc.on('exit', () => {
+      try {
+        unlinkSync(file);
+      } catch {}
+    });
+    return proc;
+  } catch {
+    return null;
+  }
+}
+
+/** Simple sine wave tone with attack/decay envelope */
+export function playTone(freq: number, durationMs: number, volume = 0.3): ChildProcess | null {
+  const n = Math.floor((durationMs / 1000) * SAMPLE_RATE);
+  const samples = new Float32Array(n);
+  const attack = Math.floor(SAMPLE_RATE * 0.01);
+  const decay = Math.floor(SAMPLE_RATE * 0.05);
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    let env = 1;
+    if (i < attack) env = i / attack;
+    if (i > n - decay) env = (n - i) / decay;
+    samples[i] = Math.sin(2 * Math.PI * freq * t) * env * volume;
+  }
+  return playWav(generateWav(samples));
+}
+
+/** White noise burst (explosion sound) */
+export function playNoise(durationMs: number, volume = 0.2): ChildProcess | null {
+  const n = Math.floor((durationMs / 1000) * SAMPLE_RATE);
+  const samples = new Float32Array(n);
+  const decay = Math.floor(SAMPLE_RATE * 0.3);
+  for (let i = 0; i < n; i++) {
+    const env = i < decay ? 1 - i / decay : 0.1;
+    samples[i] = (Math.random() * 2 - 1) * env * volume;
+  }
+  return playWav(generateWav(samples));
+}
+
+/** Triumphant ascending fanfare */
+export function playFanfare(): ChildProcess | null {
+  const notes = [262, 330, 392, 523]; // C E G C
+  const noteMs = 180;
+  const n = Math.floor(((notes.length * noteMs) / 1000) * SAMPLE_RATE);
+  const samples = new Float32Array(n);
+  const noteLen = Math.floor((noteMs / 1000) * SAMPLE_RATE);
+  for (let ni = 0; ni < notes.length; ni++) {
+    const freq = notes[ni];
+    const offset = ni * noteLen;
+    for (let i = 0; i < noteLen && offset + i < n; i++) {
+      const t = i / SAMPLE_RATE;
+      const env = Math.min(1, i / (SAMPLE_RATE * 0.02)) * Math.min(1, (noteLen - i) / (SAMPLE_RATE * 0.05));
+      samples[offset + i] =
+        (Math.sin(2 * Math.PI * freq * t) + 0.3 * Math.sin(2 * Math.PI * freq * 2 * t)) * env * 0.25;
+    }
+  }
+  return playWav(generateWav(samples));
+}
+
+/** Frequency sweep (whoosh sound) */
+export function playWhoosh(): ChildProcess | null {
+  const durationMs = 800;
+  const n = Math.floor((durationMs / 1000) * SAMPLE_RATE);
+  const samples = new Float32Array(n);
+  for (let i = 0; i < n; i++) {
+    const t = i / SAMPLE_RATE;
+    const progress = i / n;
+    const freq = 2000 - 1800 * progress; // high to low
+    const env = Math.sin(Math.PI * progress) * 0.15;
+    samples[i] = (Math.sin(2 * Math.PI * freq * t) + (Math.random() * 2 - 1) * 0.5) * env;
+  }
+  return playWav(generateWav(samples));
+}
+
+/** Quick beep for MDR counting */
+export function playClick(freq = 1200, durationMs = 40): ChildProcess | null {
+  return playTone(freq, durationMs, 0.15);
+}
+
+/** Speak the monologue using macOS `say` — slow and dramatic */
+export function speak(text: string, rate = 120, onDone?: () => void): ChildProcess | null {
+  try {
+    // Daniel = deep dramatic British male voice, slow rate for gravitas
+    const args = ['-v', 'Daniel', '-r', String(rate)];
+    const proc = spawn('say', [...args, text], { stdio: 'ignore' });
+    proc.on('exit', () => onDone?.());
+    return proc;
+  } catch {
+    onDone?.();
+    return null;
+  }
+}
+
+/** Kill a child process safely */
+export function killProc(proc: ChildProcess | null): void {
+  if (proc && !proc.killed) {
+    try {
+      proc.kill('SIGKILL');
+    } catch {}
+  }
+}

--- a/packages/mg/sprite.ts
+++ b/packages/mg/sprite.ts
@@ -1,0 +1,378 @@
+/**
+ * Michael Grinich pixel art sprite data.
+ * Extracted from a photo and quantized to 18 colors.
+ * 32×32 pixel grid, rendered with half-block terminal characters.
+ */
+
+export type RGB = [number, number, number];
+
+export const MG_PALETTE: RGB[] = [
+  [159, 159, 181], // 0: background light blue-gray (transparent)
+  [188, 189, 210], // 1: background lighter (transparent)
+  [56, 54, 59], // 2: hair dark gray-brown
+  [97, 96, 103], // 3: hair medium gray
+  [1, 0, 0], // 4: hair darkest / eyes
+  [135, 136, 148], // 5: hair light gray
+  [36, 33, 32], // 6: hair black
+  [86, 63, 52], // 7: skin dark brown
+  [221, 223, 237], // 8: background very light (transparent)
+  [139, 98, 79], // 9: skin medium-dark
+  [164, 120, 101], // a: skin medium
+  [189, 140, 119], // b: skin tan
+  [214, 165, 143], // c: skin light
+  [113, 77, 63], // d: skin shadow / mouth
+  [195, 181, 184], // e: mouth pinkish
+  [173, 155, 153], // f: jaw shadow
+  [129, 119, 118], // g: neck shadow
+  [63, 39, 24], // h: neck dark
+];
+
+export const MG_TRANSPARENT = new Set([0, 1, 8]);
+
+export const SPRITE_W = 32;
+export const SPRITE_H = 32;
+
+export const MG_GRID: string[] = [
+  '00000000000011111111111111111111',
+  '00000000001102332301111111111111',
+  '00000000111024444423011111111111',
+  '00000001115564444444211111111111',
+  '00000011134644444444631111111111',
+  '00001111024444444466662111111111',
+  '00011115444666222772664581111111',
+  '00111112446799aaabaa766288811111',
+  '011111124699abbbccbba26618881111',
+  '011111124299abbccccbb96618881111',
+  '11111116479abbbcccccba6288881111',
+  '11111112479aabbcccccba2288881111',
+  '11111112479aabcccccbaa2288881111',
+  '1111118247dd9abbca99992288881111',
+  '111118854799999bba99aa7388881111',
+  '111118856972799bb9739b9d88881111',
+  '111118897999aa9abbbbbb9988881111',
+  '1111888b79abba9abbcccbac88881111',
+  '1111888ed9abba9bbbbccbac88881111',
+  '1111888899abb99bbabccbae88881111',
+  '11118888199ba979aabbbac888811111',
+  '111188888f9a999aaa9aba8888811111',
+  '11118888819a9d9aaaabbb8888111111',
+  '1111888888d9aaabbbbbaf8888111111',
+  '1111888888779aaabbba9f8881111111',
+  '11118888887279aabaa99c8881111111',
+  '111188888872679aa979ab8811111111',
+  '111188881g772627779ab93181111111',
+  '111881036h7777799aabba4630111111',
+  '111032444299979abbbcca4444251111',
+  '102444444699a99abbccc34664442301',
+  '344444444479aaabbcccb64664444425',
+];
+
+// Pixels to change when mouth is open (y,x → palette index 4 = black)
+// Mouth is at rows 20-21, columns 12-20 (verified via pixel analysis)
+export const MOUTH_OPEN: Record<string, number> = {};
+for (const x of [12, 13, 14, 15, 16, 17, 18, 19]) MOUTH_OPEN[`20,${x}`] = 4;
+for (const x of [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]) MOUTH_OPEN[`21,${x}`] = 4;
+for (const x of [12, 13, 14, 15, 16, 17, 18]) MOUTH_OPEN[`22,${x}`] = 4;
+
+function decodeChar(c: string): number {
+  const code = c.charCodeAt(0);
+  if (code >= 48 && code <= 57) return code - 48;
+  if (code >= 97 && code <= 122) return code - 97 + 10;
+  return 0;
+}
+
+function encodeChar(n: number): string {
+  if (n < 10) return String(n);
+  return String.fromCharCode(97 + n - 10);
+}
+
+/** Get the sprite grid with optional mouth-open modification */
+export function getSpriteGrid(mouthOpen: boolean): string[] {
+  if (!mouthOpen) return MG_GRID;
+  return MG_GRID.map((row, y) => {
+    let modified = false;
+    const chars = row.split('');
+    for (let x = 0; x < chars.length; x++) {
+      const idx = MOUTH_OPEN[`${y},${x}`];
+      if (idx !== undefined) {
+        chars[x] = encodeChar(idx);
+        modified = true;
+      }
+    }
+    return modified ? chars.join('') : row;
+  });
+}
+
+/** Stamp the sprite onto an RGB background grid at position (ox, oy) */
+export function stampSprite(bg: RGB[][], grid: string[], ox: number, oy: number): void {
+  for (let y = 0; y < grid.length; y++) {
+    for (let x = 0; x < grid[y].length; x++) {
+      const idx = decodeChar(grid[y][x]);
+      if (MG_TRANSPARENT.has(idx)) continue;
+      const bx = ox + x;
+      const by = oy + y;
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
+        bg[by][bx] = MG_PALETTE[idx];
+      }
+    }
+  }
+}
+
+// === Walking sprite (pixel guy walking) ===
+// Same palette as flyer: 0=transparent, 1=hair, 2=coat, 3=skin
+// 10 wide, 16 tall
+
+// Walk frame 1: left leg forward
+const WALK_FRAME1: string[] = [
+  '....11....',
+  '...1111...',
+  '...1331...',
+  '...3333...',
+  '...2222...',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222..22.',
+  '..222..22.',
+  '..222.22..',
+  '..222.2...',
+  '..22..2...',
+  '..2...2...',
+];
+
+// Walk frame 2: legs together
+const WALK_FRAME2: string[] = [
+  '....11....',
+  '...1111...',
+  '...1331...',
+  '...3333...',
+  '...2222...',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222.22..',
+  '..222.22..',
+  '..222.22..',
+  '..222.22..',
+  '..2...2...',
+];
+
+// Walk frame 3: right leg forward
+const WALK_FRAME3: string[] = [
+  '....11....',
+  '...1111...',
+  '...1331...',
+  '...3333...',
+  '...2222...',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '..222222..',
+  '.22..222..',
+  '.22..222..',
+  '..22.222..',
+  '...2.222..',
+  '...2..22..',
+  '...2...2..',
+];
+
+const WALK_FRAMES = [WALK_FRAME1, WALK_FRAME2, WALK_FRAME3, WALK_FRAME2];
+
+/** Draw the walking figure at position (px, py) with given scale and frame */
+export function stampWalker(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
+  const sprite = WALK_FRAMES[frame % WALK_FRAMES.length];
+  const spriteW = sprite[0].length;
+  const spriteH = sprite.length;
+
+  for (let y = 0; y < spriteH; y++) {
+    const row = sprite[y] || '';
+    for (let x = 0; x < spriteW; x++) {
+      const ch = row[x];
+      if (!ch) continue;
+      const idx = decodeChar(ch);
+      if (idx === 0) continue;
+      const sx = Math.floor(px + x * scale);
+      const sy = Math.floor(py + y * scale);
+      const sw = Math.max(1, Math.floor(scale));
+      for (let dy = 0; dy < sw; dy++) {
+        for (let dx = 0; dx < sw; dx++) {
+          const bx = sx + dx;
+          const by = sy + dy;
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
+            bg[by][bx] = FLY_PALETTE[idx];
+          }
+        }
+      }
+    }
+  }
+}
+
+// === Flying sprite (simplified pixel guy with arms spread) ===
+// 0 = transparent, 1 = hair, 2 = coat (dark navy), 3 = skin
+const FLY_PALETTE: RGB[] = [
+  [0, 0, 0], // 0: transparent
+  [36, 33, 32], // 1: hair
+  [25, 35, 55], // 2: coat (dark navy)
+  [189, 140, 119], // 3: skin
+];
+
+// All frames are 12 wide, 14 tall for uniform indexing
+// 0=transparent, 1=hair, 2=coat, 3=skin
+
+// Frame 1: T-pose (arms level)
+const FLY_FRAME1: string[] = [
+  '....11......',
+  '...1111.....',
+  '...1331.....',
+  '...3333.....',
+  '.2.3333.2...',
+  '2222222222..',
+  '.2.3333.2...',
+  '...2222.....',
+  '...2222.....',
+  '...2222.....',
+  '...2222.....',
+  '...2..2.....',
+  '...2..2.....',
+  '............',
+];
+
+// Frame 2: arms up (ascending)
+const FLY_FRAME2: string[] = [
+  '1........1..',
+  '11......11..',
+  '.11....11...',
+  '..133331....',
+  '...33333....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...2..2.....',
+  '...2..2.....',
+  '............',
+];
+
+// Frame 3: diving (arms back)
+const FLY_FRAME3: string[] = [
+  '............',
+  '....11......',
+  '...1331.....',
+  '..333333....',
+  '.222222222..',
+  '..2222222...',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...22222....',
+  '...2..2.....',
+  '...2..2.....',
+  '............',
+];
+
+const FLY_FRAMES = [FLY_FRAME1, FLY_FRAME2, FLY_FRAME3, FLY_FRAME1];
+
+/** Draw the flying figure at position (px, py) with given scale and frame.
+ *  Uses the actual MG face sprite scaled down so Michael is recognizable as he flies. */
+export function stampFlyer(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
+  const sprite = FLY_FRAMES[frame % FLY_FRAMES.length];
+  const spriteW = sprite[0].length;
+  const spriteH = sprite.length;
+
+  for (let y = 0; y < spriteH; y++) {
+    const row = sprite[y] || '';
+    for (let x = 0; x < spriteW; x++) {
+      const ch = row[x];
+      if (!ch) continue;
+      const idx = decodeChar(ch);
+      if (idx === 0) continue; // transparent
+      const sx = Math.floor(px + x * scale);
+      const sy = Math.floor(py + y * scale);
+      const sw = Math.max(1, Math.floor(scale));
+      for (let dy = 0; dy < sw; dy++) {
+        for (let dx = 0; dx < sw; dx++) {
+          const bx = sx + dx;
+          const by = sy + dy;
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
+            bg[by][bx] = FLY_PALETTE[idx];
+          }
+        }
+      }
+    }
+  }
+}
+
+/** Draw the actual MG face sprite scaled, for the departure scene.
+ *  Stamps the real face sprite (with arms added as coat pixels) onto the grid. */
+export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number, _frame: number): void {
+  const grid = getSpriteGrid(false);
+  // Add coat arms on the sides of the face sprite for the flying pose
+  // The face is 32 wide; we extend with coat pixels on rows 10-20
+  const _flyerW = Math.floor(SPRITE_W * scale) + Math.floor(10 * scale);
+  const _flyerH = Math.floor(SPRITE_H * scale) + Math.floor(14 * scale);
+  const offsetX = Math.floor(5 * scale);
+  const offsetY = Math.floor(14 * scale);
+
+  // First draw coat arms (T-pose) behind the face
+  const coatColor: RGB = [25, 35, 55];
+  const armLen = Math.floor(5 * scale);
+  const armY = py + Math.floor(16 * scale);
+  // Arms extend from body
+  for (let i = 0; i < armLen; i++) {
+    // Left arm
+    const lx = px + offsetX - i - 1;
+    // Right arm
+    const rx = px + offsetX + Math.floor(SPRITE_W * scale) + i;
+    for (let dy = 0; dy < Math.max(1, Math.floor(2 * scale)); dy++) {
+      if (armY + dy >= 0 && armY + dy < bg.length) {
+        if (lx >= 0 && lx < bg[0].length) bg[armY + dy][lx] = coatColor;
+        if (rx >= 0 && rx < bg[0].length) bg[armY + dy][rx] = coatColor;
+      }
+    }
+  }
+
+  // Draw the face sprite scaled
+  for (let y = 0; y < SPRITE_H; y++) {
+    for (let x = 0; x < SPRITE_W; x++) {
+      const ch = grid[y][x];
+      if (!ch) continue;
+      const idx = decodeChar(ch);
+      if (MG_TRANSPARENT.has(idx)) continue;
+      const sx = Math.floor(px + offsetX + x * scale);
+      const sy = Math.floor(py + offsetY + y * scale);
+      const sw = Math.max(1, Math.floor(scale));
+      for (let dy = 0; dy < sw; dy++) {
+        for (let dx = 0; dx < sw; dx++) {
+          const bx = sx + dx;
+          const by = sy + dy;
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
+            bg[by][bx] = MG_PALETTE[idx];
+          }
+        }
+      }
+    }
+  }
+
+  // Draw coat body below the face
+  const coatY = py + offsetY + Math.floor(SPRITE_H * scale);
+  const coatW = Math.floor(SPRITE_W * scale * 0.6);
+  const coatStartX = px + offsetX + Math.floor(SPRITE_W * scale * 0.2);
+  for (let dy = 0; dy < Math.floor(10 * scale); dy++) {
+    for (let dx = 0; dx < coatW; dx++) {
+      const bx = coatStartX + dx;
+      const by = coatY + dy;
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
+        bg[by][bx] = coatColor;
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,8 @@ importers:
         specifier: ^1.1.0
         version: 1.3.7
 
+  packages/mg: {}
+
   packages/orchestrate: {}
 
   packages/pin-last-prompt: {}


### PR DESCRIPTION
Moves the standalone `pi-mg` extension into this monorepo as `packages/mg` (`@nicknisi/pi-mg`).

## What's here

- `packages/mg/` — `index.ts`, `sound.ts`, `sprite.ts` from the old standalone repo, plus a monorepo-shaped `package.json` (`pi` manifest, `files`, `exports`, `@earendil-works/*` peer deps) and a full README.
- Root `README.md` — new row in the **UI & appearance** table.
- Changeset: minor bump for the new package.

`/mg [name]` plays a Severance-style "100% File Completion" animation starring a pixelated Michael Grinich: MDR grid → 100% burst → landscape reveal → spoken address → departure → finale. Audio is macOS-only (`say` / `afplay`); it renders silently elsewhere.

## Source changes during the move

Three edits, all to satisfy repo checks — no behavior change:

1. Relative imports got `.ts` extensions (`./sprite` → `./sprite.ts`) — required by `nodenext` resolution, matches `packages/header`.
2. Dropped unused imports `exec` (sound.ts) and `stampSprite` (index.ts).
3. Prefixed the unused `frame` param and `flyerW` / `flyerH` locals in `stampFlyingMG` with `_`. The rest of the repo is oxlint-warning-clean.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format` — clean.
- `pi -ne -e packages/mg/index.ts -p …` loads without error (checked against a deliberately bad path, which does error).
