### PR TITLE
feat: publish compiled JS alongside the TypeScript sources

### DIFF
--- a/.changeset/compiled-js-output.md
+++ b/.changeset/compiled-js-output.md
@@ -1,0 +1,36 @@
+---
+'@nicknisi/pi-pin-last-prompt': patch
+'@nicknisi/pi-claude-compat': patch
+'@nicknisi/pi-orchestrate': patch
+'@nicknisi/pi-session-name': patch
+'@nicknisi/pi-llm-council': patch
+'@nicknisi/pi-agent-urls': patch
+'@nicknisi/pi-auto-theme': patch
+'@nicknisi/pi-chat-input': patch
+'@nicknisi/pi-statusline': patch
+'@nicknisi/pi-turn-timer': patch
+'@nicknisi/pi-artifacts': patch
+'@nicknisi/pi-save-md': patch
+'@nicknisi/pi-handoff': patch
+'@nicknisi/pi-spinner': patch
+'@nicknisi/pi-answer': patch
+'@nicknisi/pi-header': patch
+'@nicknisi/pi-shared': patch
+'@nicknisi/pi-cloak': patch
+'@nicknisi/pi-recap': patch
+'@nicknisi/pi-stash': patch
+'@nicknisi/pi-btw': patch
+'@nicknisi/pi-mg': patch
+---
+
+Publish compiled JS alongside the TypeScript sources.
+
+`exports` now resolves to `./dist/index.js` and `./dist/index.d.ts`, while the
+`pi` manifest keeps pointing at `./index.ts`. pi is unaffected — it loads
+extensions through jiti, which transpiles TypeScript on the fly, and local path
+installs still need no build step.
+
+This fixes every _other_ consumer. Node refuses to strip types inside
+`node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`), so anything
+`tsc`-built that imported one of these packages crashed at runtime on the raw
+sources. Bundlers and type resolution get a proper entry point too.

--- a/.changeset/olive-pianos-repeat.md
+++ b/.changeset/olive-pianos-repeat.md
@@ -1,0 +1,18 @@
+---
+'@nicknisi/pi-agent-urls': patch
+'@nicknisi/pi-answer': patch
+'@nicknisi/pi-artifacts': patch
+'@nicknisi/pi-btw': patch
+'@nicknisi/pi-chat-input': patch
+'@nicknisi/pi-claude-compat': patch
+'@nicknisi/pi-cloak': patch
+'@nicknisi/pi-handoff': patch
+'@nicknisi/pi-header': patch
+'@nicknisi/pi-llm-council': patch
+'@nicknisi/pi-mg': patch
+'@nicknisi/pi-recap': patch
+'@nicknisi/pi-session-name': patch
+'@nicknisi/pi-spinner': patch
+---
+
+Compile under `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`. Unchecked indexed reads are now narrowed or explicitly asserted where the index is in range by construction, and optional properties that can legitimately hold `undefined` declare it. Packages ship raw TypeScript, so this also affects how consumers typecheck against them; runtime behavior is unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      # Emit is a separate failure surface from `--noEmit`: it resolves
+      # workspace siblings through their published `exports` instead of the
+      # root tsconfig's source `paths`, so it is what catches a package whose
+      # declaration output is unusable by a real consumer.
+      - name: Build
+        run: pnpm run build
+
       # Skipped on the release PR: `chore: version packages` bumps every
       # package.json and deletes the changesets it consumed, so it always
       # looks like "packages changed, no changesets" and would never pass.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
           # version command (it requires a semver argument and never runs the
           # package.json script of the same name).
           version: pnpm run version
-          publish: pnpm changeset publish
+          # `pnpm run release`, not a bare `changeset publish` — packages ship
+          # compiled JS from dist/, which is git-ignored, so it must be built
+          # in CI before anything is published.
+          publish: pnpm run release
           title: 'chore: version packages'
           commit: 'chore: version packages'
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 dist/
+.tsconfig.build.json
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -63,11 +63,29 @@ Local paths are added to pi's settings without copying — edits in the repo are
 ```bash
 pnpm install
 pnpm typecheck   # tsgo (TypeScript 7 native preview)
+pnpm build       # compile each package to packages/<name>/dist/
 pnpm lint        # oxlint
 pnpm fmt         # oxfmt
 ```
 
-Layout: one directory per package in `packages/`, each with `index.ts` + `package.json` carrying a `pi` manifest (`"pi": { "extensions": ["./index.ts"] }`). Extensions ship TypeScript source directly — pi's loader handles it; there is no build step. `@earendil-works/*` packages are peer dependencies: pi's runtime aliases them to its own modules at load time, and the root devDependencies provide one canonical copy for typechecking (`autoInstallPeers: false` keeps it that way).
+Layout: one directory per package in `packages/`, each with `index.ts` + `package.json` carrying a `pi` manifest (`"pi": { "extensions": ["./index.ts"] }`). `@earendil-works/*` packages are peer dependencies: pi's runtime aliases them to its own modules at load time, and the root devDependencies provide one canonical copy for typechecking (`autoInstallPeers: false` keeps it that way).
+
+### Two entry points per package
+
+Each package publishes its TypeScript sources _and_ compiled JS, and they are used by different consumers:
+
+| Field           | Points at                               | Used by                                            |
+| --------------- | --------------------------------------- | -------------------------------------------------- |
+| `pi.extensions` | `./index.ts`                            | pi, which transpiles extensions through jiti       |
+| `exports`       | `./dist/index.js` + `./dist/index.d.ts` | everyone else — bundlers, and anything `tsc`-built |
+
+The split exists because Node refuses to strip types inside `node_modules` (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`), so a `tsc`-built consumer importing raw `.ts` from a package crashes at runtime. Keeping `pi.extensions` on the sources means local path installs (`pi install ../pi-extensions/packages/statusline`) still need no build step, which is the point of the rapid-testing loop.
+
+Consequences worth knowing:
+
+- **`dist/` is git-ignored**, so `pnpm build` runs in CI before publish (see `release.yml`) and from the root `prepare` script after `pnpm install`. That hook is load-bearing for local path installs: six packages depend on `@nicknisi/pi-shared`, which now resolves through its own `exports` into `dist/`, so a fresh clone with no build would fail to load them in pi. If you ever delete `dist/` by hand, run `pnpm build` — a no-op `pnpm install` will not re-run `prepare`.
+- **Relative imports use `.js`, never `.ts`** (`import { x } from './config.js'`), the normal NodeNext convention — `allowImportingTsExtensions` is deliberately off so the typecheck catches any regression.
+- **`paths` in the root tsconfig** maps `@nicknisi/pi-shared` to its source, so a fresh clone typechecks without building first. The build turns that off (`paths: {}`) and resolves siblings through their real `exports` instead, which is what proves the declaration output is actually usable.
 
 Cross-package helpers go in `packages/shared`, consumed as `"@nicknisi/pi-shared": "workspace:*"`.
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Nick Nisi's pi extensions — monorepo of independently installable pi packages",
   "type": "module",
   "scripts": {
+    "build": "node scripts/build.ts",
+    "prepare": "pnpm build",
     "typecheck": "tsgo --noEmit",
     "lint": "oxlint .",
     "format": "oxfmt .",
@@ -13,7 +15,7 @@
     "fmt:check": "oxfmt --check .",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm typecheck && changeset publish"
+    "release": "pnpm typecheck && pnpm build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",

--- a/packages/agent-urls/index.ts
+++ b/packages/agent-urls/index.ts
@@ -13,30 +13,32 @@ const DEFAULT_MAX_LINES = 500;
 
 type RunSource = 'session' | 'async' | 'artifact' | 'chain';
 
+// Optionals are widened with `| undefined`: these are parsed out of on-disk
+// JSON, where a field may be absent or explicitly undefined.
 interface ChildRef {
-  index?: number;
-  agent?: string;
-  sessionFile?: string;
-  outputFile?: string;
-  logFile?: string;
-  inputFile?: string;
-  metadataFile?: string;
-  jsonlFile?: string;
-  status?: string;
-  task?: string;
+  index?: number | undefined;
+  agent?: string | undefined;
+  sessionFile?: string | undefined;
+  outputFile?: string | undefined;
+  logFile?: string | undefined;
+  inputFile?: string | undefined;
+  metadataFile?: string | undefined;
+  jsonlFile?: string | undefined;
+  status?: string | undefined;
+  task?: string | undefined;
   updatedAt: number;
 }
 
 interface RunRef {
   runId: string;
   source: RunSource;
-  mode?: string;
-  state?: string;
-  cwd?: string;
-  asyncDir?: string;
-  chainDir?: string;
-  statusFile?: string;
-  eventsFile?: string;
+  mode?: string | undefined;
+  state?: string | undefined;
+  cwd?: string | undefined;
+  asyncDir?: string | undefined;
+  chainDir?: string | undefined;
+  statusFile?: string | undefined;
+  eventsFile?: string | undefined;
   updatedAt: number;
   children: ChildRef[];
 }
@@ -131,9 +133,9 @@ function textFromBlocks(blocks: any): string {
 }
 
 function sessionInfo(file: string): {
-  cwd?: string;
-  task?: string;
-  lastAssistant?: string;
+  cwd?: string | undefined;
+  task?: string | undefined;
+  lastAssistant?: string | undefined;
   updatedAt: number;
 } {
   let cwd: string | undefined;
@@ -178,7 +180,9 @@ function discoverSessionRuns(map: Map<string, RunRef>) {
     const normalized = file.split(path.sep).join('/');
     const match = normalized.match(/\/([0-9a-f]{8})\/run-(\d+)\/[^/]+\.jsonl$/);
     if (!match) continue;
-    const [, runId, indexText] = match;
+    // Groups 1 and 2 are non-optional in the pattern, so a match guarantees them.
+    const runId = match[1]!;
+    const indexText = match[2]!;
     const info = sessionInfo(file);
     upsertRun(map, {
       runId,
@@ -274,9 +278,10 @@ function discoverArtifactRuns(map: Map<string, RunRef>) {
     const m = base.match(/^([0-9a-f]{8})_(.+?)(?:_(\d+))?$/);
     if (!m) continue;
     const key = base;
-    const child = byBase.get(key) ?? {
-      runId: m[1],
-      agent: m[2],
+    const child: Partial<ChildRef> & { runId: string; updatedAt: number } = byBase.get(key) ?? {
+      // Groups 1 and 2 are non-optional in the pattern; group 3 is genuinely optional.
+      runId: m[1]!,
+      agent: m[2]!,
       index: m[3] ? Number(m[3]) : undefined,
       updatedAt: 0,
     };
@@ -409,7 +414,8 @@ function resolveRun(uriHostOrId: string, runs: RunRef[]): RunRef {
   if (matches.length === 0) throw new Error(`No subagent run matched '${uriHostOrId}'. Try /agent list.`);
   if (matches.length > 1)
     throw new Error(`Ambiguous run id '${uriHostOrId}' matched: ${matches.map((r) => r.runId).join(', ')}`);
-  return matches[0];
+  // Exactly one match remains after the guards above.
+  return matches[0]!;
 }
 
 function selectChild(run: RunRef, selector?: string): ChildRef[] {
@@ -485,14 +491,14 @@ function formatRunSummary(run: RunRef): string {
 
 function parseAgentUri(uri: string): {
   scheme: 'agent' | 'history';
-  id?: string;
-  selector?: string;
-  leaf?: string;
+  id?: string | undefined;
+  selector?: string | undefined;
+  leaf?: string | undefined;
 } {
   const match = uri.match(/^(agent|history):\/\/(.*)$/);
   if (!match) throw new Error(`Unsupported URI '${uri}'. Use agent://<runId> or history://<runId>.`);
   const scheme = match[1] as 'agent' | 'history';
-  const parts = match[2].split('/').filter(Boolean);
+  const parts = match[2]!.split('/').filter(Boolean);
   return { scheme, id: parts[0], selector: parts[1], leaf: parts[2] };
 }
 

--- a/packages/agent-urls/package.json
+++ b/packages/agent-urls/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/agent-urls"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/answer/index.ts
+++ b/packages/answer/index.ts
@@ -16,7 +16,7 @@ import {
 
 interface ExtractedQuestion {
   question: string;
-  context?: string;
+  context?: string | undefined;
 }
 
 interface ExtractionResult {
@@ -239,8 +239,8 @@ class AnswerComponent implements Component, Focusable {
   private readonly editor: Editor;
   private currentIndex = 0;
   private showingConfirmation = false;
-  private cachedWidth?: number;
-  private cachedLines?: string[];
+  private cachedWidth?: number | undefined;
+  private cachedLines?: string[] | undefined;
 
   constructor(
     private readonly questions: ExtractedQuestion[],
@@ -527,8 +527,8 @@ export default function (pi: ExtensionAPI) {
             extractionModel,
             { systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
             {
-              apiKey: auth.apiKey,
-              headers: auth.headers,
+              ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
+              ...(auth.headers !== undefined && { headers: auth.headers }),
               signal: loader.signal,
               // (no provider-specific reasoning override; both fallback models are Anthropic)
             },

--- a/packages/answer/package.json
+++ b/packages/answer/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/answer"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -22,7 +22,7 @@ interface ArtifactDetails {
   slug: string;
   title: string;
   kind: 'markdown' | 'html';
-  url?: string;
+  url?: string | undefined;
   absPath: string;
 }
 

--- a/packages/artifacts/package.json
+++ b/packages/artifacts/package.json
@@ -15,6 +15,7 @@
     "directory": "packages/artifacts"
   },
   "files": [
+    "dist",
     "index.ts",
     "config.ts",
     "server.ts",
@@ -26,7 +27,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "diff2html": "^3.4.52",

--- a/packages/artifacts/server.ts
+++ b/packages/artifacts/server.ts
@@ -92,7 +92,8 @@ const MIME: Record<string, string> = {
 };
 
 function handle(req: IncomingMessage, res: ServerResponse, clients: Set<ServerResponse>): void {
-  const url = (req.url ?? '/').split('?')[0];
+  // split always yields at least one element.
+  const url = (req.url ?? '/').split('?')[0]!;
 
   // SSE endpoint
   if (url === '/events') {

--- a/packages/artifacts/utils.ts
+++ b/packages/artifacts/utils.ts
@@ -97,7 +97,7 @@ export function listArtifacts(): ArtifactEntry[] {
           : 'html';
     entries.push({
       slug,
-      title: titleMatch ? titleMatch[1].trim() : slug,
+      title: titleMatch ? titleMatch[1]!.trim() : slug,
       kind,
       mtime: extractMtime(content) ?? statSync(absPath).mtimeMs,
       absPath,
@@ -109,7 +109,7 @@ export function listArtifacts(): ArtifactEntry[] {
 /** Parse the generated-at timestamp embedded by the shell template. */
 function extractMtime(html: string): number | null {
   const m = html.match(/<meta name="artifact-generated" content="(\d+)"/);
-  return m ? parseInt(m[1], 10) : null;
+  return m ? parseInt(m[1]!, 10) : null;
 }
 
 /** Normalize a request path and confirm it resolves inside the artifacts dir. Returns null if unsafe. */

--- a/packages/auto-theme/package.json
+++ b/packages/auto-theme/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/auto-theme"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/btw/index.ts
+++ b/packages/btw/index.ts
@@ -137,7 +137,7 @@ class BtwWindow implements Component, Focusable {
   private scroll = 0;
   private lastMaxScroll = 0;
   private readonly editor: Editor;
-  private doneCache?: { width: number; upTo: number; lines: string[] };
+  private doneCache?: { width: number; upTo: number; lines: string[] } | undefined;
 
   constructor(
     private readonly tui: TUI,
@@ -490,7 +490,14 @@ export default function (pi: ExtensionAPI) {
             const stream = getModelProvider(ctx, model).streamSimple(
               model,
               { systemPrompt: SYSTEM_PROMPT, messages: requestMessages },
-              { apiKey, headers, reasoning, signal },
+              // Spread conditionally: these are optional in SimpleStreamOptions,
+              // and exactOptionalPropertyTypes rejects an explicit undefined.
+              {
+                ...(apiKey !== undefined && { apiKey }),
+                ...(headers !== undefined && { headers }),
+                ...(reasoning !== undefined && { reasoning }),
+                ...(signal !== undefined && { signal }),
+              },
             );
 
             let final = '';

--- a/packages/btw/package.json
+++ b/packages/btw/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/btw"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/chat-input/index.ts
+++ b/packages/chat-input/index.ts
@@ -92,7 +92,7 @@ function getScrollText(line: string): string | null {
   const plain = plainText(line);
   if (!plain.startsWith('─')) return null;
   const m = plain.match(/((?:↑|↓)\s*\d+\s*more)/);
-  return m ? m[1] : null;
+  return m?.[1] ?? null;
 }
 
 function isBorderLike(line: string): boolean {
@@ -137,8 +137,10 @@ function menuLines(stock: string[], lastIdx: number, width: number): string[] {
 
 // ─── Component ────────────────────────────────────────────────────────────
 
-// @ts-expect-error — handlePaste is private in pi-tui's Editor types but must be
-// overridden to intercept paste; TS-private is compile-time-only, so this is safe at runtime.
+// @ts-expect-error TS2415 — handlePaste is a prototype method typed `private` in
+// pi-tui's Editor; overriding it is legal at runtime (dynamic dispatch) and is the
+// only interception point for paste handling. If this stops erroring, pi-tui made
+// it protected/public — delete both expect-error pragmas in this file.
 class ChatInput extends CustomEditor {
   private border: (s: string) => string;
   private accent: (s: string) => string;
@@ -170,7 +172,7 @@ class ChatInput extends CustomEditor {
         return;
       }
     }
-    // @ts-expect-error — see class declaration; super call into a private method works at runtime.
+    // @ts-expect-error TS2855 — see class-level note: parent method is typed private.
     super.handlePaste(pastedText);
   }
 

--- a/packages/chat-input/package.json
+++ b/packages/chat-input/package.json
@@ -15,6 +15,7 @@
     "directory": "packages/chat-input"
   },
   "files": [
+    "dist",
     "index.ts",
     "config.ts",
     "utils.ts",
@@ -23,7 +24,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/packages/claude-compat/dynamic-skills.ts
+++ b/packages/claude-compat/dynamic-skills.ts
@@ -67,14 +67,16 @@ async function expandCommands(text: string, cwd: string): Promise<string> {
 
   // Run all commands in parallel. Matches come from the original text and are
   // replaced by index, so command output is never re-scanned for placeholders.
-  const outputs = await Promise.all(matches.map((m) => runCommand(m[1] ?? m[2], cwd)));
+  const outputs = await Promise.all(matches.map((m) => runCommand(m[1] ?? m[2] ?? '', cwd)));
 
   // Replace in reverse to preserve indices
   let result = text;
   for (let i = matches.length - 1; i >= 0; i--) {
-    const start = matches[i].index!;
-    const end = start + matches[i][0].length;
-    result = result.slice(0, start) + outputs[i] + result.slice(end);
+    // i is bounded by matches.length, and outputs is built from matches.
+    const match = matches[i]!;
+    const start = match.index!;
+    const end = start + match[0].length;
+    result = result.slice(0, start) + (outputs[i] ?? '') + result.slice(end);
   }
   return result;
 }

--- a/packages/claude-compat/package.json
+++ b/packages/claude-compat/package.json
@@ -15,13 +15,17 @@
     "directory": "packages/claude-compat"
   },
   "files": [
+    "dist",
     "index.ts",
     "dynamic-skills.ts",
     "README.md"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/cloak/index.ts
+++ b/packages/cloak/index.ts
@@ -29,7 +29,7 @@ interface CloakConfig {
 interface CompiledCloakPattern {
   source: string;
   regex: RegExp;
-  replace?: string;
+  replace?: string | undefined;
 }
 
 interface CompiledCloakRule {

--- a/packages/cloak/package.json
+++ b/packages/cloak/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/cloak"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/handoff/index.ts
+++ b/packages/handoff/index.ts
@@ -186,7 +186,7 @@ export default function (pi: ExtensionAPI) {
 
       // Create new session with parent tracking
       const newSessionResult = await ctx.newSession({
-        parentSession: currentSessionFile,
+        ...(currentSessionFile !== undefined && { parentSession: currentSessionFile }),
       });
 
       if (newSessionResult.cancelled) {

--- a/packages/handoff/package.json
+++ b/packages/handoff/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/handoff"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/header/index.ts
+++ b/packages/header/index.ts
@@ -63,10 +63,12 @@ function makeGifDecoder(data: FrameData) {
   const decodedFrames = new Map<number, string[]>();
   let width: number | undefined;
 
+  // Palette/cell/frame indices all come from the encoded animation data and are
+  // in range by construction, so the indexed reads below are non-null asserted.
   const fgEscape = (idx: number): string => {
     let esc = fgEscapes.get(idx);
     if (!esc) {
-      const [r, g, b] = data.COLORS[idx];
+      const [r, g, b] = data.COLORS[idx]!;
       esc = `\x1b[38;2;${r};${g};${b}m`;
       fgEscapes.set(idx, esc);
     }
@@ -75,7 +77,7 @@ function makeGifDecoder(data: FrameData) {
   const bgEscape = (idx: number): string => {
     let esc = bgEscapes.get(idx);
     if (!esc) {
-      const [r, g, b] = data.COLORS[idx];
+      const [r, g, b] = data.COLORS[idx]!;
       esc = `\x1b[48;2;${r};${g};${b}m`;
       bgEscapes.set(idx, esc);
     }
@@ -85,7 +87,7 @@ function makeGifDecoder(data: FrameData) {
     if (idx === 0) return ' ';
     let str = cellStrings.get(idx);
     if (!str) {
-      const [top, bottom] = data.CELLS[idx];
+      const [top, bottom] = data.CELLS[idx]!;
       if (top && bottom) str = `${fgEscape(top)}${bgEscape(bottom)}▀${ANSI_RESET}`;
       else if (top) str = `${fgEscape(top)}▀${ANSI_RESET}`;
       else str = `${fgEscape(bottom)}▄${ANSI_RESET}`;
@@ -96,11 +98,11 @@ function makeGifDecoder(data: FrameData) {
 
   return {
     count: data.FRAMES.length,
-    delay: (i: number) => data.FRAMES[i].delay,
+    delay: (i: number) => data.FRAMES[i]!.delay,
     frame(index: number): string[] {
       let lines = decodedFrames.get(index);
       if (!lines) {
-        lines = data.FRAMES[index].lines.map((tokens) =>
+        lines = data.FRAMES[index]!.lines.map((tokens) =>
           tokens
             .map((token) => {
               const star = token.indexOf('*');
@@ -360,7 +362,8 @@ export default function (pi: ExtensionAPI) {
   const showDashboard = (ctx: ExtensionContext) => {
     const gif = mode === 'blink' || mode === 'waiting' ? GIFS[mode][size] : undefined;
     const pool = mode === 'waiting' ? WAITING_QUOTES : mode === 'blink' ? BLINK_QUOTES : QUOTES;
-    const quote = pool[Math.floor(Math.random() * pool.length)];
+    // pool is a non-empty literal list, so the random index is always in range.
+    const quote = pool[Math.floor(Math.random() * pool.length)]!;
     let typed = 0;
     let blink = false;
     let nextBlinkAt = Date.now() + 2000 + Math.random() * 3000;
@@ -482,7 +485,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerCommand('nicknisi-header', {
     description: 'Cycle nicknisi header style (blink → waiting → full → compact)',
     handler: async (_args, ctx) => {
-      mode = MODES[(MODES.indexOf(mode) + 1) % MODES.length];
+      mode = MODES[(MODES.indexOf(mode) + 1) % MODES.length]!;
       if (shown && ctx.mode === 'tui') {
         stopAnimation();
         showDashboard(ctx);
@@ -497,7 +500,7 @@ export default function (pi: ExtensionAPI) {
     description: 'Set nicknisi header size (small|medium|large, no arg cycles)',
     handler: async (args, ctx) => {
       const requested = args.trim() as Size;
-      size = SIZES.includes(requested) ? requested : SIZES[(SIZES.indexOf(size) + 1) % SIZES.length];
+      size = SIZES.includes(requested) ? requested : SIZES[(SIZES.indexOf(size) + 1) % SIZES.length]!;
       saveConfig({ ...loadConfig(), size });
       if (shown && ctx.mode === 'tui') {
         stopAnimation();

--- a/packages/header/index.ts
+++ b/packages/header/index.ts
@@ -35,12 +35,12 @@ import {
   type Theme,
 } from '@earendil-works/pi-coding-agent';
 import type { Component } from '@earendil-works/pi-tui';
-import * as blinkDataLarge from './frames-blink-large.ts';
-import * as blinkDataSmall from './frames-blink-small.ts';
-import * as blinkData from './frames-blink.ts';
-import * as waitingDataLarge from './frames-waiting-large.ts';
-import * as waitingDataSmall from './frames-waiting-small.ts';
-import * as waitingData from './frames-waiting.ts';
+import * as blinkDataLarge from './frames-blink-large.js';
+import * as blinkDataSmall from './frames-blink-small.js';
+import * as blinkData from './frames-blink.js';
+import * as waitingDataLarge from './frames-waiting-large.js';
+import * as waitingDataSmall from './frames-waiting-small.js';
+import * as waitingData from './frames-waiting.js';
 
 const ANSI_RESET = '\x1b[0m';
 const ANSI_RE = /\u001b\[[0-9;]*m/g; // eslint-disable-line no-control-regex -- intentional: matches ANSI color escapes

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -15,13 +15,17 @@
     "directory": "packages/header"
   },
   "files": [
+    "dist",
     "index.ts",
     "frames-*.ts",
     "gen-frames.mjs"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/llm-council/config.ts
+++ b/packages/llm-council/config.ts
@@ -202,7 +202,7 @@ export const CONFIG = {
 
 export interface ResolvedCouncil {
   member: {
-    council: { model: string; displayName?: string; label: string; systemPrompt: string }[];
+    council: { model: string; displayName?: string | undefined; label: string; systemPrompt: string }[];
     tools: string[] | null;
     thinking: string | null;
     extensions: string[] | null;
@@ -211,7 +211,7 @@ export interface ResolvedCouncil {
   };
   chairman: {
     model: string;
-    displayName?: string;
+    displayName?: string | undefined;
     systemPrompt: string;
     exposePersonas: boolean;
     tools: string[] | null;

--- a/packages/llm-council/index.ts
+++ b/packages/llm-council/index.ts
@@ -63,7 +63,7 @@ function statusIcon(status: MemberResult['status'], theme: Theme, spinnerFrame: 
     case 'error':
       return applyColor(theme, CONFIG.shared.status.errorColor, CONFIG.shared.errorPrefix.prefix);
     case 'working':
-      return applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]);
+      return applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length]!);
     default:
       return applyColor(theme, CONFIG.shared.status.waitingIconColor, CONFIG.shared.status.waitingIcon);
   }
@@ -77,7 +77,7 @@ function memberHeader(icon: string, m: Pick<MemberResult, 'label' | 'model' | 'd
 }
 
 /** `<icon> [badge] Chairman <model>` row. */
-function chairmanHeader(icon: string, c: { model: string; displayName?: string }, theme: Theme): string {
+function chairmanHeader(icon: string, c: { model: string; displayName?: string | undefined }, theme: Theme): string {
   const badge = CONFIG.chairman.display.icon ? `${CONFIG.chairman.display.icon} ` : '';
   return indentLine(
     `${icon} ${badge}${applyColor(theme, CONFIG.chairman.display.labelColor, 'Chairman')} ${applyColor(theme, CONFIG.chairman.display.modelColor, c.displayName ?? c.model)}`,
@@ -159,7 +159,7 @@ function clearSpinner(ctx: any) {
 }
 
 function spinnerDot(theme: Theme, frame: number): string {
-  return `${applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[frame % SPINNER_FRAMES.length])} `;
+  return `${applyColor(theme, CONFIG.shared.spinner.color, SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!)} `;
 }
 
 function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme: any) {
@@ -240,7 +240,7 @@ function createExpandedView(details: CouncilDetails, theme: Theme, markdownTheme
 interface MemberResult {
   label: string;
   model: string;
-  displayName?: string;
+  displayName?: string | undefined;
   systemPrompt: string;
   status: 'pending' | 'working' | 'done' | 'error';
   text: string;
@@ -254,7 +254,7 @@ interface CouncilDetails {
   members: MemberResult[];
   chairman?: {
     model: string;
-    displayName?: string;
+    displayName?: string | undefined;
     status: 'pending' | 'working' | 'done' | 'error';
     text: string;
     error?: string;
@@ -529,13 +529,16 @@ async function runCouncil(
   }
 
   // Phase 2: Run chairman
-  details.chairman = {
+  // Held in a local so the mutations below don't each have to re-narrow
+  // the optional `details.chairman`; both reference the same object.
+  const chairman: NonNullable<CouncilDetails['chairman']> = {
     model: council.chairman.model,
     displayName: council.chairman.displayName,
     status: 'working',
     text: '',
     startedAt: Date.now(),
   };
+  details.chairman = chairman;
   details.stage = 'chairman';
   emit();
 
@@ -567,20 +570,20 @@ async function runCouncil(
   );
 
   if (chairmanResult.exitCode === 0 && chairmanResult.text) {
-    details.chairman.status = 'done';
-    details.chairman.doneAt = Date.now();
-    details.chairman.text = chairmanResult.text;
+    chairman.status = 'done';
+    chairman.doneAt = Date.now();
+    chairman.text = chairmanResult.text;
   } else {
-    details.chairman.status = 'error';
-    details.chairman.doneAt = Date.now();
-    details.chairman.error = chairmanResult.error || 'Chairman failed';
-    details.chairman.text = chairmanResult.text || '';
+    chairman.status = 'error';
+    chairman.doneAt = Date.now();
+    chairman.error = chairmanResult.error || 'Chairman failed';
+    chairman.text = chairmanResult.text || '';
   }
 
   details.stage = 'complete';
   emit();
 
-  const finalText = details.chairman.text || details.chairman.error || 'No output from chairman';
+  const finalText = chairman.text || chairman.error || 'No output from chairman';
   return {
     content: [{ type: 'text', text: finalText }],
     details,

--- a/packages/llm-council/package.json
+++ b/packages/llm-council/package.json
@@ -15,6 +15,7 @@
     "directory": "packages/llm-council"
   },
   "files": [
+    "dist",
     "index.ts",
     "config.ts",
     "utils.ts",
@@ -25,7 +26,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "typebox": "^1.1.0"

--- a/packages/mg/index.ts
+++ b/packages/mg/index.ts
@@ -52,9 +52,12 @@ function renderColorGrid(grid: RGB[][]): string[] {
   const lines: string[] = [];
   for (let y = 0; y < grid.length; y += 2) {
     let line = '';
-    for (let x = 0; x < grid[0].length; x++) {
-      const top = grid[y][x];
-      const bot = y + 1 < grid.length ? grid[y + 1][x] : null;
+    // Rows hoisted once: y and x are bounded by the grid dimensions.
+    const rowTop = grid[y]!;
+    const rowBot = y + 1 < grid.length ? grid[y + 1]! : null;
+    for (let x = 0; x < grid[0]!.length; x++) {
+      const top = rowTop[x]!;
+      const bot = rowBot ? rowBot[x]! : null;
       if (!bot) {
         line += `\x1b[38;2;${top[0]};${top[1]};${top[2]}m▀`;
       } else if (top[0] === bot[0] && top[1] === bot[1] && top[2] === bot[2]) {
@@ -213,7 +216,7 @@ function renderBigText(text: string, r: number, g: number, b: number): string[] 
   for (let row = 0; row < 7; row++) {
     let line = '';
     for (const ch of chars) {
-      const glyph = FONT[ch] || FONT['0'];
+      const glyph = FONT[ch] || FONT['0']!;
       line += color + glyph[row] + reset;
     }
     lines.push(line);
@@ -254,7 +257,7 @@ function createExplosion(pw: number, ph: number): Particle[] {
       y: cy,
       vx: Math.cos(angle) * speed,
       vy: Math.sin(angle) * speed * 0.6,
-      color: colors[i % colors.length],
+      color: colors[i % colors.length]!,
       life: 1.0,
     });
   }
@@ -278,7 +281,7 @@ function renderExplosion(particles: Particle[], pw: number, ph: number, progress
     const px = Math.floor(p.x);
     const py = Math.floor(p.y);
     if (px >= 0 && px < pw && py >= 0 && py < ph && p.life > 0) {
-      grid[py][px] = [
+      grid[py]![px] = [
         Math.floor(p.color[0] * p.life),
         Math.floor(p.color[1] * p.life),
         Math.floor(p.color[2] * p.life),
@@ -469,7 +472,7 @@ class HundredPercentComponent {
         const row: RGB[] = [];
         for (let x = 0; x < pw; x++) {
           if (y < cutoff) {
-            row.push(landscape[y][x]);
+            row.push(landscape[y]![x]!);
           } else {
             row.push([8, 8, 16]);
           }
@@ -550,9 +553,9 @@ class HundredPercentComponent {
       // Stamp sprite with fade
       const palette = MG_PALETTE;
       for (let y = 0; y < sprite.length; y++) {
-        for (let x = 0; x < sprite[y].length; x++) {
+        for (let x = 0; x < sprite[y]!.length; x++) {
           const idx = (() => {
-            const code = sprite[y][x].charCodeAt(0);
+            const code = sprite[y]![x]!.charCodeAt(0);
             if (code >= 48 && code <= 57) return code - 48;
             if (code >= 97 && code <= 122) return code - 97 + 10;
             return 0;
@@ -560,10 +563,10 @@ class HundredPercentComponent {
           if (MG_TRANSPARENT.has(idx)) continue;
           const bx = ox + x;
           const by = oy + y;
-          if (by >= 0 && by < grid.length && bx >= 0 && bx < grid[0].length) {
-            const spriteColor = palette[idx];
-            const bgColor = grid[by][bx];
-            grid[by][bx] = lerpRGB(bgColor, spriteColor, fadeIn);
+          if (by >= 0 && by < grid.length && bx >= 0 && bx < grid[0]!.length) {
+            const spriteColor = palette[idx]!;
+            const bgColor = grid[by]![bx]!;
+            grid[by]![bx] = lerpRGB(bgColor, spriteColor, fadeIn);
           }
         }
       }
@@ -582,7 +585,7 @@ class HundredPercentComponent {
       const reset = '\x1b[0m';
       const subLine = `${subColor}${subtitle}${reset}`;
       gridLines.push('');
-      gridLines.push(centerLines([subLine], contentWidth)[0]);
+      gridLines.push(centerLines([subLine], contentWidth)[0]!);
     }
 
     return centerLines(gridLines, contentWidth);
@@ -626,11 +629,11 @@ class HundredPercentComponent {
         const trailT = Math.max(0, tt - i * 0.025);
         const tx = Math.floor(lerp(startX, endX, trailT));
         const ty = Math.floor(lerp(startY, endY, trailT) - Math.sin(trailT * Math.PI * 2) * ph * 0.1);
-        if (ty >= 0 && ty < grid.length && tx >= 0 && tx < grid[0].length) {
+        if (ty >= 0 && ty < grid.length && tx >= 0 && tx < grid[0]!.length) {
           // Fade trail by distance
           const alpha = 1 - i / 5;
-          const orig = grid[ty][tx];
-          grid[ty][tx] = [
+          const orig = grid[ty]![tx]!;
+          grid[ty]![tx] = [
             Math.round(lerp(orig[0], trailColor[0], alpha * 0.5)),
             Math.round(lerp(orig[1], trailColor[1], alpha * 0.5)),
             Math.round(lerp(orig[2], trailColor[2], alpha * 0.5)),
@@ -661,7 +664,7 @@ class HundredPercentComponent {
 
     // Add "COMPLETE" below the big "100%"
     for (let i = 0; i < text.length; i++) {
-      lines.push(text[i]);
+      lines.push(text[i]!);
     }
     lines.push('');
     const completeLine = `${completeColor}     C O M P L E T E${reset}`;

--- a/packages/mg/index.ts
+++ b/packages/mg/index.ts
@@ -12,9 +12,9 @@
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { matchesKey } from '@earendil-works/pi-tui';
 import type { ChildProcess } from 'node:child_process';
-import type { RGB } from './sprite.ts';
-import { getSpriteGrid, stampFlyer, stampWalker, MG_TRANSPARENT, MG_PALETTE } from './sprite.ts';
-import { playTone, playNoise, playFanfare, playWhoosh, playClick, speak, killProc } from './sound.ts';
+import type { RGB } from './sprite.js';
+import { getSpriteGrid, stampFlyer, stampWalker, MG_TRANSPARENT, MG_PALETTE } from './sprite.js';
+import { playTone, playNoise, playFanfare, playWhoosh, playClick, speak, killProc } from './sound.js';
 
 // === Constants ===
 

--- a/packages/mg/package.json
+++ b/packages/mg/package.json
@@ -15,13 +15,17 @@
     "directory": "packages/mg"
   },
   "files": [
+    "dist",
     "index.ts",
     "sound.ts",
     "sprite.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/packages/mg/sound.ts
+++ b/packages/mg/sound.ts
@@ -28,7 +28,7 @@ function generateWav(samples: Float32Array): Buffer {
   buf.write('data', 36);
   buf.writeUInt32LE(dataLen, 40);
   for (let i = 0; i < samples.length; i++) {
-    const v = Math.max(-1, Math.min(1, samples[i]));
+    const v = Math.max(-1, Math.min(1, samples[i]!));
     buf.writeInt16LE(Math.floor(v * 32767), 44 + i * 2);
   }
   return buf;
@@ -86,7 +86,7 @@ export function playFanfare(): ChildProcess | null {
   const samples = new Float32Array(n);
   const noteLen = Math.floor((noteMs / 1000) * SAMPLE_RATE);
   for (let ni = 0; ni < notes.length; ni++) {
-    const freq = notes[ni];
+    const freq = notes[ni]!;
     const offset = ni * noteLen;
     for (let i = 0; i < noteLen && offset + i < n; i++) {
       const t = i / SAMPLE_RATE;

--- a/packages/mg/sprite.ts
+++ b/packages/mg/sprite.ts
@@ -106,13 +106,13 @@ export function getSpriteGrid(mouthOpen: boolean): string[] {
 /** Stamp the sprite onto an RGB background grid at position (ox, oy) */
 export function stampSprite(bg: RGB[][], grid: string[], ox: number, oy: number): void {
   for (let y = 0; y < grid.length; y++) {
-    for (let x = 0; x < grid[y].length; x++) {
-      const idx = decodeChar(grid[y][x]);
+    for (let x = 0; x < grid[y]!.length; x++) {
+      const idx = decodeChar(grid[y]![x]!);
       if (MG_TRANSPARENT.has(idx)) continue;
       const bx = ox + x;
       const by = oy + y;
-      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-        bg[by][bx] = MG_PALETTE[idx];
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+        bg[by]![bx] = MG_PALETTE[idx]!;
       }
     }
   }
@@ -186,8 +186,8 @@ const WALK_FRAMES = [WALK_FRAME1, WALK_FRAME2, WALK_FRAME3, WALK_FRAME2];
 
 /** Draw the walking figure at position (px, py) with given scale and frame */
 export function stampWalker(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
-  const sprite = WALK_FRAMES[frame % WALK_FRAMES.length];
-  const spriteW = sprite[0].length;
+  const sprite = WALK_FRAMES[frame % WALK_FRAMES.length]!;
+  const spriteW = sprite[0]!.length;
   const spriteH = sprite.length;
 
   for (let y = 0; y < spriteH; y++) {
@@ -204,8 +204,8 @@ export function stampWalker(bg: RGB[][], px: number, py: number, scale: number, 
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = FLY_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = FLY_PALETTE[idx]!;
           }
         }
       }
@@ -284,8 +284,8 @@ const FLY_FRAMES = [FLY_FRAME1, FLY_FRAME2, FLY_FRAME3, FLY_FRAME1];
 /** Draw the flying figure at position (px, py) with given scale and frame.
  *  Uses the actual MG face sprite scaled down so Michael is recognizable as he flies. */
 export function stampFlyer(bg: RGB[][], px: number, py: number, scale: number, frame: number): void {
-  const sprite = FLY_FRAMES[frame % FLY_FRAMES.length];
-  const spriteW = sprite[0].length;
+  const sprite = FLY_FRAMES[frame % FLY_FRAMES.length]!;
+  const spriteW = sprite[0]!.length;
   const spriteH = sprite.length;
 
   for (let y = 0; y < spriteH; y++) {
@@ -302,8 +302,8 @@ export function stampFlyer(bg: RGB[][], px: number, py: number, scale: number, f
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = FLY_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = FLY_PALETTE[idx]!;
           }
         }
       }
@@ -334,8 +334,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
     const rx = px + offsetX + Math.floor(SPRITE_W * scale) + i;
     for (let dy = 0; dy < Math.max(1, Math.floor(2 * scale)); dy++) {
       if (armY + dy >= 0 && armY + dy < bg.length) {
-        if (lx >= 0 && lx < bg[0].length) bg[armY + dy][lx] = coatColor;
-        if (rx >= 0 && rx < bg[0].length) bg[armY + dy][rx] = coatColor;
+        if (lx >= 0 && lx < bg[0]!.length) bg[armY + dy]![lx] = coatColor;
+        if (rx >= 0 && rx < bg[0]!.length) bg[armY + dy]![rx] = coatColor;
       }
     }
   }
@@ -343,7 +343,7 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
   // Draw the face sprite scaled
   for (let y = 0; y < SPRITE_H; y++) {
     for (let x = 0; x < SPRITE_W; x++) {
-      const ch = grid[y][x];
+      const ch = grid[y]![x];
       if (!ch) continue;
       const idx = decodeChar(ch);
       if (MG_TRANSPARENT.has(idx)) continue;
@@ -354,8 +354,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
         for (let dx = 0; dx < sw; dx++) {
           const bx = sx + dx;
           const by = sy + dy;
-          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-            bg[by][bx] = MG_PALETTE[idx];
+          if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+            bg[by]![bx] = MG_PALETTE[idx]!;
           }
         }
       }
@@ -370,8 +370,8 @@ export function stampFlyingMG(bg: RGB[][], px: number, py: number, scale: number
     for (let dx = 0; dx < coatW; dx++) {
       const bx = coatStartX + dx;
       const by = coatY + dy;
-      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0].length) {
-        bg[by][bx] = coatColor;
+      if (by >= 0 && by < bg.length && bx >= 0 && bx < bg[0]!.length) {
+        bg[by]![bx] = coatColor;
       }
     }
   }

--- a/packages/orchestrate/package.json
+++ b/packages/orchestrate/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/orchestrate"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/pin-last-prompt/package.json
+++ b/packages/pin-last-prompt/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/pin-last-prompt"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -126,8 +126,10 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
     },
     {
       apiKey: auth.apiKey,
-      headers: auth.headers,
-      env: auth.env,
+      // Spread conditionally: optional in ProviderStreamOptions, and
+      // exactOptionalPropertyTypes rejects an explicit undefined.
+      ...(auth.headers !== undefined && { headers: auth.headers }),
+      ...(auth.env !== undefined && { env: auth.env }),
       reasoningEffort: 'low',
       cacheRetention: 'none',
       sessionId: uuidv7(),

--- a/packages/recap/package.json
+++ b/packages/recap/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/recap"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/packages/save-md/package.json
+++ b/packages/save-md/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/save-md"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/packages/session-name/index.ts
+++ b/packages/session-name/index.ts
@@ -295,7 +295,7 @@ export default function sessionNameExtension(pi: ExtensionAPI): void {
         .trim();
       if (!raw) return null;
       let title = raw
-        .split(/\n/)[0]
+        .split(/\n/)[0]!
         .trim()
         .replace(/^["'`]+|["'`]+$/g, '')
         .replace(/[.!?]+$/, '')
@@ -408,7 +408,8 @@ export default function sessionNameExtension(pi: ExtensionAPI): void {
 
       const idx = lines.indexOf(choice);
       if (idx < 0) return;
-      const target = list[idx];
+      // lines is mapped 1:1 from list, so a valid index into one indexes the other.
+      const target = list[idx]!;
 
       const result = await ctx.switchSession(target.path, {
         withSession: async (rctx) => {

--- a/packages/session-name/package.json
+++ b/packages/session-name/package.json
@@ -15,12 +15,16 @@
     "directory": "packages/session-name"
   },
   "files": [
+    "dist",
     "index.ts",
     "session-name.example.json"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,7 @@
     "directory": "packages/shared"
   },
   "files": [
+    "dist",
     "index.ts",
     "llm.ts",
     "tui-utils.ts",
@@ -22,7 +23,10 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/packages/spinner/index.ts
+++ b/packages/spinner/index.ts
@@ -1140,7 +1140,8 @@ const VERBS = [
 ];
 
 function randomVerb(): string {
-  return VERBS[Math.floor(Math.random() * VERBS.length)];
+  // VERBS is a non-empty literal array and the index is always in range.
+  return VERBS[Math.floor(Math.random() * VERBS.length)]!;
 }
 
 export default function (pi: ExtensionAPI) {

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/spinner"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/stash/package.json
+++ b/packages/stash/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/stash"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*"

--- a/packages/statusline/package.json
+++ b/packages/statusline/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/statusline"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "dependencies": {
     "@nicknisi/pi-shared": "workspace:*"

--- a/packages/turn-timer/package.json
+++ b/packages/turn-timer/package.json
@@ -15,11 +15,15 @@
     "directory": "packages/turn-timer"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
-    ".": "./index.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,162 @@
+/**
+ * Compile every workspace package to `packages/<name>/dist/`.
+ *
+ * Why this exists: pi loads extensions through jiti, which transpiles
+ * TypeScript on the fly, so these packages work fine shipping raw `.ts`.
+ * Node itself does not — it refuses to strip types inside `node_modules`
+ * (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`). So any consumer that is
+ * *not* pi — a tsc-built CLI, a bundler, anything importing the package
+ * directly — crashes on the raw sources. Publishing compiled JS alongside
+ * them fixes that without taking anything away: `exports` points at
+ * `dist/`, while the `pi` manifest still points at `index.ts` so local
+ * path installs (`pi install ../pi-extensions/packages/foo`) keep working
+ * with no build step.
+ *
+ * Implementation note: compiler options live in exactly one place, the root
+ * tsconfig.json. This writes a throwaway config *inside* each package that
+ * extends it and flips on emit. It has to live in the package dir rather
+ * than a temp dir — `types`, `extends`, and `include` all resolve relative
+ * to the config file, and a config in /tmp cannot find @types/node.
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const packagesDir = join(root, 'packages');
+const TSGO = join(root, 'node_modules', '.bin', 'tsgo');
+
+/** Throwaway per-package build config. Git-ignored; removed in `finally`. */
+const CONFIG_NAME = '.tsconfig.build.json';
+
+const BUILD_CONFIG = {
+  extends: '../../tsconfig.json',
+  compilerOptions: {
+    noEmit: false,
+    declaration: true,
+    rootDir: '.',
+    outDir: './dist',
+    // Drop the root's intra-repo source mapping. It exists so the no-emit
+    // typecheck works on a fresh clone, but during emit it would pull a
+    // dependency's sources into this program and violate rootDir. Here we
+    // want the real thing: resolve siblings through their published
+    // `exports`, which also proves their declaration emit is usable.
+    paths: {},
+  },
+  // Every package is flat, so a non-recursive glob is enough — and it keeps
+  // `dist/` (and its .d.ts files) out of the input set on rebuilds.
+  include: ['./*.ts'],
+  exclude: ['./dist'],
+};
+
+/** Package dir name -> npm name, for every workspace package. */
+function workspacePackages(): Map<string, string> {
+  const entries = readdirSync(packagesDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(packagesDir, e.name, 'package.json')))
+    .map((e) => e.name)
+    .sort();
+  return new Map(
+    entries.map((dir) => {
+      const pkg = JSON.parse(readFileSync(join(packagesDir, dir, 'package.json'), 'utf-8')) as { name: string };
+      return [dir, pkg.name];
+    }),
+  );
+}
+
+/**
+ * Dependency-first build order. Siblings resolve through `exports` to
+ * `dist/index.d.ts`, so a package's workspace dependencies must already be
+ * emitted before it compiles.
+ */
+function buildOrder(packages: Map<string, string>): string[] {
+  const dirByName = new Map([...packages].map(([dir, name]) => [name, dir]));
+  const ordered: string[] = [];
+  const state = new Map<string, 'visiting' | 'done'>();
+
+  const visit = (dir: string): void => {
+    const status = state.get(dir);
+    if (status === 'done') return;
+    if (status === 'visiting') throw new Error(`dependency cycle at packages/${dir}`);
+    state.set(dir, 'visiting');
+
+    const pkg = JSON.parse(readFileSync(join(packagesDir, dir, 'package.json'), 'utf-8')) as {
+      dependencies?: Record<string, string>;
+    };
+    for (const dep of Object.keys(pkg.dependencies ?? {})) {
+      const depDir = dirByName.get(dep);
+      if (depDir !== undefined) visit(depDir);
+    }
+
+    state.set(dir, 'done');
+    ordered.push(dir);
+  };
+
+  for (const dir of packages.keys()) visit(dir);
+  return ordered;
+}
+
+function build(name: string): boolean {
+  const dir = join(packagesDir, name);
+  const configPath = join(dir, CONFIG_NAME);
+
+  rmSync(join(dir, 'dist'), { recursive: true, force: true });
+  writeFileSync(configPath, `${JSON.stringify(BUILD_CONFIG, null, 2)}\n`);
+  try {
+    const result = spawnSync(TSGO, ['-p', configPath], { cwd: dir, stdio: 'inherit' });
+    return result.status === 0;
+  } finally {
+    rmSync(configPath, { force: true });
+  }
+}
+
+/**
+ * Guard the contract the whole build rests on: `exports` must point into
+ * `dist/`, `files` must ship it, and the `pi` manifest must keep pointing at
+ * the sources so local path installs need no build.
+ */
+function verify(name: string): string[] {
+  const dir = join(packagesDir, name);
+  const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf-8')) as {
+    exports?: unknown;
+    files?: unknown;
+    pi?: { extensions?: unknown };
+  };
+  const problems: string[] = [];
+
+  const entry = (pkg.exports as { '.'?: { default?: string } })?.['.']?.default;
+  if (entry === undefined) {
+    problems.push('exports["."].default is missing');
+  } else if (!existsSync(join(dir, entry))) {
+    problems.push(`exports entry ${entry} was not emitted`);
+  }
+
+  if (!Array.isArray(pkg.files) || !pkg.files.includes('dist')) {
+    problems.push('files is missing "dist"');
+  }
+
+  const piExtensions = pkg.pi?.extensions;
+  if (Array.isArray(piExtensions) && piExtensions.some((p) => String(p).startsWith('./dist/'))) {
+    problems.push('pi.extensions points at dist/ — it must stay on the sources');
+  }
+
+  return problems;
+}
+
+const names = buildOrder(workspacePackages());
+const failed: string[] = [];
+
+for (const name of names) {
+  if (!build(name)) {
+    failed.push(`${name}: compile failed`);
+    continue;
+  }
+  for (const problem of verify(name)) failed.push(`${name}: ${problem}`);
+}
+
+if (failed.length > 0) {
+  console.error(`\nBuild failed:\n${failed.map((f) => `  - ${f}`).join('\n')}`);
+  process.exit(1);
+}
+
+console.log(`Built ${names.length} packages.`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,10 +10,15 @@
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "noEmit": true,
-    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    // Intra-repo imports resolve to source, not to emitted output. Without
+    // this, `exports` pointing at ./dist/index.d.ts would make both the
+    // typecheck and the build depend on a prior build of pi-shared.
+    "paths": {
+      "@nicknisi/pi-shared": ["./packages/shared/index.ts"]
+    }
   },
   "include": ["packages/**/*.ts"],
   "exclude": ["**/node_modules"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "lib": ["es2022"],
     "types": ["node"],
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
Unblocks arc adopting these packages, and fixes a portability bug they all share.

## The problem

pi loads extensions through jiti (`createJiti` + `jiti.import` in pi's `core/extensions/loader.js`), which transpiles TypeScript on the fly. That is why shipping raw `index.ts` has always worked — and it will keep working.

Node is a different story. It refuses to strip types inside `node_modules`:

```
Error [ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING]:
Stripping types is currently unsupported for files under node_modules
```

So any consumer that is *not* pi — a tsc-built CLI, a bundler, anything importing the package directly — crashes at runtime. Concretely, this is what stops [arc](https://github.com/workos/arc) from replacing its vendored forks with these packages: inline-importing them breaks arc's `dist/` under node, and loading them as pi packages yields nothing in arc's compiled binary.

## The fix

Each package publishes its sources **and** compiled JS, aimed at different consumers:

| Field | Points at | Used by |
|---|---|---|
| `pi.extensions` | `./index.ts` | pi, via jiti |
| `exports` | `./dist/index.js` + `./dist/index.d.ts` | everyone else |

Keeping `pi.extensions` on the sources means local path installs (`pi install ../pi-extensions/packages/statusline`) still need no build step — the rapid-testing loop is untouched.

## What's here

- **`scripts/build.ts`** — compiles each package with tsgo. Compiler options stay in exactly one place: it writes a throwaway config per package that extends the root `tsconfig.json` and flips on emit. The config has to live in the package dir, not `/tmp`, because `extends`, `types`, and `include` all resolve relative to the config file.
- **Dependency-ordered builds** — siblings now resolve through `exports` into emitted output, so `pi-shared` must be built before its six dependents.
- **`paths` in the root tsconfig** maps `@nicknisi/pi-shared` to its source, so a fresh clone typechecks without building first. The build turns that *off* (`paths: {}`) and resolves through real `exports` instead — which is what proves the declaration output is actually usable, rather than just re-checking sources.
- **`allowImportingTsExtensions` removed** — emit forbids it. `header` and `mg` were the only two packages using `.ts` relative imports; they now use `.js` like the other 20. Leaving the flag off means the typecheck catches any regression.
- **Root `prepare` hook.** Load-bearing, not a nicety: `dist/` is git-ignored, and six packages resolve `@nicknisi/pi-shared` into it, so a fresh clone with no build would fail to load them in pi. Verified it fires on a real install (~10s) — note it is skipped on a no-op install, so a hand-deleted `dist/` needs `pnpm build`.
- **CI** builds after typecheck; **release** publishes via `pnpm run release` so `dist/` exists before `changeset publish`.

## Verification

| check | result |
|---|---|
| `pnpm format:check` / `lint` / `typecheck` | pass |
| `pnpm build` from a clean tree | 22/22 packages |
| `pnpm typecheck` with no `dist/` present (fresh clone) | pass |
| Node ESM import of a package from `node_modules` | **works** — was `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` |
| tsc type resolution for a consumer | resolves via `dist/index.d.ts` |
| jiti load of `pi.extensions` entry (statusline, header, mg, artifacts, llm-council, chat-input) | all load, including `header`/`mg` after the `.ts` → `.js` change |
| `npm pack` contents | ships both `dist/` and sources |

Patch bump for all 22 packages.
