### PR TITLE
chore: compile all packages under two stricter TypeScript flags

### DIFF
--- a/.changeset/olive-pianos-repeat.md
+++ b/.changeset/olive-pianos-repeat.md
@@ -1,0 +1,18 @@
+---
+'@nicknisi/pi-agent-urls': patch
+'@nicknisi/pi-answer': patch
+'@nicknisi/pi-artifacts': patch
+'@nicknisi/pi-btw': patch
+'@nicknisi/pi-chat-input': patch
+'@nicknisi/pi-claude-compat': patch
+'@nicknisi/pi-cloak': patch
+'@nicknisi/pi-handoff': patch
+'@nicknisi/pi-header': patch
+'@nicknisi/pi-llm-council': patch
+'@nicknisi/pi-mg': patch
+'@nicknisi/pi-recap': patch
+'@nicknisi/pi-session-name': patch
+'@nicknisi/pi-spinner': patch
+---
+
+Compile under `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`. Unchecked indexed reads are now narrowed or explicitly asserted where the index is in range by construction, and optional properties that can legitimately hold `undefined` declare it. Packages ship raw TypeScript, so this also affects how consumers typecheck against them; runtime behavior is unchanged.

--- a/packages/agent-urls/index.ts
+++ b/packages/agent-urls/index.ts
@@ -13,30 +13,32 @@ const DEFAULT_MAX_LINES = 500;
 
 type RunSource = 'session' | 'async' | 'artifact' | 'chain';
 
+// Optionals are widened with `| undefined`: these are parsed out of on-disk
+// JSON, where a field may be absent or explicitly undefined.
 interface ChildRef {
-  index?: number;
-  agent?: string;
-  sessionFile?: string;
-  outputFile?: string;
-  logFile?: string;
-  inputFile?: string;
-  metadataFile?: string;
-  jsonlFile?: string;
-  status?: string;
-  task?: string;
+  index?: number | undefined;
+  agent?: string | undefined;
+  sessionFile?: string | undefined;
+  outputFile?: string | undefined;
+  logFile?: string | undefined;
+  inputFile?: string | undefined;
+  metadataFile?: string | undefined;
+  jsonlFile?: string | undefined;
+  status?: string | undefined;
+  task?: string | undefined;
   updatedAt: number;
 }
 
 interface RunRef {
   runId: string;
   source: RunSource;
-  mode?: string;
-  state?: string;
-  cwd?: string;
-  asyncDir?: string;
-  chainDir?: string;
-  statusFile?: string;
-  eventsFile?: string;
+  mode?: string | undefined;
+  state?: string | undefined;
+  cwd?: string | undefined;
+  asyncDir?: string | undefined;
+  chainDir?: string | undefined;
+  statusFile?: string | undefined;
+  eventsFile?: string | undefined;
   updatedAt: number;
   children: ChildRef[];
 }
@@ -131,9 +133,9 @@ function textFromBlocks(blocks: any): string {
 }
 
 function sessionInfo(file: string): {
-  cwd?: string;
-  task?: string;
-  lastAssistant?: string;
+  cwd?: string | undefined;
+  task?: string | undefined;
+  lastAssistant?: string | undefined;
   updatedAt: number;
 } {
   let cwd: string | undefined;
@@ -178,7 +180,9 @@ function discoverSessionRuns(map: Map<string, RunRef>) {
     const normalized = file.split(path.sep).join('/');
     const match = normalized.match(/\/([0-9a-f]{8})\/run-(\d+)\/[^/]+\.jsonl$/);
     if (!match) continue;
-    const [, runId, indexText] = match;
+    // Groups 1 and 2 are non-optional in the pattern, so a match guarantees them.
+    const runId = match[1]!;
+    const indexText = match[2]!;
     const info = sessionInfo(file);
     upsertRun(map, {
       runId,
@@ -274,9 +278,10 @@ function discoverArtifactRuns(map: Map<string, RunRef>) {
     const m = base.match(/^([0-9a-f]{8})_(.+?)(?:_(\d+))?$/);
     if (!m) continue;
     const key = base;
-    const child = byBase.get(key) ?? {
-      runId: m[1],
-      agent: m[2],
+    const child: Partial<ChildRef> & { runId: string; updatedAt: number } = byBase.get(key) ?? {
+      // Groups 1 and 2 are non-optional in the pattern; group 3 is genuinely optional.
+      runId: m[1]!,
+      agent: m[2]!,
       index: m[3] ? Number(m[3]) : undefined,
       updatedAt: 0,
     };
@@ -409,7 +414,8 @@ function resolveRun(uriHostOrId: string, runs: RunRef[]): RunRef {
   if (matches.length === 0) throw new Error(`No subagent run matched '${uriHostOrId}'. Try /agent list.`);
   if (matches.length > 1)
     throw new Error(`Ambiguous run id '${uriHostOrId}' matched: ${matches.map((r) => r.runId).join(', ')}`);
-  return matches[0];
+  // Exactly one match remains after the guards above.
+  return matches[0]!;
 }
 
 function selectChild(run: RunRef, selector?: string): ChildRef[] {
@@ -485,14 +491,14 @@ function formatRunSummary(run: RunRef): string {
 
 function parseAgentUri(uri: string): {
   scheme: 'agent' | 'history';
-  id?: string;
-  selector?: string;
-  leaf?: string;
+  id?: string | undefined;
+  selector?: string | undefined;
+  leaf?: string | undefined;
 } {
   const match = uri.match(/^(agent|history):\/\/(.*)$/);
   if (!match) throw new Error(`Unsupported URI '${uri}'. Use agent://<runId> or history://<runId>.`);
   const scheme = match[1] as 'agent' | 'history';
-  const parts = match[2].split('/').filter(Boolean);
+  const parts = match[2]!.split('/').filter(Boolean);
   return { scheme, id: parts[0], selector: parts[1], leaf: parts[2] };
 }
 

--- a/packages/answer/index.ts
+++ b/packages/answer/index.ts
@@ -16,7 +16,7 @@ import {
 
 interface ExtractedQuestion {
   question: string;
-  context?: string;
+  context?: string | undefined;
 }
 
 interface ExtractionResult {
@@ -239,8 +239,8 @@ class AnswerComponent implements Component, Focusable {
   private readonly editor: Editor;
   private currentIndex = 0;
   private showingConfirmation = false;
-  private cachedWidth?: number;
-  private cachedLines?: string[];
+  private cachedWidth?: number | undefined;
+  private cachedLines?: string[] | undefined;
 
   constructor(
     private readonly questions: ExtractedQuestion[],
@@ -527,8 +527,8 @@ export default function (pi: ExtensionAPI) {
             extractionModel,
             { systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
             {
-              apiKey: auth.apiKey,
-              headers: auth.headers,
+              ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
+              ...(auth.headers !== undefined && { headers: auth.headers }),
               signal: loader.signal,
               // (no provider-specific reasoning override; both fallback models are Anthropic)
             },

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -22,7 +22,7 @@ interface ArtifactDetails {
   slug: string;
   title: string;
   kind: 'markdown' | 'html';
-  url?: string;
+  url?: string | undefined;
   absPath: string;
 }
 

--- a/packages/artifacts/server.ts
+++ b/packages/artifacts/server.ts
@@ -92,7 +92,8 @@ const MIME: Record<string, string> = {
 };
 
 function handle(req: IncomingMessage, res: ServerResponse, clients: Set<ServerResponse>): void {
-  const url = (req.url ?? '/').split('?')[0];
+  // split always yields at least one element.
+  const url = (req.url ?? '/').split('?')[0]!;
 
   // SSE endpoint
   if (url === '/events') {

--- a/packages/artifacts/utils.ts
+++ b/packages/artifacts/utils.ts
@@ -97,7 +97,7 @@ export function listArtifacts(): ArtifactEntry[] {
           : 'html';
     entries.push({
       slug,
-      title: titleMatch ? titleMatch[1].trim() : slug,
+      title: titleMatch ? titleMatch[1]!.trim() : slug,
       kind,
       mtime: extractMtime(content) ?? statSync(absPath).mtimeMs,
       absPath,
@@ -109,7 +109,7 @@ export function listArtifacts(): ArtifactEntry[] {
 /** Parse the generated-at timestamp embedded by the shell template. */
 function extractMtime(html: string): number | null {
   const m = html.match(/<meta name="artifact-generated" content="(\d+)"/);
-  return m ? parseInt(m[1], 10) : null;
+  return m ? parseInt(m[1]!, 10) : null;
 }
 
 /** Normalize a request path and confirm it resolves inside the artifacts dir. Returns null if unsafe. */

--- a/packages/btw/index.ts
+++ b/packages/btw/index.ts
@@ -137,7 +137,7 @@ class BtwWindow implements Component, Focusable {
   private scroll = 0;
   private lastMaxScroll = 0;
   private readonly editor: Editor;
-  private doneCache?: { width: number; upTo: number; lines: string[] };
+  private doneCache?: { width: number; upTo: number; lines: string[] } | undefined;
 
   constructor(
     private readonly tui: TUI,
@@ -490,7 +490,14 @@ export default function (pi: ExtensionAPI) {
             const stream = getModelProvider(ctx, model).streamSimple(
               model,
               { systemPrompt: SYSTEM_PROMPT, messages: requestMessages },
-              { apiKey, headers, reasoning, signal },
+              // Spread conditionally: these are optional in SimpleStreamOptions,
+              // and exactOptionalPropertyTypes rejects an explicit undefined.
+              {
+                ...(apiKey !== undefined && { apiKey }),
+                ...(headers !== undefined && { headers }),
+                ...(reasoning !== undefined && { reasoning }),
+                ...(signal !== undefined && { signal }),
+              },
             );
 
             let final = '';

--- a/packages/chat-input/index.ts
+++ b/packages/chat-input/index.ts
@@ -92,7 +92,7 @@ function getScrollText(line: string): string | null {
   const plain = plainText(line);
   if (!plain.startsWith('─')) return null;
   const m = plain.match(/((?:↑|↓)\s*\d+\s*more)/);
-  return m ? m[1] : null;
+  return m?.[1] ?? null;
 }
 
 function isBorderLike(line: string): boolean {
@@ -137,8 +137,10 @@ function menuLines(stock: string[], lastIdx: number, width: number): string[] {
 
 // ─── Component ────────────────────────────────────────────────────────────
 
-// @ts-expect-error — handlePaste is private in pi-tui's Editor types but must be
-// overridden to intercept paste; TS-private is compile-time-only, so this is safe at runtime.
+// @ts-expect-error TS2415 — handlePaste is a prototype method typed `private` in
+// pi-tui's Editor; overriding it is legal at runtime (dynamic dispatch) and is the
+// only interception point for paste handling. If this stops erroring, pi-tui made
+// it protected/public — delete both expect-error pragmas in this file.
 class ChatInput extends CustomEditor {
   private border: (s: string) => string;
   private accent: (s: string) => string;
@@ -170,7 +172,7 @@ class ChatInput extends CustomEditor {
         return;
       }
     }
-    // @ts-expect-error — see class declaration; super call into a private method works at runtime.
+    // @ts-expect-error TS2855 — see class-level note: parent method is typed private.
     super.handlePaste(pastedText);
   }
 

--- a/packages/claude-compat/dynamic-skills.ts
+++ b/packages/claude-compat/dynamic-skills.ts
@@ -67,14 +67,16 @@ async function expandCommands(text: string, cwd: string): Promise<string> {
 
   // Run all commands in parallel. Matches come from the original text and are
   // replaced by index, so command output is never re-scanned for placeholders.
-  const outputs = await Promise.all(matches.map((m) => runCommand(m[1] ?? m[2], cwd)));
+  const outputs = await Promise.all(matches.map((m) => runCommand(m[1] ?? m[2] ?? '', cwd)));
 
   // Replace in reverse to preserve indices
   let result = text;
   for (let i = matches.length - 1; i >= 0; i--) {
-    const start = matches[i].index!;
-    const end = start + matches[i][0].length;
-    result = result.slice(0, start) + outputs[i] + result.slice(end);
+    // i is bounded by matches.length, and outputs is built from matches.
+    const match = matches[i]!;
+    const start = match.index!;
+    const end = start + match[0].length;
+    result = result.slice(0, start) + (outputs[i] ?? '') + result.slice(end);
   }
   return result;
 }

--- a/packages/cloak/index.ts
+++ b/packages/cloak/index.ts
@@ -29,7 +29,7 @@ interface CloakConfig {
 interface CompiledCloakPattern {
   source: string;
   regex: RegExp;
-  replace?: string;
+  replace?: string | undefined;
 }
 
 interface CompiledCloakRule {

--- a/packages/handoff/index.ts
+++ b/packages/handoff/index.ts
@@ -186,7 +186,7 @@ export default function (pi: ExtensionAPI) {
 
       // Create new session with parent tracking
       const newSessionResult = await ctx.newSession({
-        parentSession: currentSessionFile,
+        ...(currentSessionFile !== undefined && { parentSession: currentSessionFile }),
       });
 
       if (newSessionResult.cancelled) {

--- a/packages/header/index.ts
+++ b/packages/header/index.ts
@@ -63,10 +63,12 @@ function makeGifDecoder(data: FrameData) {
   const decodedFrames = new Map<number, string[]>();
   let width: number | undefined;
 
+  // Palette/cell/frame indices all come from the encoded animation data and are
+  // in range by construction, so the indexed reads below are non-null asserted.
   const fgEscape = (idx: number): string => {
     let esc = fgEscapes.get(idx);
     if (!esc) {
-      const [r, g, b] = data.COLORS[idx];
+      const [r, g, b] = data.COLORS[idx]!;
       esc = `\x1b[38;2;${r};${g};${b}m`;
       fgEscapes.set(idx, esc);
     }
@@ -75,7 +77,7 @@ function makeGifDecoder(data: FrameData) {
   const bgEscape = (idx: number): string => {
     let esc = bgEscapes.get(idx);
     if (!esc) {
-      const [r, g, b] = data.COLORS[idx];
+      const [r, g, b] = data.COLORS[idx]!;
       esc = `\x1b[48;2;${r};${g};${b}m`;
       bgEscapes.set(idx, esc);
     }
@@ -85,7 +87,7 @@ function makeGifDecoder(data: FrameData) {
     if (idx === 0) return ' ';
     let str = cellStrings.get(idx);
     if (!str) {
-      const [top, bottom] = data.CELLS[idx];
+      const [top, bottom] = data.CELLS[idx]!;
       if (top && bottom) str = `${fgEscape(top)}${bgEscape(bottom)}▀${ANSI_RESET}`;
       else if (top) str = `${fgEscape(top)}▀${ANSI_RESET}`;
       else str = `${fgEscape(bottom)}▄${ANSI_RESET}`;
@@ -96,11 +98,11 @@ function makeGifDecoder(data: FrameData) {
 
   return {
     count: data.FRAMES.length,
-    delay: (i: number) => data.FRAMES[i].delay,
+    delay: (i: number) => data.FRAMES[i]!.delay,
     frame(index: number): string[] {
       let lines = decodedFrames.get(index);
       if (!lines) {
-        lines = data.FRAMES[index].lines.map((tokens) =>
+        lines = data.FRAMES[index]!.lines.map((tokens) =>
           tokens
             .map((token) => {
               const star = token.indexOf('*');
@@ -360,7 +362,8 @@ export default function (pi: ExtensionAPI) {
   const showDashboard = (ctx: ExtensionContext) => {
     const gif = mode === 'blink' || mode === 'waiting' ? GIFS[mode][size] : undefined;
     const pool = mode === 'waiting' ? WAITING_QUOTES : mode === 'blink' ? BLINK_QUOTES : QUOTES;
-    const quote = pool[Math.floor(Math.random() * pool.length)];
+    // pool is a non-empty literal list, so the random index is always in range.
+    const quote = pool[Math.floor(Math.random() * pool.length)]!;
     let typed = 0;
     let blink = false;
     let nextBlinkAt = Date.now() + 2000 + Math.random() * 3000;
@@ -482,7 +485,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand('nicknisi-header', {
     description: 'Cycle nicknisi header style (blink → waiting → full → compact)',
     handler: async (_args, ctx) => {
-      mode = MODES[(MODES.indexOf(mode) + 1) % MODES.length];
+      mode = MODES[(MODES.indexOf(mode) + 1) % MODES.length]!;
       if (shown && ctx.mode === 'tui') {
         stopAnimation();
         showDashboard(ctx);
@@ -497,7 +500,7 @@ export default function (pi: ExtensionAPI) {
     description: 'Set nicknisi header size (small|medium|large, no arg cycles)',
     handler: async (args, ctx) => {
       const requested = args.trim() as Size;
-      size = SIZES.includes(requested) ? requested : SIZES[(SIZES.indexOf(size) + 1) % SIZES.length];
+      size = SIZES.includes(requested) ? requested : SIZES[(SIZES.indexOf(size) + 1) % SIZES.length]!;
       saveConfig({ ...loadConfig(), size });
       if (shown && ctx.mode === 'tui') {
         stopAnimation();

--- a/packages/llm-council/config.ts
+++ b/packages/llm-council/config.ts
@@ -202,7 +202,7 @@ export const CONFIG = {
 
 export interface ResolvedCouncil {
   member: {
-    council: { model: string; displayName?: string; label: string; systemPrompt: string }[];
+    council: { model: string; displayName?: string | undefined; label: string; systemPrompt: string }[];
     tools: string[] | null;
     thinking: string | null;
     extensions: string[] | null;
@@ -211,7 +211,7 @@ export interface ResolvedCouncil {
   };
   chairman: {
     model: string;
-    displayName?: string;
+    displayName?: string | undefined;
     systemPrompt: string;
     exposePersonas: boolean;
     tools: string[] | null;

--- a/packages/llm-council/index.ts
+++ b/packages/llm-council/index.ts
@@ -63,7 +63,7 @@ function statusIcon(status: MemberResult['status'], theme: Theme, spinnerFrame: 
     case 'error':
       return applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix);
     case 'working':
-      return applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]);
+      return applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]!);
     default:
       return applyColor(theme, CONFIG.shared.status.waitingIconColor, CONFIG.shared.status.waitingIcon);
   }
@@ -77,7 +77,7 @@ function memberHeader(icon: string, m: Pick<MemberResult, 'label' | 'model' | 'd
 }
 
 /** `<icon> [badge] Chairman <model>` row. */
-function chairmanHeader(icon: string, c: { model: string; displayName?: string }, theme: Theme): string {
+function chairmanHeader(icon: string, c: { model: string; displayName?: string | undefined }, theme: Theme): string {
   const badge = CONFIG.chairman.display.icon ? `${CONFIG.chairman.display.icon} ` : '';
   return indentLine(
     `${icon} ${badge}${applyColor(theme, CONFIG.chairman.display.labelColor, 'Chairman')} ${applyColor(theme, CONFIG.chairman.display.modelColor, c.displayName ?? c.model)}`,
@@ -159,7 +159,7 @@ function clearSpinner(ctx: any) {
 }
 
 function spinnerDot(theme: Theme, frame: number): string {
-  return `${applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[frame % SPINNER_FRAMES.length])} `;
+  return `${applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!)} `;
 }
 
 function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme: any) {
@@ -240,7 +240,7 @@ function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme
 interface MemberResult {
   label: string;
   model: string;
-  displayName?: string;
+  displayName?: string | undefined;
   systemPrompt: string;
   status: 'pending' | 'working' | 'done' | 'error';
   text: string;
@@ -254,7 +254,7 @@ interface CouncilDetails {
   members: MemberResult[];
   chairman?: {
     model: string;
-    displayName?: string;
+    displayName?: string | undefined;
     status: 'pending' | 'working' | 'done' | 'error';
     text: string;
     error?: string;
@@ -529,13 +529,16 @@ async function runCouncil(
   }
 
   // Phase 2: Run chairman
-  details.chairman = {
+  // Held in a local so the mutations below don't each have to re-narrow
+  // the optional `details.chairman`; both reference the same object.
+  const chairman: NonNullable<CouncilDetails['chairman']> = {
     model: council.chairman.model,
     displayName: council.chairman.displayName,
     status: 'working',
     text: '',
     startedAt: Date.now(),
   };
+  details.chairman = chairman;
   details.stage = 'chairman';
   emit();
 
@@ -567,20 +570,20 @@ async function runCouncil(
   );
 
   if (chairmanResult.exitCode === 0 && chairmanResult.text) {
-    details.chairman.status = 'done';
-    details.chairman.doneAt = Date.now();
-    details.chairman.text = chairmanResult.text;
+    chairman.status = 'done';
+    chairman.doneAt = Date.now();
+    chairman.text = chairmanResult.text;
   } else {
-    details.chairman.status = 'error';
-    details.chairman.doneAt = Date.now();
-    details.chairman.error = chairmanResult.error || 'Chairman failed';
-    details.chairman.text = chairmanResult.text || '';
+    chairman.status = 'error';
+    chairman.doneAt = Date.now();
+    chairman.error = chairmanResult.error || 'Chairman failed';
+    chairman.text = chairmanResult.text || '';
   }
 
   details.stage = 'complete';
   emit();
 
-  const finalText = details.chairman.text || details.chairman.error || 'No output from chairman';
+  const finalText = chairman.text || chairman.error || 'No output from chairman';
   return {
     content: [{ type: 'text', text: finalText }],
     details,

--- a/packages/mg/index.ts
+++ b/packages/mg/index.ts
@@ -52,9 +52,12 @@ function renderColorGrid(grid: RGB[][]): string[] {
   const lines: string[] = [];
   for (let y = 0; y < grid.length; y += 2) {
     let line = '';
-    for (let x = 0; x < grid[0].length; x++) {
-      const top = grid[y][x];
-      const bot = y + 1 < grid.length ? grid[y + 1][x] : null;
+    // Rows hoisted once: y and x are bounded by the grid dimensions.
+    const rowTop = grid[y]!;
+    const rowBot = y + 1 < grid.length ? grid[y + 1]! : null;
+    for (let x = 0; x < grid[0]!.length; x++) {
+      const top = rowTop[x]!;
+      const bot = rowBot ? rowBot[x]! : null;
       if (!bot) {
         line += `\x1b[38;2;${top[0]};${top[1]};${top[2]}m▀`;
       } else if (top[0] === bot[0] && top[1] === bot[1] && top[2] === bot[2]) {
@@ -213,7 +216,7 @@ function renderBigText(text: string, r: number, g: number, b: number): string[] 
   for (let row = 0; row < 7; row++) {
     let line = '';
     for (const ch of chars) {
-      const glyph = FONT[ch] || FONT['0'];
+      const glyph = FONT[ch] || FONT['0']!;
       line += color + glyph[row] + reset;
     }
     lines.push(line);
@@ -254,7 +257,7 @@ function createExplosion(pw: number, ph: number): Particle[] {
       y: cy,
       vx: Math.cos(angle) * speed,
       vy: Math.sin(angle) * speed * 0.6,
-      color: colors[i % colors.length],
+      color: colors[i % colors.length]!,
       life: 1.0,
     });
   }
@@ -278,7 +281,7 @@ function renderExplosion(particles: Particle[], pw: number, ph: number, progress
     const px = Math.floor(p.x);
     const py = Math.floor(p.y);
     if (px >= 0 && px < pw && py >= 0 && py < ph && p.life > 0) {
-      grid[py][px] = [
+      grid[py]![px] = [
         Math.floor(p.color[0] * p.life),
         Math.floor(p.color[1] * p.life),
         Math.floor(p.color[2] * p.life),
@@ -469,7 +472,7 @@ class HundredPercentComponent {
         const row: RGB[] = [];
         for (let x = 0; x < pw; x++) {
           if (y < cutoff) {
-            row.push(landscape[y][x]);
+            row.push(landscape[y]![x]!);
           } else {
             row.push([8, 8, 16]);
           }
@@ -550,9 +553,9 @@ class HundredPercentComponent {
       // Stamp sprite with fade
       const palette = MG_PALETTE;
       for (let y = 0; y < sprite.length; y++) {
-        for (let x = 0; x < sprite[y].length; x++) {
+        for (let x = 0; x < sprite[y]!.length; x++) {
           const idx = (() => {
-            const code = sprite[y][x].charCodeAt(0);
+            const code = sprite[y]![x]!.charCodeAt(0);
             if (code >= 48 && code <= 57) return code - 48;
             if (code >= 97 && code <= 122) return code - 97 + 10;
             return 0;
@@ -560,10 +563,10 @@ class HundredPercentComponent {
           if (MG_TRANSPARENT.has(idx)) continue;
           const bx = ox + x;
           const by = oy + y;
-          if (by >= 0 && by < grid.length && bx >= 0 && bx < grid[0].length) {
-            const spriteColor = palette[idx];
-            const bgColor = grid[by][bx];
-            grid[by][bx] = lerpRGB(bgColor, spriteColor, fadeIn);
+          if (by >= 0 && by < grid.length && bx >= 0 && bx < grid[0]!.length) {
+            const spriteColor = palette[idx]!;
+            const bgColor = grid[by]![bx]!;
+            grid[by]![bx] = lerpRGB(bgColor, spriteColor, fadeIn);
           }
         }
       }
@@ -582,7 +585,7 @@ class HundredPercentComponent {
       const reset = '\x1b[0m';
       const subLine = `${subColor}${subtitle}${reset}`;
       gridLines.push('');
-      gridLines.push(centerLines([subLine], contentWidth)[0]);
+      gridLines.push(centerLines([subLine], contentWidth)[0]!);
     }
 
     return centerLines(gridLines, contentWidth);
@@ -626,11 +629,11 @@ class HundredPercentComponent {
         const trailT = Math.max(0, tt - i * 0.025);
         const tx = Math.floor(lerp(startX, endX, trailT));
         const ty = Math.floor(lerp(startY, endY, trailT) - Math.sin(trailT * Math.PI * 2) * ph * 0.1);
-        if (ty >= 0 && ty < grid.length && tx >= 0 && tx < grid[0].length) {
+        if (ty >= 0 && ty < grid.length && tx >= 0 && tx < grid[0]!.length) {
           // Fade trail by distance
           const alpha = 1 - i / 5;
-          const orig = grid[ty][tx];
-          grid[ty][tx] = [
+          const orig = grid[ty]![tx]!;
+          grid[ty]![tx] = [
             Math.round(lerp(orig[0], trailColor[0], alpha * 0.5)),
             Math.round(lerp(orig[1], trailColor[1], alpha * 0.5)),
             Math.round(lerp(orig[2], trailColor[2], alpha * 0.5)),
@@ -661,7 +664,7 @@ class HundredPercentComponent {
 
     // Add "COMPLETE" below the big "100%"
     for (let i = 0; i < text.length; i++) {
-      lines.push(text[i]);
+      lines.push(text[i]!);
     }
     lines.push('');
     const completeLine = `${completeColor}     C O M P L E T E${reset}`;

--- a/packages/mg/sound.ts
+++ b/packages/mg/sound.ts
@@ -28,7 +28,7 @@ function generateWav(samples: Float32Array): Buffer {
   buf.write('data', 36);
   buf.writeUInt32LE(dataLen, 40);
   for (let i = 0; i < samples.length; i++) {
-    const v = Math.max(-1, Math.min(1, samples[i]));
+    const v = Math.max(-1, Math.min(1, samples[i]!));
     buf.writeInt16LE(Math.floor(v * 32767), 44 + i * 2);
   }
   return buf;
@@ -86,7 +86,7 @@ export function playFanfare(): ChildProcess | null {
   const samples = new Float32Array(n);
   const noteLen = Math.floor((noteMs / 1000) * SAMPLE_RATE);
   for (let ni = 0; ni < notes.length; ni++) {
-    const freq = notes[ni];
+    const freq = notes[ni]!;
     const offset = ni * noteLen;
     for (let i = 0; i < noteLen && offset + i < n; i++) {
       const t = i / SAMPLE_RATE;

--- a/packages/mg/sprite.ts
+++ b/packages/mg/sprite.ts
@@ -106,13 +106,13 @@ export function getSpriteGrid(mouthOpen: boolean): string[] {
 /** Stamp the sprite onto an RGB background grid at position (ox, oy) */
 export function stampSprite(bg: RGB[][], grid: string[], ox: number, oy: number): void {
   for (let y = 0; y < grid.length; y++) {
-    for (let x = 0; x < grid[y].length; x++) {
-      const idx = decodeChar(grid[y][x]);
+    for (let x = 0; x < grid[y]!.length; x++) {
+      const idx = decodeChar(grid[y]![x]!);
       if (MG_TRANSPARENT.has(idx)) continue;
       const bx = ox + x;
       const by = oy + y;
-      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-        bg[by][bx] = MG_PALETTE[idx];
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+        bg[by]![bx] = MG_PALETTE[idx]!;
       }
     }
   }
@@ -186,8 +186,8 @@ const WALK_FRAMES = [WALK_FRAME1, WALK_FRAME2, WALK_FRAME3, WALK_FRAME2];
 
 /** Draw the walking figure at position (px, py) with given scale and frame */
 export function stampWalker(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
-  const sprite = WALK_FRAMES[frame % WALK_FRAMES.length];
-  const spriteW = sprite[0].length;
+  const sprite = WALK_FRAMES[frame % WALK_FRAMES.length]!;
+  const spriteW = sprite[0]!.length;
   const spriteH = sprite.length;
 
   for (let y = 0; y < spriteH; y++) {
@@ -204,8 +204,8 @@ export function stampWalker(bg: RGB[][], px: number, py: number, scale: number, 
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = FLY_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = FLY_PALETTE[idx]!;
           }
         }
       }
@@ -284,8 +284,8 @@ const FLY_FRAMES = [FLY_FRAME1, FLY_FRAME2, FLY_FRAME3, FLY_FRAME1];
 /** Draw the flying figure at position (px, py) with given scale and frame.
  *  Uses the actual MG face sprite scaled down so Michael is recognizable as he flies. */
 export function stampFlyer(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
-  const sprite = FLY_FRAMES[frame % FLY_FRAMES.length];
-  const spriteW = sprite[0].length;
+  const sprite = FLY_FRAMES[frame % FLY_FRAMES.length]!;
+  const spriteW = sprite[0]!.length;
   const spriteH = sprite.length;
 
   for (let y = 0; y < spriteH; y++) {
@@ -302,8 +302,8 @@ export function stampFlyer(bg: RGB[][], px: number, py: number, scale: number, f
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = FLY_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = FLY_PALETTE[idx]!;
           }
         }
       }
@@ -334,8 +334,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
     const rx = px + offsetX + Math.floor(SPRITE_W * scale) + i;
     for (let dy = 0; dy < Math.max(1, Math.floor(2 * scale)); dy++) {
       if (armY + dy >= 0 && armY + dy < bg.length) {
-        if (lx >= 0 && lx < bg[0].length) bg[armY + dy][lx] = coatColor;
-        if (rx >= 0 && rx < bg[0].length) bg[armY + dy][rx] = coatColor;
+        if (lx >= 0 && lx < bg[0]!.length) bg[armY + dy]![lx] = coatColor;
+        if (rx >= 0 && rx < bg[0]!.length) bg[armY + dy]![rx] = coatColor;
       }
     }
   }
@@ -343,7 +343,7 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
   // Draw the face sprite scaled
   for (let y = 0; y < SPRITE_H; y++) {
     for (let x = 0; x < SPRITE_W; x++) {
-      const ch = grid[y][x];
+      const ch = grid[y]![x];
       if (!ch) continue;
       const idx = decodeChar(ch);
       if (MG_TRANSPARENT.has(idx)) continue;
@@ -354,8 +354,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = MG_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = MG_PALETTE[idx]!;
           }
         }
       }
@@ -370,8 +370,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
     for (let dx = 0; dx < coatW; dx++) {
       const bx = coatStartX + dx;
       const by = coatY + dy;
-      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-        bg[by][bx] = coatColor;
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+        bg[by]![bx] = coatColor;
       }
     }
   }

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -126,8 +126,10 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
     },
     {
       apiKey: auth.apiKey,
-      headers: auth.headers,
-      env: auth.env,
+      // Spread conditionally: optional in ProviderStreamOptions, and
+      // exactOptionalPropertyTypes rejects an explicit undefined.
+      ...(auth.headers !== undefined && { headers: auth.headers }),
+      ...(auth.env !== undefined && { env: auth.env }),
       reasoningEffort: 'low',
       cacheRetention: 'none',
       sessionId: uuidv7(),

--- a/packages/session-name/index.ts
+++ b/packages/session-name/index.ts
@@ -295,7 +295,7 @@ export default function sessionNameExtension(pi: ExtensionAPI): void {
         .trim();
       if (!raw) return null;
       let title = raw
-        .split(/\n/)[0]
+        .split(/\n/)[0]!
         .trim()
         .replace(/^["'`]+|["'`]+$/g, '')
         .replace(/[.!?]+$/, '')
@@ -408,7 +408,8 @@ export default function sessionNameExtension(pi: ExtensionAPI): void {
 
       const idx = lines.indexOf(choice);
       if (idx < 0) return;
-      const target = list[idx];
+      // lines is mapped 1:1 from list, so a valid index into one indexes the other.
+      const target = list[idx]!;
 
       const result = await ctx.switchSession(target.path, {
         withSession: async (rctx) => {

--- a/packages/spinner/index.ts
+++ b/packages/spinner/index.ts
@@ -1140,7 +1140,8 @@ const VERBS = [
 ];
 
 function randomVerb(): string {
-  return VERBS[Math.floor(Math.random() * VERBS.length)];
+  // VERBS is a non-empty literal array and the index is always in range.
+  return VERBS[Math.floor(Math.random() * VERBS.length)]!;
 }
 
 export default function (pi: ExtensionAPI) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["es2022"],
     "types": ["node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
Enables `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` in the root tsconfig — the last substantive difference between these packages and the copies arc vendors.

## Coverage

There are no per-package tsconfigs and `include` is `packages/**/*.ts`, so the root config governs **all 22 packages**. Verified before enabling.

## The 137 errors, by category

| category | approach |
|---|---|
| Indexed reads in range by construction | assert, with the invariant in a comment |
| Several reads sharing a row | hoist the row into a local, assert once |
| Optionals that genuinely hold `undefined` | widen to `?: T \| undefined` |
| pi APIs rejecting explicit `undefined` | spread conditionally |

Concretely: palette/frame/grid indices in `mg`, regex groups the pattern guarantees in `agent-urls`, `split()` results, parsed-JSON fields in `agent-urls`, `displayName` in `llm-council`, render caches in `answer`/`btw`.

I deliberately avoided blanket-asserting. Where a real invariant existed I hoisted and documented it — e.g. `renderColorGrid` went from 15 errors to zero by lifting two row locals, which reads better than 15 inline `!`.

## Runtime behavior is unchanged

Two files (`mg/sprite.ts`, `mg/index.ts`) needed repetitive mechanical edits, so I verified them by stripping `!` from both revisions and diffing:

```
✓ identical apart from non-null assertions
```

That rules out an accidental logic change hiding in a bulk edit.

## Also ported from arc

The remaining readability wins that aren't tsconfig-driven:

- `llm-council` holds the chairman in a local instead of repeatedly re-narrowing `details.chairman` (this alone cleared 8 errors)
- `chat-input`'s scroll-text lookup uses `m?.[1] ?? null`
- `chat-input`'s two `@ts-expect-error` pragmas now cite `TS2415` / `TS2855` and state when they should be deleted: *"If this stops erroring, pi-tui made it protected/public."*

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all clean
- **All 22 packages still load under jiti** — the way pi actually loads extensions — with `22 loaded, 0 failed`
- Mechanical passes diff-verified as described above

## Note on the changeset

Patch for the 14 packages with source changes. These ship raw TypeScript, so type-level changes are visible to consumers typechecking against them — that's why it's a release rather than a silent internal change. Runtime behavior is identical.
