### PR TITLE
fix: contain llm-council resource names and honor the real agent dir

### DIFF
--- a/.changeset/agent-dir-config-paths.md
+++ b/.changeset/agent-dir-config-paths.md
@@ -1,0 +1,13 @@
+---
+'@nicknisi/pi-session-name': patch
+'@nicknisi/pi-recap': patch
+---
+
+Read config from the real agent dir instead of a hardcoded `~/.pi/agent`.
+
+Both packages built their config path from `os.homedir()`, so anyone running a
+non-default agent dir (`PI_CODING_AGENT_DIR`, or a harness that sets it) had
+their config silently ignored — and in recap's case, writes landed in the wrong
+place too. They now use `getAgentDir()`, like the other packages. recap also
+resolves the path per call, so a config it just wrote is visible to the next
+read.

--- a/.changeset/llm-council-containment.md
+++ b/.changeset/llm-council-containment.md
@@ -1,0 +1,18 @@
+---
+'@nicknisi/pi-llm-council': patch
+---
+
+Security: contain council `extensions`/`skills` names to the agent dir.
+
+Council `extensions` and `skills` entries are bare resource names resolved
+under the user's own agent dir, but they can be supplied by
+`<cwd>/.pi/configs/llm-council.json` — untrusted repository input.
+`buildExecArgs()` passed them straight through `path.join`, so a crafted name
+such as `../../../proc/self/cwd/.pi/payload` collapsed into an arbitrary
+filesystem path handed to pi as `-e`/`--skill`, loading repo-controlled code
+outside pi's project-trust gate. Opening a council in a hostile repository was
+enough to trigger it.
+
+Names must now be contained bare names — no path separators, no `..` — and the
+resolved path is verified to stay under the agent dir. Anything else is skipped
+with a diagnostic. Legitimate names are unaffected.

--- a/packages/llm-council/index.ts
+++ b/packages/llm-council/index.ts
@@ -280,6 +280,22 @@ interface ExecConfig {
 
 // ── Subprocess ───────────────────────────────────────────────────────────
 
+// Council `extensions`/`skills` entries are bare resource names resolved under
+// the user's own agent dir. Project-local config (<cwd>/.pi/configs/llm-council.json)
+// is untrusted repository input, so a name must never contain path separators or
+// `..` segments: otherwise `path.join` collapses a crafted name into an arbitrary
+// filesystem path passed to pi as `-e`/`--skill`, loading repo-controlled code
+// outside pi's project-trust gate. Reject anything that isn't a contained bare name.
+function resolveContainedResourcePath(kind: 'extensions' | 'skills', name: string, leaf: string): string | null {
+  if (typeof name !== 'string' || name.length === 0) return null;
+  if (name.includes('/') || name.includes('\\') || name === '..' || name === '.') return null;
+  const baseDir = path.join(getAgentDir(), kind);
+  const resolved = path.resolve(baseDir, name, leaf);
+  const containmentRoot = path.resolve(baseDir) + path.sep;
+  if (!resolved.startsWith(containmentRoot)) return null;
+  return resolved;
+}
+
 function buildExecArgs(exec: ExecConfig): string[] {
   const args: string[] = [];
 
@@ -303,7 +319,14 @@ function buildExecArgs(exec: ExecConfig): string[] {
   } else {
     args.push('--no-extensions');
     for (const name of exec.extensions) {
-      args.push('-e', path.join(getAgentDir(), 'extensions', name, 'src', 'index.ts'));
+      const extPath = resolveContainedResourcePath('extensions', name, path.join('src', 'index.ts'));
+      if (extPath === null) {
+        console.error(
+          `[llm-council] ignoring extension ${JSON.stringify(name)}: names must be bare (no path separators or "..")`,
+        );
+        continue;
+      }
+      args.push('-e', extPath);
     }
   }
 
@@ -315,7 +338,14 @@ function buildExecArgs(exec: ExecConfig): string[] {
   } else {
     args.push('--no-skills');
     for (const name of exec.skills) {
-      args.push('--skill', path.join(getAgentDir(), 'skills', name, 'SKILL.md'));
+      const skillPath = resolveContainedResourcePath('skills', name, 'SKILL.md');
+      if (skillPath === null) {
+        console.error(
+          `[llm-council] ignoring skill ${JSON.stringify(name)}: names must be bare (no path separators or "..")`,
+        );
+        continue;
+      }
+      args.push('--skill', skillPath);
     }
   }
 

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -1,9 +1,8 @@
 import { uuidv7 } from '@earendil-works/pi-ai';
 import { complete, getModel } from '@earendil-works/pi-ai/compat';
-import { getMarkdownTheme, type ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { getAgentDir, getMarkdownTheme, type ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Box, Markdown, Text } from '@earendil-works/pi-tui';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 
 // Auto-recap: after N idle minutes, inject a dimmed recap card into the transcript.
@@ -11,7 +10,13 @@ import * as path from 'node:path';
 type Config = { idleMinutes: number; model?: { provider: string; id: string } };
 
 const DEFAULT_CONFIG: Config = { idleMinutes: 3 };
-const CONFIG_PATH = path.join(os.homedir(), '.pi', 'agent', 'configs', 'recap.json');
+// Resolved per call, not at module load: `getAgentDir()` honours the agent-dir
+// env var, so hardcoding ~/.pi/agent would read (and write) the wrong file for
+// anyone running a non-default agent dir. Per-call also means a config written
+// by `saveConfig` is visible to the next read.
+function configPath(): string {
+  return path.join(getAgentDir(), 'configs', 'recap.json');
+}
 const ENTRY_TYPE = 'recap';
 const TICK_MS = 30_000;
 const MIN_BRANCH_LEN = 4;
@@ -24,7 +29,7 @@ let piRef: ExtensionAPI | null = null;
 
 function readConfig(): Config {
   try {
-    const parsed = JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    const parsed = JSON.parse(fs.readFileSync(configPath(), 'utf8'));
     return {
       idleMinutes: typeof parsed.idleMinutes === 'number' ? parsed.idleMinutes : DEFAULT_CONFIG.idleMinutes,
       model: parsed.model && typeof parsed.model === 'object' ? parsed.model : undefined,
@@ -35,8 +40,8 @@ function readConfig(): Config {
 }
 
 function writeConfig(c: Config) {
-  fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(c, null, 2));
+  fs.mkdirSync(path.dirname(configPath()), { recursive: true });
+  fs.writeFileSync(configPath(), JSON.stringify(c, null, 2));
 }
 
 type Entry = { type: string; message?: { role?: string; content?: unknown } };

--- a/packages/session-name/index.ts
+++ b/packages/session-name/index.ts
@@ -40,6 +40,7 @@
 import type { Message } from '@earendil-works/pi-ai';
 import { getModelProvider } from '@nicknisi/pi-shared';
 import {
+  getAgentDir,
   SessionManager,
   type ExtensionAPI,
   type ExtensionContext,
@@ -47,7 +48,6 @@ import {
   type SessionInfo,
 } from '@earendil-works/pi-coding-agent';
 import { readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
 // ── Config ────────────────────────────────────────────────────────────────
@@ -81,7 +81,9 @@ const DEFAULT_CONFIG: SessionNameConfig = {
 
 function loadConfig(): SessionNameConfig {
   try {
-    const path = join(homedir(), '.pi', 'agent', 'configs', 'session-name.json');
+    // `getAgentDir()`, not a hardcoded ~/.pi/agent: the agent dir is
+    // configurable, and reading the wrong one silently ignores the user's config.
+    const path = join(getAgentDir(), 'configs', 'session-name.json');
     const raw = readFileSync(path, 'utf8');
     const parsed = JSON.parse(raw) as Partial<SessionNameConfig>;
     return { ...DEFAULT_CONFIG, ...parsed };


### PR DESCRIPTION
Three fixes, all surfaced while checking whether [arc](https://github.com/workos/arc) can drop its vendored forks in favour of these packages. The first is a security fix and is the reason this PR is separate from the arc work.

## 1. llm-council: path traversal → RCE (security)

Council `extensions` and `skills` entries are bare resource names resolved under the user's own agent dir. But `loadCouncil()` lets `<cwd>/.pi/configs/llm-council.json` — untrusted repository input — supply them:

```ts
extensions: pm?.extensions ?? CONFIG.member.extensions,
skills:     pm?.skills     ?? CONFIG.member.skills,
```

and `buildExecArgs()` passed them straight through:

```ts
args.push('-e', path.join(getAgentDir(), 'extensions', name, 'src', 'index.ts'));
```

A crafted name such as `../../../proc/self/cwd/.pi/payload` collapses into an arbitrary filesystem path handed to pi as `-e`/`--skill`, loading repo-controlled code **outside pi's project-trust gate**. Cloning a hostile repo and opening a council is enough to trigger it.

Names must now be contained bare names — no path separators, no `..` — with the resolved path verified to stay under the agent dir. Anything else is skipped with a diagnostic; legitimate names are unaffected.

This was patched in arc as VULN-3080 (arc `7803810`) on the same day PR #2 landed, which is how it slipped past — PR #2 was merged just before the fix existed. Shipped in `@nicknisi/pi-llm-council` 0.1.0 → 0.1.2.

**Worth considering separately:** the affected versions are public on npm, so a GHSA may be warranted. Your call — I have not filed anything.

## 2 & 3. recap and session-name ignored the configured agent dir

Both built their config path from `os.homedir()`:

```ts
path.join(os.homedir(), '.pi', 'agent', 'configs', 'recap.json')
join(homedir(), '.pi', 'agent', 'configs', 'session-name.json')
```

So anyone running a non-default agent dir — `PI_CODING_AGENT_DIR`, or a harness that sets it — had their config silently ignored, and recap's writes landed in the wrong place. Both now use `getAgentDir()` like the rest of the packages. recap resolves per call, so a config it just wrote is visible to the next read.

## Verification

Ran against the **compiled `dist/` output**, not the sources, since that is what consumers now load.

Containment, with `PI_CODING_AGENT_DIR=/tmp/vulnprobe/agent`:

```
-- hostile extension names --
  "../../../proc/self/cwd/.pi/payload"     blocked
  ".."                                     blocked
  "/etc/passwd"                            blocked
  "a/../../../evil"                        blocked
  "..\\..\\evil"                           blocked
  ""                                       blocked
-- legitimate names still work --
  /tmp/vulnprobe/agent/extensions/my-ext/src/index.ts
  /tmp/vulnprobe/agent/skills/my-skill/SKILL.md
```

Agent dir, with `PI_CODING_AGENT_DIR=/tmp/fakeagent` and a config planted there:

```
recap config path:       /tmp/fakeagent/configs/recap.json
session-name reads cfg:  99   (99 = read from PI_CODING_AGENT_DIR, 6 = default)
```

Plus `format:check`, `lint`, `typecheck`, and `build` (22/22) all pass.

Patch bump for the three affected packages.
