### PR TITLE
feat(chat-input): add working-state spinner and border glow animations

### DIFF
--- a/.changeset/whimsy-working-animations.md
+++ b/.changeset/whimsy-working-animations.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-chat-input': minor
+---
+
+Add working-state whimsy: the prefix glyph animates as a spinner and the border glows (pulse or shimmer) while pi is thinking, driven by `agent_start`/`agent_settled`. Nine built-in spinner presets (`spinnerStyle`: dots, disc, moon, star, orbit, corners, triangle, scanner, mini-scanner), each with a tuned default interval, plus custom frames via `spinnerFrames`. Fully configurable via `spinner`, `spinnerStyle`, `spinnerFrames`, `spinnerIntervalMs`, `spinnerColor`, `glow`, `glowStyle`, `glowColor`, and `glowPeriodMs` in `chat-input.json`. `spinnerColor` and `glowColor` also accept the special value `"rainbow"`, which hue-rotates once per `rainbowPeriodMs`.

--- a/.changeset/whimsy-working-animations.md
+++ b/.changeset/whimsy-working-animations.md
@@ -3,3 +3,5 @@
 ---
 
 Add working-state whimsy: the prefix glyph animates as a spinner and the border glows (pulse or shimmer) while pi is thinking, driven by `agent_start`/`agent_settled`. Nine built-in spinner presets (`spinnerStyle`: dots, disc, moon, star, orbit, corners, triangle, scanner, mini-scanner), each with a tuned default interval, plus custom frames via `spinnerFrames`. Fully configurable via `spinner`, `spinnerStyle`, `spinnerFrames`, `spinnerIntervalMs`, `spinnerColor`, `glow`, `glowStyle`, `glowColor`, and `glowPeriodMs` in `chat-input.json`. `spinnerColor` and `glowColor` also accept the special value `"rainbow"`, which hue-rotates once per `rainbowPeriodMs`.
+
+The pulse glow anchors on `borderColor` (not the focus-adjusted border), so the default `border`→`accent` pulse is visible out of the box even with `focusIndicator` on. New `/chat-input` command reloads `chat-input.json` in place (no restart) and previews the working animation for ~3 seconds; invalid JSON is now reported at startup (warning) and on reload (error, previous config kept) instead of silently falling back to defaults.

--- a/packages/chat-input/README.md
+++ b/packages/chat-input/README.md
@@ -15,9 +15,10 @@ standalone `paste-expand.ts` so the two features don't fight over
 
 - **Custom editor component** via `ctx.ui.setEditorComponent` (no slash
   commands, no tools, no keybindings, no custom entry types).
-- **Events hooked**: `session_start` (installs the editor component) and
-  `session_shutdown` (removes it and tears down focus tracking). TUI mode
-  only; both handlers no-op when `ctx.mode !== "tui"`.
+- **Events hooked**: `session_start` (installs the editor component),
+  `agent_start` / `agent_settled` (drive the working-state animations), and
+  `session_shutdown` (removes it and tears down focus tracking and animation
+  timers). TUI mode only; all handlers no-op when `ctx.mode !== "tui"`.
 - **Paste-again-to-expand**: overrides the editor's `handlePaste` to detect
   when an incoming paste matches an already-collapsed paste's stored content;
   if the marker `[paste #N ...]` is still in the buffer, the marker is replaced
@@ -33,6 +34,8 @@ standalone `paste-expand.ts` so the two features don't fight over
 - **Scroll indicators**: pi's stock `↑ N more` / `↓ N more` indicators are detected in the stock borders and re-embedded in the replacement borders
 - **Responsive**: below a minimum width (see caveats) the extension defers to pi's stock editor rendering
 - **Focus indicator**: border switches colour when the tmux pane holding this session has terminal focus (requires tmux `focus-events on`)
+- **Spinner prefix**: while pi is working, the prefix glyph animates as a spinner — pick from built-in presets or define your own frames (configurable speed and colour, including `"rainbow"`)
+- **Border glow**: while pi is working, the border either _pulses_ (breathes between the border colour and a glow colour) or _shimmers_ (a highlight sweeps along the top/bottom rules)
 
 ## Install
 
@@ -82,7 +85,14 @@ Missing file or invalid JSON falls back to all defaults silently. Copy
   "prefixColor": "accent",
   "corners": "rounded",
   "focusIndicator": true,
-  "focusedBorderColor": "accent"
+  "focusedBorderColor": "accent",
+  "spinner": true,
+  "spinnerStyle": "dots",
+  "spinnerColor": "accent",
+  "glow": true,
+  "glowStyle": "pulse",
+  "glowColor": "accent",
+  "glowPeriodMs": 2000
 }
 ```
 
@@ -98,6 +108,43 @@ Missing file or invalid JSON falls back to all defaults silently. Copy
 | `corners`            | `"rounded" \| "square"` | `"rounded"` | `rounded` = `╭╮│╰╯`, `square` = `┌┐│└┘`. Any other value falls back to `rounded`.                                        |
 | `focusIndicator`     | `boolean`               | `true`      | Track terminal focus (DECSET 1004) and restyle the border when this pane is focused. Requires `focus-events on` in tmux. |
 | `focusedBorderColor` | `string`                | `"accent"`  | Border colour while the pane is focused; `borderColor` is used when unfocused.                                           |
+| `spinner`            | `boolean`               | `true`      | Animate the prefix as a spinner while pi is working (between `agent_start` and `agent_settled`).                         |
+| `spinnerStyle`       | `string`                | `"dots"`    | Built-in spinner preset — see [Spinner presets](#spinner-presets). Unknown names fall back to `dots`.                    |
+| `spinnerFrames`      | `string[]`              | —           | Custom spinner frames; overrides `spinnerStyle`. Any cell width — the prefix slot is sized to the widest frame.          |
+| `spinnerIntervalMs`  | `number`                | per preset  | Milliseconds per spinner frame. Defaults to the active preset's tuned interval.                                          |
+| `spinnerColor`       | `string`                | `"accent"`  | Theme colour token, hex colour, or `"rainbow"` (hue rotates while spinning).                                             |
+| `glow`               | `boolean`               | `true`      | Animate the border while pi is working.                                                                                  |
+| `glowStyle`          | `"pulse" \| "shimmer"`  | `"pulse"`   | `pulse` breathes the whole border toward `glowColor`; `shimmer` sweeps a highlight along the top/bottom rules.           |
+| `glowColor`          | `string`                | `"accent"`  | Theme colour token, hex colour, or `"rainbow"` the glow animates toward.                                                 |
+| `glowPeriodMs`       | `number`                | `2000`      | Milliseconds per glow cycle (one full pulse breath or one shimmer sweep).                                                |
+| `rainbowPeriodMs`    | `number`                | `1200`      | Milliseconds per full hue rotation when a colour is set to `"rainbow"`.                                                  |
+
+### Spinner presets
+
+Each preset has a tuned default interval; set `spinnerIntervalMs` to override.
+
+| Preset         | Frames                       | Interval | Notes                                                                                              |
+| -------------- | ---------------------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `dots`         | `⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏`        | 80ms     | Classic braille dots (default).                                                                    |
+| `disc`         | `⣾ ⣽ ⣻ ⢿ ⡿ ⣟ ⣯ ⣷`            | 90ms     | Dense braille disc with an orbiting gap.                                                           |
+| `moon`         | `🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘`    | 90ms     | Moon phases. Emoji — widens the prefix slot to 2 cells.                                            |
+| `star`         | `✶ ✸ ✹ ✺ ✹ ✸`                | 90ms     | Twinkling star — flares and dims.                                                                  |
+| `orbit`        | `◜ ◠ ◝ ◞ ◡ ◟`                | 80ms     | A dot orbiting a circle.                                                                           |
+| `corners`      | `▖ ▘ ▝ ▗`                    | 120ms    | A quarter-block bouncing around the cell's corners.                                                |
+| `triangle`     | `◢ ◣ ◤ ◥`                    | 120ms    | A spinning filled triangle.                                                                        |
+| `scanner`      | `●····· … ·····● …` (bounce) | 60ms     | KITT scanner — comet with a fading tail. **6 cells wide**, so the idle prefix slot is 6 cells too. |
+| `mini-scanner` | `●·· ·●· ··● ·●·`            | 120ms    | Scanner's little sibling — 3 cells, no tail.                                                       |
+
+Define your own with `spinnerFrames` (any array of non-empty strings; it takes
+precedence over `spinnerStyle`):
+
+```json
+{ "spinnerFrames": ["◐", "◓", "◑", "◒"], "spinnerIntervalMs": 100 }
+```
+
+The prefix slot is sized to the widest frame of the active spinner (idle `❯`
+included), so wide frames permanently indent the input — the layout never
+shifts when the agent starts or stops.
 
 ### Colour tokens
 
@@ -107,6 +154,16 @@ Any valid theme colour token works. See your active theme in
 `customMessageLabel`, …). Hex values must be 6-digit `#rrggbb`; invalid values
 fall back to the uncoloured text. Hex takes precedence over theme tokens in
 `applyColor`.
+
+`spinnerColor` and `glowColor` additionally accept `"rainbow"`: a truecolor
+hue rotation completing one full spectrum lap per `rainbowPeriodMs`. A rainbow
+`glowColor` makes the pulse breathe toward a continuously rotating hue (and
+the shimmer highlight cycle colours).
+
+> **Tip — pulse looks invisible?** With `focusIndicator` on (the default), the
+> focused border colour is `accent`; a `glowColor` of `"accent"` then pulses
+> accent→accent, which is a no-op. Pick a `glowColor` that differs from the
+> resting border colour, or set `focusedBorderColor` to `"border"`.
 
 No environment variables are used.
 
@@ -155,3 +212,12 @@ No npm runtime dependencies; `node:fs` / `node:os` / `node:path` only.
   wrong types).
 - **setEditorComponent conflicts**: any other extension calling
   `setEditorComponent` after this one will replace the editor (last call wins).
+- **Pulse needs truecolor**: the pulse glow interpolates RGB between the
+  resting border colour and `glowColor`. Both endpoints must resolve to RGB —
+  hex values always do; theme tokens only if the theme emits truecolor
+  (`38;2;r;g;b`) sequences. If either endpoint can't be resolved, the border
+  falls back to a steady `glowColor` while working. Shimmer has no such
+  requirement.
+- **Animation cost**: while pi is working, a single timer requests a TUI
+  re-render every `spinnerIntervalMs` (or 80ms for glow-only). Idle sessions
+  have no timer running.

--- a/packages/chat-input/README.md
+++ b/packages/chat-input/README.md
@@ -13,8 +13,10 @@ standalone `paste-expand.ts` so the two features don't fight over
 
 ## What it adds
 
-- **Custom editor component** via `ctx.ui.setEditorComponent` (no slash
-  commands, no tools, no keybindings, no custom entry types).
+- **Custom editor component** via `ctx.ui.setEditorComponent` (no tools, no
+  keybindings, no custom entry types).
+- **`/chat-input` command**: reloads `chat-input.json` without restarting pi
+  and previews the working animation for ~3 seconds.
 - **Events hooked**: `session_start` (installs the editor component),
   `agent_start` / `agent_settled` (drive the working-state animations), and
   `session_shutdown` (removes it and tears down focus tracking and animation
@@ -45,9 +47,10 @@ pi install /path/to/pi-extensions/packages/chat-input
 
 ## Usage
 
-Once installed, there is nothing to invoke — the editor component is installed
-automatically at session start. Editing, history, autocomplete, and paste
-behave as usual inside the box.
+Once installed, the editor component is installed automatically at session
+start. Editing, history, autocomplete, and paste behave as usual inside the
+box. Run `/chat-input` after editing the config to reload it in place and
+preview the spinner/glow without sending a prompt.
 
 Paste-again-to-expand works automatically too: pi collapses large pastes
 (>10 lines or >1000 chars) into `[paste #N +X lines]` markers; paste the same
@@ -68,10 +71,12 @@ Layout (boxed):
 
 ## Configuration
 
-Config is read once at extension load from
-`~/.pi/agent/configs/chat-input.json` — restart pi to apply changes. The path
-follows pi's agent dir, so it moves with `PI_CODING_AGENT_DIR` if you set it.
-Missing file or invalid JSON falls back to all defaults silently. Copy
+Config is read at extension load from
+`~/.pi/agent/configs/chat-input.json`; run `/chat-input` to reload it without
+restarting pi (it also previews the working animation). The path follows pi's
+agent dir, so it moves with `PI_CODING_AGENT_DIR` if you set it. A missing
+file means all defaults; invalid JSON is reported (at startup via a warning,
+on `/chat-input` via an error) and the previous/default config is kept. Copy
 `chat-input.example.json` from this package as a starting point.
 
 ```json
@@ -160,10 +165,11 @@ hue rotation completing one full spectrum lap per `rainbowPeriodMs`. A rainbow
 `glowColor` makes the pulse breathe toward a continuously rotating hue (and
 the shimmer highlight cycle colours).
 
-> **Tip — pulse looks invisible?** With `focusIndicator` on (the default), the
-> focused border colour is `accent`; a `glowColor` of `"accent"` then pulses
-> accent→accent, which is a no-op. Pick a `glowColor` that differs from the
-> resting border colour, or set `focusedBorderColor` to `"border"`.
+The pulse anchors on `borderColor` (not the focus-adjusted border), so the
+default `border`→`accent` pulse is visible even while the pane is focused and
+the resting border is already `accent`. If you set `glowColor` equal to
+`borderColor`, the pulse has nothing to breathe toward and is invisible —
+pick two colours that differ.
 
 No environment variables are used.
 
@@ -206,14 +212,17 @@ No npm runtime dependencies; `node:fs` / `node:os` / `node:path` only.
 - **tmux**: the focus indicator only changes state if tmux has
   `focus-events on` (and the outer terminal passes focus events through).
   Outside tmux it works only if the terminal itself emits CSI I / CSI O.
-- **Config is load-time**: `chat-input.json` is read once at module load; edits
-  require a pi restart. There is no validation or error reporting — bad JSON or
-  wrong types fall back to defaults (or may throw at render time for wildly
-  wrong types).
+- **Config validation is shallow**: bad JSON is reported and numeric/enum
+  fields are range-checked, but wildly wrong types for unchecked string fields
+  (e.g. a number for `prefix`) may throw at render time.
+- **Reload doesn't rebuild the editor**: `/chat-input` mutates the live config
+  that render code reads, which covers every documented key. A key that only
+  takes effect at component construction would need a restart (none currently
+  do).
 - **setEditorComponent conflicts**: any other extension calling
   `setEditorComponent` after this one will replace the editor (last call wins).
-- **Pulse needs truecolor**: the pulse glow interpolates RGB between the
-  resting border colour and `glowColor`. Both endpoints must resolve to RGB —
+- **Pulse needs truecolor**: the pulse glow interpolates RGB between
+  `borderColor` and `glowColor`. Both endpoints must resolve to RGB —
   hex values always do; theme tokens only if the theme emits truecolor
   (`38;2;r;g;b`) sequences. If either endpoint can't be resolved, the border
   falls back to a steady `glowColor` while working. Shimmer has no such

--- a/packages/chat-input/chat-input.example.json
+++ b/packages/chat-input/chat-input.example.json
@@ -9,5 +9,13 @@
   "prefixColor": "accent",
   "corners": "rounded",
   "focusIndicator": true,
-  "focusedBorderColor": "accent"
+  "focusedBorderColor": "accent",
+  "spinner": true,
+  "spinnerStyle": "dots",
+  "spinnerColor": "accent",
+  "glow": true,
+  "glowStyle": "pulse",
+  "glowColor": "accent",
+  "glowPeriodMs": 2000,
+  "rainbowPeriodMs": 1200
 }

--- a/packages/chat-input/config.ts
+++ b/packages/chat-input/config.ts
@@ -25,7 +25,69 @@ export const DEFAULT_CONFIG = {
   FOCUS_INDICATOR: true,
   /** Theme colour token or hex for the border while the pane is focused. */
   FOCUSED_BORDER_COLOR: 'accent',
+  /** Animate the prefix glyph as a spinner while the agent is working. */
+  SPINNER: true,
+  /** Built-in spinner preset (see SPINNERS). Custom spinnerFrames override it. */
+  SPINNER_STYLE: 'dots' as SpinnerStyle,
+  /** Theme colour token, hex, or "rainbow" for the spinner. */
+  SPINNER_COLOR: 'accent',
+  /** Animate the border while the agent is working. */
+  GLOW: true,
+  /** "pulse" breathes the border colour; "shimmer" sweeps a highlight along the rules. */
+  GLOW_STYLE: 'pulse' as 'pulse' | 'shimmer',
+  /** Theme colour token, hex, or "rainbow" the glow animates toward. */
+  GLOW_COLOR: 'accent',
+  /** Milliseconds per glow cycle. */
+  GLOW_PERIOD_MS: 2000,
+  /** Milliseconds per full hue rotation for "rainbow" colours. */
+  RAINBOW_PERIOD_MS: 1200,
 };
+
+/** Built-in spinner presets. Frames may be any cell width — the prefix slot
+ * is sized to the widest frame of the active spinner. Each preset carries a
+ * tuned default interval, overridable with spinnerIntervalMs. */
+export const SPINNERS = {
+  /** Classic braille dots (pi-style). */
+  dots: { frames: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'], intervalMs: 80 },
+  /** Dense braille disc with an orbiting gap. */
+  disc: { frames: ['⣾', '⣽', '⣻', '⢿', '⡿', '⣟', '⣯', '⣷'], intervalMs: 90 },
+  /** Moon phases (emoji, 2 cells wide). */
+  moon: { frames: ['🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘'], intervalMs: 90 },
+  /** Twinkling star — flares and dims rather than spinning. */
+  star: { frames: ['✶', '✸', '✹', '✺', '✹', '✸'], intervalMs: 90 },
+  /** A dot orbiting a circle. */
+  orbit: { frames: ['◜', '◠', '◝', '◞', '◡', '◟'], intervalMs: 80 },
+  /** A quarter-block bouncing around the corners of the cell. */
+  corners: { frames: ['▖', '▘', '▝', '▗'], intervalMs: 120 },
+  /** A spinning filled triangle. */
+  triangle: { frames: ['◢', '◣', '◤', '◥'], intervalMs: 120 },
+  /** KITT scanner — a comet with a fading tail bouncing across 6 cells. */
+  scanner: {
+    frames: [
+      '●·····',
+      '•●····',
+      '·•●···',
+      '··•●··',
+      '···•●·',
+      '····•●',
+      '·····●',
+      '····●•',
+      '···●•·',
+      '··●•··',
+      '·●•···',
+      '●•····',
+    ],
+    intervalMs: 60,
+  },
+  /** Scanner's little sibling — 3 cells, no tail. */
+  'mini-scanner': { frames: ['●··', '·●·', '··●', '·●·'], intervalMs: 120 },
+} as const;
+
+export type SpinnerStyle = keyof typeof SPINNERS;
+
+function isSpinnerStyle(s: unknown): s is SpinnerStyle {
+  return typeof s === 'string' && s in SPINNERS;
+}
 
 interface ChatInputUserConfig {
   boxedView?: boolean;
@@ -38,6 +100,16 @@ interface ChatInputUserConfig {
   corners?: 'rounded' | 'square';
   focusIndicator?: boolean;
   focusedBorderColor?: string;
+  spinner?: boolean;
+  spinnerStyle?: SpinnerStyle;
+  spinnerFrames?: string[];
+  spinnerIntervalMs?: number;
+  spinnerColor?: string;
+  glow?: boolean;
+  glowStyle?: 'pulse' | 'shimmer';
+  glowColor?: string;
+  glowPeriodMs?: number;
+  rainbowPeriodMs?: number;
 }
 
 const CONFIG_PATH = join(getAgentDir(), 'configs', 'chat-input.json');
@@ -52,6 +124,16 @@ function loadUserConfig(): ChatInputUserConfig {
 
 const u = loadUserConfig();
 
+// Spinner resolution: explicit spinnerFrames win, then the named preset,
+// then the default preset. The preset also supplies the default interval.
+const preset = SPINNERS[isSpinnerStyle(u.spinnerStyle) ? u.spinnerStyle : DEFAULT_CONFIG.SPINNER_STYLE];
+const customFrames =
+  Array.isArray(u.spinnerFrames) &&
+  u.spinnerFrames.length > 0 &&
+  u.spinnerFrames.every((f) => typeof f === 'string' && f.length > 0)
+    ? u.spinnerFrames
+    : null;
+
 export const CONFIG = {
   BOXED_VIEW: u.boxedView ?? DEFAULT_CONFIG.BOXED_VIEW,
   BOX_PAD_X: u.boxPadX ?? DEFAULT_CONFIG.BOX_PAD_X,
@@ -63,4 +145,18 @@ export const CONFIG = {
   CORNERS: (u.corners === 'square' ? 'square' : 'rounded') as 'rounded' | 'square',
   FOCUS_INDICATOR: u.focusIndicator ?? DEFAULT_CONFIG.FOCUS_INDICATOR,
   FOCUSED_BORDER_COLOR: u.focusedBorderColor ?? DEFAULT_CONFIG.FOCUSED_BORDER_COLOR,
+  SPINNER: u.spinner ?? DEFAULT_CONFIG.SPINNER,
+  SPINNER_FRAMES: (customFrames ?? preset.frames) as readonly string[],
+  SPINNER_INTERVAL_MS:
+    typeof u.spinnerIntervalMs === 'number' && u.spinnerIntervalMs > 0 ? u.spinnerIntervalMs : preset.intervalMs,
+  SPINNER_COLOR: u.spinnerColor ?? DEFAULT_CONFIG.SPINNER_COLOR,
+  GLOW: u.glow ?? DEFAULT_CONFIG.GLOW,
+  GLOW_STYLE: (u.glowStyle === 'shimmer' ? 'shimmer' : 'pulse') as 'pulse' | 'shimmer',
+  GLOW_COLOR: u.glowColor ?? DEFAULT_CONFIG.GLOW_COLOR,
+  GLOW_PERIOD_MS:
+    typeof u.glowPeriodMs === 'number' && u.glowPeriodMs > 0 ? u.glowPeriodMs : DEFAULT_CONFIG.GLOW_PERIOD_MS,
+  RAINBOW_PERIOD_MS:
+    typeof u.rainbowPeriodMs === 'number' && u.rainbowPeriodMs > 0
+      ? u.rainbowPeriodMs
+      : DEFAULT_CONFIG.RAINBOW_PERIOD_MS,
 };

--- a/packages/chat-input/config.ts
+++ b/packages/chat-input/config.ts
@@ -89,6 +89,10 @@ function isSpinnerStyle(s: unknown): s is SpinnerStyle {
   return typeof s === 'string' && s in SPINNERS;
 }
 
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && value > 0 ? value : fallback;
+}
+
 interface ChatInputUserConfig {
   boxedView?: boolean;
   boxPadX?: number;
@@ -114,49 +118,68 @@ interface ChatInputUserConfig {
 
 const CONFIG_PATH = join(getAgentDir(), 'configs', 'chat-input.json');
 
-function loadUserConfig(): ChatInputUserConfig {
+/** Read the user config. `error` is set only for real problems (bad JSON,
+ * unreadable file) — a missing file is the normal "all defaults" case. */
+function loadUserConfig(): { user: ChatInputUserConfig; error: string | null } {
   try {
-    return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-  } catch {
-    return {};
+    return { user: JSON.parse(readFileSync(CONFIG_PATH, 'utf8')), error: null };
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return { user: {}, error: null };
+    return { user: {}, error: e instanceof Error ? e.message : String(e) };
   }
 }
 
-const u = loadUserConfig();
+function buildConfig(u: ChatInputUserConfig) {
+  // Spinner resolution: explicit spinnerFrames win, then the named preset,
+  // then the default preset. The preset also supplies the default interval.
+  const preset = SPINNERS[isSpinnerStyle(u.spinnerStyle) ? u.spinnerStyle : DEFAULT_CONFIG.SPINNER_STYLE];
+  const customFrames =
+    Array.isArray(u.spinnerFrames) &&
+    u.spinnerFrames.length > 0 &&
+    u.spinnerFrames.every((f) => typeof f === 'string' && f.length > 0)
+      ? u.spinnerFrames
+      : null;
 
-// Spinner resolution: explicit spinnerFrames win, then the named preset,
-// then the default preset. The preset also supplies the default interval.
-const preset = SPINNERS[isSpinnerStyle(u.spinnerStyle) ? u.spinnerStyle : DEFAULT_CONFIG.SPINNER_STYLE];
-const customFrames =
-  Array.isArray(u.spinnerFrames) &&
-  u.spinnerFrames.length > 0 &&
-  u.spinnerFrames.every((f) => typeof f === 'string' && f.length > 0)
-    ? u.spinnerFrames
-    : null;
+  return {
+    BOXED_VIEW: u.boxedView ?? DEFAULT_CONFIG.BOXED_VIEW,
+    BOX_PAD_X: u.boxPadX ?? DEFAULT_CONFIG.BOX_PAD_X,
+    MENU_GAP: u.menuGap ?? DEFAULT_CONFIG.MENU_GAP,
+    EXTRA_MENU_INDENT: u.extraMenuIndent ?? DEFAULT_CONFIG.EXTRA_MENU_INDENT,
+    BORDER_COLOR: u.borderColor ?? DEFAULT_CONFIG.BORDER_COLOR,
+    PREFIX: u.prefix ?? DEFAULT_CONFIG.PREFIX,
+    PREFIX_COLOR: u.prefixColor ?? DEFAULT_CONFIG.PREFIX_COLOR,
+    CORNERS: (u.corners === 'square' ? 'square' : 'rounded') as 'rounded' | 'square',
+    FOCUS_INDICATOR: u.focusIndicator ?? DEFAULT_CONFIG.FOCUS_INDICATOR,
+    FOCUSED_BORDER_COLOR: u.focusedBorderColor ?? DEFAULT_CONFIG.FOCUSED_BORDER_COLOR,
+    SPINNER: u.spinner ?? DEFAULT_CONFIG.SPINNER,
+    SPINNER_FRAMES: (customFrames ?? preset.frames) as readonly string[],
+    SPINNER_INTERVAL_MS: positiveNumber(u.spinnerIntervalMs, preset.intervalMs),
+    SPINNER_COLOR: u.spinnerColor ?? DEFAULT_CONFIG.SPINNER_COLOR,
+    GLOW: u.glow ?? DEFAULT_CONFIG.GLOW,
+    GLOW_STYLE: (u.glowStyle === 'shimmer' ? 'shimmer' : 'pulse') as 'pulse' | 'shimmer',
+    GLOW_COLOR: u.glowColor ?? DEFAULT_CONFIG.GLOW_COLOR,
+    GLOW_PERIOD_MS: positiveNumber(u.glowPeriodMs, DEFAULT_CONFIG.GLOW_PERIOD_MS),
+    RAINBOW_PERIOD_MS: positiveNumber(u.rainbowPeriodMs, DEFAULT_CONFIG.RAINBOW_PERIOD_MS),
+  };
+}
 
-export const CONFIG = {
-  BOXED_VIEW: u.boxedView ?? DEFAULT_CONFIG.BOXED_VIEW,
-  BOX_PAD_X: u.boxPadX ?? DEFAULT_CONFIG.BOX_PAD_X,
-  MENU_GAP: u.menuGap ?? DEFAULT_CONFIG.MENU_GAP,
-  EXTRA_MENU_INDENT: u.extraMenuIndent ?? DEFAULT_CONFIG.EXTRA_MENU_INDENT,
-  BORDER_COLOR: u.borderColor ?? DEFAULT_CONFIG.BORDER_COLOR,
-  PREFIX: u.prefix ?? DEFAULT_CONFIG.PREFIX,
-  PREFIX_COLOR: u.prefixColor ?? DEFAULT_CONFIG.PREFIX_COLOR,
-  CORNERS: (u.corners === 'square' ? 'square' : 'rounded') as 'rounded' | 'square',
-  FOCUS_INDICATOR: u.focusIndicator ?? DEFAULT_CONFIG.FOCUS_INDICATOR,
-  FOCUSED_BORDER_COLOR: u.focusedBorderColor ?? DEFAULT_CONFIG.FOCUSED_BORDER_COLOR,
-  SPINNER: u.spinner ?? DEFAULT_CONFIG.SPINNER,
-  SPINNER_FRAMES: (customFrames ?? preset.frames) as readonly string[],
-  SPINNER_INTERVAL_MS:
-    typeof u.spinnerIntervalMs === 'number' && u.spinnerIntervalMs > 0 ? u.spinnerIntervalMs : preset.intervalMs,
-  SPINNER_COLOR: u.spinnerColor ?? DEFAULT_CONFIG.SPINNER_COLOR,
-  GLOW: u.glow ?? DEFAULT_CONFIG.GLOW,
-  GLOW_STYLE: (u.glowStyle === 'shimmer' ? 'shimmer' : 'pulse') as 'pulse' | 'shimmer',
-  GLOW_COLOR: u.glowColor ?? DEFAULT_CONFIG.GLOW_COLOR,
-  GLOW_PERIOD_MS:
-    typeof u.glowPeriodMs === 'number' && u.glowPeriodMs > 0 ? u.glowPeriodMs : DEFAULT_CONFIG.GLOW_PERIOD_MS,
-  RAINBOW_PERIOD_MS:
-    typeof u.rainbowPeriodMs === 'number' && u.rainbowPeriodMs > 0
-      ? u.rainbowPeriodMs
-      : DEFAULT_CONFIG.RAINBOW_PERIOD_MS,
-};
+const initial = loadUserConfig();
+let lastError = initial.error;
+
+/** Live config — reloadConfig() mutates this object in place, so modules
+ * that read `CONFIG.X` at use time see updates without re-importing. */
+export const CONFIG = buildConfig(initial.user);
+
+/** Error from the most recent config load, or null if it loaded cleanly. */
+export function configLoadError(): string | null {
+  return lastError;
+}
+
+/** Re-read chat-input.json into CONFIG. On error the previous config is
+ * kept. Returns the error message, or null on success. */
+export function reloadConfig(): string | null {
+  const { user, error } = loadUserConfig();
+  if (!error) Object.assign(CONFIG, buildConfig(user));
+  lastError = error;
+  return error;
+}

--- a/packages/chat-input/index.ts
+++ b/packages/chat-input/index.ts
@@ -11,7 +11,7 @@
  * config-driven (~/.pi/agent/configs/chat-input.json) and supports a
  * prefix glyph, boxed/unboxed modes, configurable padding, menu gap,
  * rounded vs square corners, and working-state animations (spinner prefix
- * and border glow between agent_start and agent_settled). The rounded ╭╮│╰╯ corners remain the
+ * and border glow while the agent works). The rounded ╭╮│╰╯ corners remain the
  * default to preserve the original look. Paste-expand behavior was merged
  * in from the former standalone `paste-expand.ts` so the two features don't
  * fight over `setEditorComponent` (last-call-wins).
@@ -72,7 +72,7 @@ import { CustomEditor, type ExtensionAPI, type ExtensionContext } from '@earendi
 import type { TUI, EditorTheme } from '@earendil-works/pi-tui';
 import type { KeybindingsManager } from '@earendil-works/pi-coding-agent';
 import { visibleWidth } from '@earendil-works/pi-tui';
-import { CONFIG } from './config.js';
+import { CONFIG, configLoadError, reloadConfig } from './config.js';
 import { applyColor, mixRgb, plainText, rainbowRgb, resolveRgb, rgbColor } from './utils.js';
 
 // Corner glyphs per style.
@@ -102,36 +102,59 @@ function isBorderLike(line: string): boolean {
 
 /** Prefix width in terminal cells — layout math supports multi-cell prefixes.
  * When the spinner is enabled the slot is sized to the widest frame so the
- * layout doesn't shift while animating. */
-const PREFIX_W = Math.max(
-  1,
-  visibleWidth(CONFIG.PREFIX),
-  ...(CONFIG.SPINNER ? CONFIG.SPINNER_FRAMES.map((f) => visibleWidth(f)) : []),
-);
+ * layout doesn't shift while animating. Recomputed on config reload. */
+let PREFIX_W = prefixWidth();
+
+function prefixWidth(): number {
+  return Math.max(
+    1,
+    visibleWidth(CONFIG.PREFIX),
+    ...(CONFIG.SPINNER ? CONFIG.SPINNER_FRAMES.map((f) => visibleWidth(f)) : []),
+  );
+}
 
 // ─── Working-state animation (spinner prefix + border glow) ───────────────
-// Busy between agent_start and agent_settled. A single timer drives both
-// animations by requesting renders; frames/phases derive from Date.now() so
-// they stay smooth regardless of tick jitter. pi-tui's invalidate() is a
-// no-op — requestRender() is the only way to repaint from a timer.
+// Busy between agent_start and agent_settled (or during a /chat-input
+// preview). A single timer drives both animations by requesting renders;
+// frames/phases derive from Date.now() so they stay smooth regardless of
+// tick jitter. pi-tui's invalidate() is a no-op — requestRender() is the
+// only way to repaint from a timer.
 
 let agentBusy = false;
+let agentRunning = false; // real agent run in flight (vs. preview-only busy)
 let busySince = 0;
 let animTimer: ReturnType<typeof setInterval> | undefined;
+let previewTimer: ReturnType<typeof setTimeout> | undefined;
 let animTui: TUI | undefined;
 
-const ANIMATED = CONFIG.SPINNER || CONFIG.GLOW;
-const ANIM_TICK_MS = Math.min(CONFIG.SPINNER ? CONFIG.SPINNER_INTERVAL_MS : Infinity, CONFIG.GLOW ? 80 : Infinity);
-
 function startAnimation(): void {
-  if (!ANIMATED || animTimer || !animTui) return;
-  animTimer = setInterval(() => animTui?.requestRender(), ANIM_TICK_MS);
+  if (animTimer || !animTui) return;
+  if (!CONFIG.SPINNER && !CONFIG.GLOW) return;
+  const tickMs = Math.min(CONFIG.SPINNER ? CONFIG.SPINNER_INTERVAL_MS : Infinity, CONFIG.GLOW ? 80 : Infinity);
+  animTimer = setInterval(() => animTui?.requestRender(), tickMs);
   animTimer.unref?.();
 }
 
 function stopAnimation(): void {
   if (animTimer) clearInterval(animTimer);
   animTimer = undefined;
+}
+
+function beginBusy(): void {
+  agentBusy = true;
+  busySince = Date.now();
+  startAnimation();
+}
+
+function endBusy(): void {
+  agentBusy = false;
+  stopAnimation();
+  animTui?.requestRender();
+}
+
+function cancelPreview(): void {
+  if (previewTimer) clearTimeout(previewTimer);
+  previewTimer = undefined;
 }
 
 function spinnerFrame(): string {
@@ -195,7 +218,11 @@ class ChatInput extends CustomEditor {
   private accent: (s: string) => string;
   private spin: (s: string) => string;
   private glow: (s: string) => string;
-  private corners = CORNERS[CONFIG.CORNERS];
+
+  // Read from CONFIG at render time so a config reload takes effect live.
+  private get corners() {
+    return CORNERS[CONFIG.CORNERS];
+  }
 
   constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, palette: Palette) {
     super(tui, theme, keybindings, { paddingX: 0 });
@@ -312,13 +339,13 @@ class ChatInput extends CustomEditor {
     return this.border('─'.repeat(left)) + this.glow('─'.repeat(right - left)) + this.border('─'.repeat(width - right));
   }
 
-  /** First-line prefix: spinner frame while the agent works, glyph otherwise. */
+  /** First-line prefix: spinner frame while the agent works, glyph otherwise.
+   * Always padded to PREFIX_W so the layout never shifts. */
   private prefixGlyph(): string {
-    if (agentBusy && CONFIG.SPINNER) {
-      const frame = spinnerFrame();
-      return this.spin(frame) + ' '.repeat(Math.max(0, PREFIX_W - visibleWidth(frame)));
-    }
-    return this.accent(CONFIG.PREFIX) + ' '.repeat(Math.max(0, PREFIX_W - visibleWidth(CONFIG.PREFIX)));
+    const spinning = agentBusy && CONFIG.SPINNER;
+    const glyph = spinning ? spinnerFrame() : CONFIG.PREFIX;
+    const painted = spinning ? this.spin(glyph) : this.accent(glyph);
+    return painted + ' '.repeat(Math.max(0, PREFIX_W - visibleWidth(glyph)));
   }
 
   /** Body lines (between the stock borders): pad + prefix + content, then `wrap`. */
@@ -431,24 +458,33 @@ export default function chatInput(pi: ExtensionAPI) {
   pi.on('session_start', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
     ctx.ui.setEditorComponent((tui, theme, kb) => {
-      const baseBorder = (s: string) => applyColor(ctx.ui.theme, CONFIG.BORDER_COLOR, s);
-      const focusBorder = (s: string) => applyColor(ctx.ui.theme, CONFIG.FOCUSED_BORDER_COLOR, s);
-      const restingBorder = (s: string) => (CONFIG.FOCUS_INDICATOR && paneFocused ? focusBorder(s) : baseBorder(s));
+      // All palette fns read CONFIG.* at call time so /chat-input reloads
+      // take effect without rebuilding the editor component.
+      const restingBorder = (s: string) =>
+        applyColor(
+          ctx.ui.theme,
+          CONFIG.FOCUS_INDICATOR && paneFocused ? CONFIG.FOCUSED_BORDER_COLOR : CONFIG.BORDER_COLOR,
+          s,
+        );
 
       // Paint with a colour name that may be a theme token, hex, or the
       // special "rainbow" value (hue rotates once per rainbowPeriodMs).
-      const paint = (color: string) => (s: string) =>
+      const paint = (color: string, s: string): string =>
         color === 'rainbow' ? rgbColor(rainbowRgb(CONFIG.RAINBOW_PERIOD_MS), s) : applyColor(ctx.ui.theme, color, s);
 
-      // Pulse glow: interpolate the resting border colour toward the glow
-      // colour. Falls back to a steady glow colour when either endpoint
-      // can't be resolved to RGB (non-truecolor theme tokens).
-      const staticGlowRgb = CONFIG.GLOW_COLOR === 'rainbow' ? null : resolveRgb(ctx.ui.theme, CONFIG.GLOW_COLOR);
+      // Pulse glow: interpolate borderColor toward the glow colour. Anchoring
+      // on borderColor (not the focus-adjusted resting colour) keeps the
+      // default visible: with focusIndicator on, the focused resting border
+      // is accent, and an accent→accent pulse would be a no-op. Falls back to
+      // a steady glow colour when either endpoint can't be resolved to RGB
+      // (non-truecolor theme tokens).
       const pulseBorder = (s: string): string => {
-        const glowRgb = CONFIG.GLOW_COLOR === 'rainbow' ? rainbowRgb(CONFIG.RAINBOW_PERIOD_MS) : staticGlowRgb;
-        const baseName = CONFIG.FOCUS_INDICATOR && paneFocused ? CONFIG.FOCUSED_BORDER_COLOR : CONFIG.BORDER_COLOR;
-        const baseRgb = resolveRgb(ctx.ui.theme, baseName);
-        if (!baseRgb || !glowRgb) return paint(CONFIG.GLOW_COLOR)(s);
+        const glowRgb =
+          CONFIG.GLOW_COLOR === 'rainbow'
+            ? rainbowRgb(CONFIG.RAINBOW_PERIOD_MS)
+            : resolveRgb(ctx.ui.theme, CONFIG.GLOW_COLOR);
+        const baseRgb = resolveRgb(ctx.ui.theme, CONFIG.BORDER_COLOR);
+        if (!baseRgb || !glowRgb) return paint(CONFIG.GLOW_COLOR, s);
         return rgbColor(mixRgb(baseRgb, glowRgb, pulsePhase()), s);
       };
 
@@ -460,29 +496,68 @@ export default function chatInput(pi: ExtensionAPI) {
       return new ChatInput(tui, theme, kb, {
         border: borderFn,
         accent: (s: string) => applyColor(ctx.ui.theme, CONFIG.PREFIX_COLOR, s),
-        spin: paint(CONFIG.SPINNER_COLOR),
-        glow: paint(CONFIG.GLOW_COLOR),
+        spin: (s: string) => paint(CONFIG.SPINNER_COLOR, s),
+        glow: (s: string) => paint(CONFIG.GLOW_COLOR, s),
       });
     });
+
+    const loadError = configLoadError();
+    if (loadError) ctx.ui.notify(`chat-input.json ignored (using defaults): ${loadError}`, 'warning');
+  });
+
+  pi.registerCommand('chat-input', {
+    description: 'Reload chat-input.json and preview the working animation',
+    handler: async (_args, ctx) => {
+      const error = reloadConfig();
+      if (error) {
+        ctx.ui.notify(`chat-input.json not applied (kept previous config): ${error}`, 'error');
+        return;
+      }
+      PREFIX_W = prefixWidth();
+      if (animTui) {
+        if (CONFIG.FOCUS_INDICATOR) enableFocusTracking(animTui);
+        else disableFocusTracking();
+      }
+      if (agentBusy) {
+        // Restart the timer so a changed spinner interval takes effect.
+        stopAnimation();
+        startAnimation();
+      }
+      ctx.ui.notify('chat-input config reloaded', 'info');
+      animTui?.requestRender();
+
+      // Fake a short busy window so the spinner/glow can be seen without
+      // sending a prompt. A real agent run takes over seamlessly.
+      if (!agentRunning && (CONFIG.SPINNER || CONFIG.GLOW)) {
+        cancelPreview();
+        beginBusy();
+        previewTimer = setTimeout(() => {
+          previewTimer = undefined;
+          if (!agentRunning) endBusy();
+        }, 3000);
+        previewTimer.unref?.();
+      }
+    },
   });
 
   pi.on('agent_start', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
-    agentBusy = true;
-    busySince = Date.now();
-    startAnimation();
+    agentRunning = true;
+    cancelPreview();
+    beginBusy();
   });
 
   pi.on('agent_settled', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
-    agentBusy = false;
-    stopAnimation();
-    animTui?.requestRender();
+    agentRunning = false;
+    endBusy();
   });
 
   pi.on('session_shutdown', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
     if (CONFIG.FOCUS_INDICATOR) disableFocusTracking();
+    cancelPreview();
+    agentRunning = false;
     agentBusy = false;
     stopAnimation();
     animTui = undefined;

--- a/packages/chat-input/index.ts
+++ b/packages/chat-input/index.ts
@@ -10,7 +10,8 @@
  * Evolved from the earlier `box-editor.ts`: the rendering is now
  * config-driven (~/.pi/agent/configs/chat-input.json) and supports a
  * prefix glyph, boxed/unboxed modes, configurable padding, menu gap,
- * and rounded vs square corners. The rounded ╭╮│╰╯ corners remain the
+ * rounded vs square corners, and working-state animations (spinner prefix
+ * and border glow between agent_start and agent_settled). The rounded ╭╮│╰╯ corners remain the
  * default to preserve the original look. Paste-expand behavior was merged
  * in from the former standalone `paste-expand.ts` so the two features don't
  * fight over `setEditorComponent` (last-call-wins).
@@ -72,7 +73,7 @@ import type { TUI, EditorTheme } from '@earendil-works/pi-tui';
 import type { KeybindingsManager } from '@earendil-works/pi-coding-agent';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import { CONFIG } from './config.js';
-import { applyColor, plainText } from './utils.js';
+import { applyColor, mixRgb, plainText, rainbowRgb, resolveRgb, rgbColor } from './utils.js';
 
 // Corner glyphs per style.
 const CORNERS = {
@@ -99,8 +100,49 @@ function isBorderLike(line: string): boolean {
   return isSolidBorder(line) || getScrollText(line) !== null;
 }
 
-/** Prefix width in terminal cells — layout math supports multi-cell prefixes. */
-const PREFIX_W = Math.max(1, visibleWidth(CONFIG.PREFIX));
+/** Prefix width in terminal cells — layout math supports multi-cell prefixes.
+ * When the spinner is enabled the slot is sized to the widest frame so the
+ * layout doesn't shift while animating. */
+const PREFIX_W = Math.max(
+  1,
+  visibleWidth(CONFIG.PREFIX),
+  ...(CONFIG.SPINNER ? CONFIG.SPINNER_FRAMES.map((f) => visibleWidth(f)) : []),
+);
+
+// ─── Working-state animation (spinner prefix + border glow) ───────────────
+// Busy between agent_start and agent_settled. A single timer drives both
+// animations by requesting renders; frames/phases derive from Date.now() so
+// they stay smooth regardless of tick jitter. pi-tui's invalidate() is a
+// no-op — requestRender() is the only way to repaint from a timer.
+
+let agentBusy = false;
+let busySince = 0;
+let animTimer: ReturnType<typeof setInterval> | undefined;
+let animTui: TUI | undefined;
+
+const ANIMATED = CONFIG.SPINNER || CONFIG.GLOW;
+const ANIM_TICK_MS = Math.min(CONFIG.SPINNER ? CONFIG.SPINNER_INTERVAL_MS : Infinity, CONFIG.GLOW ? 80 : Infinity);
+
+function startAnimation(): void {
+  if (!ANIMATED || animTimer || !animTui) return;
+  animTimer = setInterval(() => animTui?.requestRender(), ANIM_TICK_MS);
+  animTimer.unref?.();
+}
+
+function stopAnimation(): void {
+  if (animTimer) clearInterval(animTimer);
+  animTimer = undefined;
+}
+
+function spinnerFrame(): string {
+  const frames = CONFIG.SPINNER_FRAMES;
+  return frames[Math.floor((Date.now() - busySince) / CONFIG.SPINNER_INTERVAL_MS) % frames.length]!;
+}
+
+/** 0..1 breathing intensity for the pulse glow. */
+function pulsePhase(): number {
+  return (1 - Math.cos((2 * Math.PI * (Date.now() % CONFIG.GLOW_PERIOD_MS)) / CONFIG.GLOW_PERIOD_MS)) / 2;
+}
 
 /** Locate pi's stock top/bottom borders and their scroll indicators in a render. */
 function scanBorders(stock: string[]): {
@@ -137,6 +179,13 @@ function menuLines(stock: string[], lastIdx: number, width: number): string[] {
 
 // ─── Component ────────────────────────────────────────────────────────────
 
+interface Palette {
+  border: (s: string) => string;
+  accent: (s: string) => string;
+  spin: (s: string) => string;
+  glow: (s: string) => string;
+}
+
 // @ts-expect-error TS2415 — handlePaste is a prototype method typed `private` in
 // pi-tui's Editor; overriding it is legal at runtime (dynamic dispatch) and is the
 // only interception point for paste handling. If this stops erroring, pi-tui made
@@ -144,18 +193,16 @@ function menuLines(stock: string[], lastIdx: number, width: number): string[] {
 class ChatInput extends CustomEditor {
   private border: (s: string) => string;
   private accent: (s: string) => string;
+  private spin: (s: string) => string;
+  private glow: (s: string) => string;
   private corners = CORNERS[CONFIG.CORNERS];
 
-  constructor(
-    tui: TUI,
-    theme: EditorTheme,
-    keybindings: KeybindingsManager,
-    borderFn: (s: string) => string,
-    accentFn: (s: string) => string,
-  ) {
+  constructor(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager, palette: Palette) {
     super(tui, theme, keybindings, { paddingX: 0 });
-    this.border = borderFn;
-    this.accent = accentFn;
+    this.border = palette.border;
+    this.accent = palette.accent;
+    this.spin = palette.spin;
+    this.glow = palette.glow;
   }
 
   // ── Paste-again-to-expand ───────────────────────────────────────────────
@@ -246,9 +293,32 @@ class ChatInput extends CustomEditor {
 
   /** A horizontal rule of `width` cells, with the scroll indicator inlaid when present. */
   private rule(scroll: string | null, width: number): string {
-    if (!scroll) return this.border('─'.repeat(width));
+    if (!scroll) {
+      if (agentBusy && CONFIG.GLOW && CONFIG.GLOW_STYLE === 'shimmer') return this.shimmerRule(width);
+      return this.border('─'.repeat(width));
+    }
     const label = `── ${scroll} `;
     return this.border(label) + this.border('─'.repeat(Math.max(0, width - visibleWidth(label))));
+  }
+
+  /** A rule with a glowing highlight sweeping left → right. */
+  private shimmerRule(width: number): string {
+    const win = Math.max(3, Math.min(10, Math.floor(width / 6)));
+    const cycle = width + win;
+    const head = Math.floor(((Date.now() % CONFIG.GLOW_PERIOD_MS) / CONFIG.GLOW_PERIOD_MS) * cycle);
+    const left = Math.max(0, head - win);
+    const right = Math.min(width, head);
+    if (right <= left) return this.border('─'.repeat(width));
+    return this.border('─'.repeat(left)) + this.glow('─'.repeat(right - left)) + this.border('─'.repeat(width - right));
+  }
+
+  /** First-line prefix: spinner frame while the agent works, glyph otherwise. */
+  private prefixGlyph(): string {
+    if (agentBusy && CONFIG.SPINNER) {
+      const frame = spinnerFrame();
+      return this.spin(frame) + ' '.repeat(Math.max(0, PREFIX_W - visibleWidth(frame)));
+    }
+    return this.accent(CONFIG.PREFIX) + ' '.repeat(Math.max(0, PREFIX_W - visibleWidth(CONFIG.PREFIX)));
   }
 
   /** Body lines (between the stock borders): pad + prefix + content, then `wrap`. */
@@ -267,7 +337,7 @@ class ChatInput extends CustomEditor {
       if (lastIdx !== -1 && i > lastIdx) continue;
       const vw = visibleWidth(stock[i]!);
       const fill = vw < contentWidth ? ' '.repeat(contentWidth - vw) : '';
-      const prefixStr = isFirst ? this.accent(CONFIG.PREFIX) : ' '.repeat(PREFIX_W);
+      const prefixStr = isFirst ? this.prefixGlyph() : ' '.repeat(PREFIX_W);
       body.push(wrap(pad + prefixStr + pad + stock[i]! + fill));
       isFirst = false;
     }
@@ -363,18 +433,59 @@ export default function chatInput(pi: ExtensionAPI) {
     ctx.ui.setEditorComponent((tui, theme, kb) => {
       const baseBorder = (s: string) => applyColor(ctx.ui.theme, CONFIG.BORDER_COLOR, s);
       const focusBorder = (s: string) => applyColor(ctx.ui.theme, CONFIG.FOCUSED_BORDER_COLOR, s);
-      const borderFn = CONFIG.FOCUS_INDICATOR
-        ? (s: string) => (paneFocused ? focusBorder(s) : baseBorder(s))
-        : baseBorder;
-      const accentFn = (s: string) => applyColor(ctx.ui.theme, CONFIG.PREFIX_COLOR, s);
+      const restingBorder = (s: string) => (CONFIG.FOCUS_INDICATOR && paneFocused ? focusBorder(s) : baseBorder(s));
+
+      // Paint with a colour name that may be a theme token, hex, or the
+      // special "rainbow" value (hue rotates once per rainbowPeriodMs).
+      const paint = (color: string) => (s: string) =>
+        color === 'rainbow' ? rgbColor(rainbowRgb(CONFIG.RAINBOW_PERIOD_MS), s) : applyColor(ctx.ui.theme, color, s);
+
+      // Pulse glow: interpolate the resting border colour toward the glow
+      // colour. Falls back to a steady glow colour when either endpoint
+      // can't be resolved to RGB (non-truecolor theme tokens).
+      const staticGlowRgb = CONFIG.GLOW_COLOR === 'rainbow' ? null : resolveRgb(ctx.ui.theme, CONFIG.GLOW_COLOR);
+      const pulseBorder = (s: string): string => {
+        const glowRgb = CONFIG.GLOW_COLOR === 'rainbow' ? rainbowRgb(CONFIG.RAINBOW_PERIOD_MS) : staticGlowRgb;
+        const baseName = CONFIG.FOCUS_INDICATOR && paneFocused ? CONFIG.FOCUSED_BORDER_COLOR : CONFIG.BORDER_COLOR;
+        const baseRgb = resolveRgb(ctx.ui.theme, baseName);
+        if (!baseRgb || !glowRgb) return paint(CONFIG.GLOW_COLOR)(s);
+        return rgbColor(mixRgb(baseRgb, glowRgb, pulsePhase()), s);
+      };
+
+      const borderFn = (s: string) =>
+        agentBusy && CONFIG.GLOW && CONFIG.GLOW_STYLE === 'pulse' ? pulseBorder(s) : restingBorder(s);
+
       if (CONFIG.FOCUS_INDICATOR) enableFocusTracking(tui);
-      return new ChatInput(tui, theme, kb, borderFn, accentFn);
+      animTui = tui;
+      return new ChatInput(tui, theme, kb, {
+        border: borderFn,
+        accent: (s: string) => applyColor(ctx.ui.theme, CONFIG.PREFIX_COLOR, s),
+        spin: paint(CONFIG.SPINNER_COLOR),
+        glow: paint(CONFIG.GLOW_COLOR),
+      });
     });
+  });
+
+  pi.on('agent_start', (_event, ctx: ExtensionContext) => {
+    if (ctx.mode !== 'tui') return;
+    agentBusy = true;
+    busySince = Date.now();
+    startAnimation();
+  });
+
+  pi.on('agent_settled', (_event, ctx: ExtensionContext) => {
+    if (ctx.mode !== 'tui') return;
+    agentBusy = false;
+    stopAnimation();
+    animTui?.requestRender();
   });
 
   pi.on('session_shutdown', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
     if (CONFIG.FOCUS_INDICATOR) disableFocusTracking();
+    agentBusy = false;
+    stopAnimation();
+    animTui = undefined;
     ctx.ui.setEditorComponent(undefined);
   });
 }

--- a/packages/chat-input/utils.ts
+++ b/packages/chat-input/utils.ts
@@ -20,6 +20,55 @@ function hexToAnsi(hex: string): string {
   return `\x1b[38;2;${r};${g};${b}m`;
 }
 
+export type Rgb = [number, number, number];
+
+function hexToRgb(hex: string): Rgb | null {
+  const h = hex.replace('#', '');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/** Resolve a theme token or hex colour to RGB. Returns null when the theme
+ * doesn't emit a truecolor sequence for the token (e.g. 256-colour themes). */
+export function resolveRgb(theme: Theme, color: string): Rgb | null {
+  if (isHexColor(color)) return hexToRgb(color);
+  try {
+    const painted = theme.fg(color as ThemeColor, 'x');
+    const m = painted.match(/\x1b\[38;2;(\d+);(\d+);(\d+)m/);
+    if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  } catch {
+    /* unknown token */
+  }
+  return null;
+}
+
+/** Linear mix of two RGB colours; t=0 gives `a`, t=1 gives `b`. */
+export function mixRgb(a: Rgb, b: Rgb, t: number): Rgb {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+/** Fully saturated rainbow colour, hue-rotating once per `periodMs`. */
+export function rainbowRgb(periodMs: number): Rgb {
+  const h = ((Date.now() % periodMs) / periodMs) * 6; // hue in [0,6)
+  const x = Math.round(255 * (1 - Math.abs((h % 2) - 1)));
+  const sector = Math.floor(h);
+  if (sector === 0) return [255, x, 0];
+  if (sector === 1) return [x, 255, 0];
+  if (sector === 2) return [0, 255, x];
+  if (sector === 3) return [0, x, 255];
+  if (sector === 4) return [x, 0, 255];
+  return [255, 0, x];
+}
+
+/** Paint text with a truecolor foreground. */
+export function rgbColor(rgb: Rgb, text: string): string {
+  return `\x1b[38;2;${rgb[0]};${rgb[1]};${rgb[2]}m${text}\x1b[0m`;
+}
+
 /** Apply a colour by theme token or hex value. Hex takes precedence. */
 export function applyColor(theme: Theme, color: string, text: string): string {
   if (isHexColor(color)) {


### PR DESCRIPTION
Adds working-state whimsy to `@nicknisi/pi-chat-input`: while pi is thinking (between `agent_start` and `agent_settled`), the prefix glyph animates as a spinner and the box border glows. Everything is configurable via `~/.pi/agent/configs/chat-input.json`.

## Spinner prefix

- **9 built-in presets** via `spinnerStyle`: `dots` (default), `disc`, `moon`, `star`, `orbit`, `corners`, `triangle`, `scanner` (6-cell KITT comet), `mini-scanner` — each with a tuned default frame interval
- **Define your own** with `spinnerFrames` (overrides the preset); frames may be any cell width — the prefix slot is sized to the widest frame so the layout never shifts mid-run
- `spinnerIntervalMs` overrides the preset interval; `spinnerColor` takes a theme token, hex, or `"rainbow"`

## Border glow

- `glowStyle: "pulse"` — border breathes between the resting border colour and `glowColor`, RGB-interpolated (sine curve). Falls back to steady `glowColor` when a theme token isn't truecolor
- `glowStyle: "shimmer"` — a highlight sweeps left→right along the top/bottom rules
- `glowColor` accepts theme tokens, hex, or `"rainbow"` (hue rotates once per `rainbowPeriodMs`)
- Layers correctly with the existing focus indicator (pulse interpolates from whichever resting colour applies); README documents the accent-on-accent no-op trap

## Implementation

- Busy state driven by `agent_start` / `agent_settled` (spinner survives auto-retries/compaction/follow-ups)
- One `setInterval` runs **only while busy**, calling `tui.requestRender()`; frames/phases derive from `Date.now()` so animation stays smooth regardless of tick jitter; timer torn down on settle and session shutdown, `unref()`d
- Rainbow is a truecolor hue rotation helper in `utils.ts`

## Verification

- `pnpm typecheck` (incl. dist build), `pnpm lint`, `pnpm format:check` all pass
- jiti smoke-load: default export is a function
- Config precedence proven via subprocess under a fake `PI_CODING_AGENT_DIR`: custom `spinnerFrames` beat `spinnerStyle` (`["A","B"] @ 33ms`), unknown style falls back to `dots` @ 80ms, `scanner` resolves 12 frames @ its tuned 60ms
- Live-tested in a real pi session across all iterations (pulse, shimmer, wide frames, rainbow)

Changeset included (minor).
