### PR TITLE
feat(shared): add in-process subagent runtime

### DIFF
--- a/.changeset/shared-subagent-runtime.md
+++ b/.changeset/shared-subagent-runtime.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-shared': minor
+---
+
+Add `subagents.ts`: an in-process subagent runtime (`createSubagentRuntime`) that spawns hermetic child agent sessions through pi's SDK (`createAgentSession`) — no subprocesses, no pi-subagents dependency. Tool allowlists by construction, closure-based supervisor channel (`<namespace>_contact_supervisor`), TypeBox `outputSchema` validation with a discriminated result union (`ok | crashed | empty | schema_invalid | aborted`), per-runtime concurrency cap, and an in-memory run registry. Also exports `resolveContainedAgentResource` for containment-checked resolution of bare names under the agent dir. `typebox` is now a runtime dependency.

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -2,11 +2,11 @@
 
 Shared helper library for the extensions in this monorepo. It is not a pi extension itself — it exports no default extension entry, adds no commands, tools, keybindings, widgets, or events, and installing it into pi directly does nothing. Other packages depend on it via `"@nicknisi/pi-shared": "workspace:*"` and import from it like any library.
 
-It exists to centralize two things that several extensions were duplicating: one-off LLM calls on pi-ai's modern provider API (no `/compat` imports), and a set of TUI utilities (gradient text, renderable-tree surgery, two-column layout, escape-sequence sanitization, render dispatch) plus a composable searchable select component.
+It exists to centralize things that several extensions were duplicating: one-off LLM calls on pi-ai's modern provider API (no `/compat` imports), a set of TUI utilities (gradient text, renderable-tree surgery, two-column layout, escape-sequence sanitization, render dispatch) plus a composable searchable select component, and an in-process subagent runtime for spawning focused child agent sessions.
 
 ## Exports
 
-`index.ts` re-exports everything from `llm.ts`, `tui-utils.ts`, and `searchable-select-list.ts`.
+`index.ts` re-exports everything from `llm.ts`, `tui-utils.ts`, `searchable-select-list.ts`, and `subagents.ts`.
 
 ### LLM (`llm.ts`)
 
@@ -82,6 +82,49 @@ list.onCancel = () => {
 
 `selectList` is exposed as a readonly field for direct list manipulation.
 
+### Subagents (`subagents.ts`)
+
+```ts
+import { createSubagentRuntime } from '@nicknisi/pi-shared';
+```
+
+In-process subagent runtime: spawn focused child agent sessions through pi's SDK (`createAgentSession`) — no subprocesses, no dependency on pi-subagents. Because pi's extension loader aliases `@earendil-works/*` imports to the running host, children are always version-matched to the pi that loaded the extension.
+
+```ts
+const subagents = createSubagentRuntime({ namespace: 'my-extension' });
+
+const result = await subagents.spawn({
+  model: 'anthropic/claude-haiku-4-5', // optional; pi default resolution when omitted
+  prompt: 'Review src/auth.ts for …',
+  tools: ['read', 'grep'], // allowlist; [] = none; omit = pi defaults
+  systemPrompt: 'You are a security reviewer.', // appended to pi's default prompt
+  outputSchema: MySchema, // optional TypeBox schema for the final message
+  onSupervisorRequest: async ({ message }) => 'supervisor reply',
+});
+
+if (result.ok) {
+  result.text; // final assistant message (last message only, never a concatenation)
+  result.data; // parsed + validated output, when outputSchema was given
+  result.usage; // { inputTokens, outputTokens, totalTokens, cost? }
+} else {
+  result.kind; // 'crashed' | 'empty' | 'schema_invalid' | 'aborted'
+}
+```
+
+Design rules baked in:
+
+- **Hermetic children.** No user extensions, skills, prompt templates, themes, or context files load into a child unless explicitly requested (`extensionPaths`, `skillPaths`, `includeContextFiles`). A configured pi-subagents install never leaks in.
+- **Tool scoping by construction.** A child gets exactly the allowlisted built-ins plus the supervisor tool when requested. No spawn capability exists as a tool, so children cannot spawn children.
+- **Never rejects.** `spawn()` resolves a discriminated union. `schema_invalid` (unparseable/invalid JSON) is deliberately distinct from a schema-valid answer whose _content_ reports failure — engines with retry loops key off that distinction.
+- **The supervisor channel is a closure.** `onSupervisorRequest` registers a `<namespace>_contact_supervisor` tool in the child wired straight to the parent handler — no filesystem protocol, no polling.
+- **Ecosystem recursion guard, honored not namespaced.** Spawning is refused when `PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_CHILD` are set (i.e. your extension is itself running inside a pi-subagents child).
+- **Run registry.** `listRuns()` returns recent runs (newest first, capped at 200); `activeCount()` reports in-flight spawns. Concurrency is capped per runtime (`maxConcurrent`, default 4). pi's loader gives every extension its own evaluated copy of this module, so a _cross-extension_ limiter is impossible — size each runtime accordingly.
+- **Timeout/abort.** `timeoutMs` (default 15 min, `0` disables) and `signal` both map to `session.abort()`; both produce `kind: 'aborted'`.
+
+Also exported: `resolveContainedAgentResource(kind, name, leaf)` — containment-checked resolution of a bare name under the agent dir (`~/.pi/agent/extensions/<name>/<leaf>` etc.) for untrusted config input; returns `null` for anything with path separators or `..`.
+
+Non-goals for now: background/detached runs, persisted run artifacts, worktree isolation, and orchestration (chains/workflows) are deliberately out of this module — the registry is in-memory and children share the parent's event loop and memory (no crash isolation; a pathological child can hurt the host session).
+
 ## Usage
 
 Consumers in this monorepo add the workspace dependency:
@@ -94,7 +137,7 @@ Consumers in this monorepo add the workspace dependency:
 }
 ```
 
-and import individual functions as shown above. Known consumers: `answer`, `btw`, `handoff`, `header`, `session-name`, `statusline`.
+and import individual functions as shown above. Known consumers: `answer`, `btw`, `handoff`, `header`, `llm-council`, `session-name`, `statusline`.
 
 ## Configuration
 
@@ -118,7 +161,9 @@ Peer dependencies (all `*`, provided by the pi runtime):
 - `@earendil-works/pi-coding-agent` — `ExtensionContext` type; the `RenderableNode` shape targets its component tree.
 - `@earendil-works/pi-tui` — `truncateToWidth`, `visibleWidth` (layout), and `Container`, `Input`, `SelectList`, `getKeybindings` (searchable select).
 
-No runtime npm dependencies; Node builtins only (`node:os`, `node:path`).
+Runtime npm dependencies:
+
+- `typebox` — `outputSchema` validation in `subagents.ts` (`Value.Check`/`Clean`/`Convert`/`Errors`). At pi-load time the import is aliased to pi's bundled copy; the declared dependency covers non-pi consumers of the published package.
 
 ## Caveats
 
@@ -126,5 +171,5 @@ No runtime npm dependencies; Node builtins only (`node:os`, `node:path`).
 - `hideLabeledSection` relies on rendering children to a throwaway buffer to compare visible text — it depends on `render(width)` being side-effect-free enough to call speculatively, and on target sections having a stable first visible line (pi's `[Themes]` widget label is a pi internal that could change).
 - `scheduleHideLabeledSection` is a timing heuristic (`[0, 50, 250, 1000]` ms) for asynchronously injected nodes; a sufficiently slow injection can slip past the last poll.
 - `SearchableSelectList` hardcodes the `tui.select.*` keybinding IDs from pi-tui. If those IDs are renamed, navigation silently stops routing.
-- `package.json` `files` lists `index.ts`, `llm.ts`, `tui-utils.ts` but not `searchable-select-list.ts`. Harmless for workspace use (nothing is packed), but `pnpm pack`/publish would produce a broken tarball.
+- `package.json` `files` lists every shipped source plus `dist`; `pnpm pack`/publish produces a working tarball.
 - The package is marked `private: true` and ships TypeScript sources (`exports: { ".": "./index.ts" }`); consumers must run in pi's TS-loading extension environment, not plain Node.

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './llm.js';
 export * from './tui-utils.js';
 export * from './searchable-select-list.js';
+export * from './subagents.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,7 @@
     "dist",
     "index.ts",
     "llm.ts",
+    "subagents.ts",
     "tui-utils.ts",
     "searchable-select-list.ts"
   ],
@@ -27,6 +28,9 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
+  },
+  "dependencies": {
+    "typebox": "^1.1.0"
   },
   "peerDependencies": {
     "@earendil-works/pi-ai": "*",

--- a/packages/shared/subagents.ts
+++ b/packages/shared/subagents.ts
@@ -1,0 +1,548 @@
+/**
+ * In-process subagent runtime for pi extensions.
+ *
+ * Spawns focused child agent sessions through pi's SDK (`createAgentSession`)
+ * — no subprocesses, no dependency on pi-subagents. Because pi's extension
+ * loader aliases `@earendil-works/*` imports to the running host, children are
+ * always version-matched to the pi that loaded the extension.
+ *
+ * Design rules baked in:
+ * - Hermetic by default: no user extensions, skills, prompt templates, themes,
+ *   or context files load into a child unless explicitly requested via
+ *   `extensionPaths` / `skillPaths` / `includeContextFiles`.
+ * - Tool scoping is by construction: a child gets exactly the allowlisted
+ *   built-in tools plus the closure supervisor tool (when requested). A child
+ *   cannot spawn children of its own — no spawn capability exists as a tool.
+ * - `spawn()` never rejects. Failures are typed:
+ *   'crashed' | 'empty' | 'schema_invalid' | 'aborted'.
+ * - The ecosystem recursion guard is honored, not namespaced: when
+ *   PI_SUBAGENT_DEPTH / PI_SUBAGENT_CHILD are present (we are inside a
+ *   pi-subagents child), spawning is refused.
+ *
+ * Proven by spike before implementation: hermetic loader, tool allowlists,
+ * closure supervisor round-trip, streaming, ~2ms abort, and model/auth
+ * inheritance all verified against pi 0.84.1.
+ */
+
+import { randomUUID } from 'node:crypto';
+import * as path from 'node:path';
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  defineTool,
+  getAgentDir,
+  ModelRuntime,
+  resolveCliModel,
+  SessionManager,
+  SettingsManager,
+} from '@earendil-works/pi-coding-agent';
+import { Type, type TSchema } from 'typebox';
+import { Value } from 'typebox/value';
+
+// ── Public types ───────────────────────────────────────────────────────────
+
+const THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+
+export interface SupervisorRequest {
+  message: string;
+  reason?: string | undefined;
+}
+
+export type SupervisorHandler = (request: SupervisorRequest) => string | Promise<string>;
+
+export interface SpawnOptions {
+  /** The task prompt sent to the child. */
+  prompt: string;
+  /** Registry label (e.g. 'reviewer', 'member-A'). Purely informational. */
+  agent?: string;
+  /**
+   * Model spec ('provider/id', optionally with a ':thinking' suffix) resolved
+   * against the user's configured models/auth. Omit to use pi's default
+   * resolution (session settings, else first available).
+   */
+  model?: string;
+  /** Appended to pi's default system prompt (like --append-system-prompt). */
+  systemPrompt?: string;
+  /** Replace pi's default system prompt entirely instead of appending. */
+  replaceSystemPrompt?: boolean;
+  /**
+   * Built-in tool allowlist. undefined = pi defaults (read, bash, edit,
+   * write); [] = no tools; [...] = exactly those. The supervisor tool (when
+   * `onSupervisorRequest` is set) is always added automatically.
+   */
+  tools?: string[];
+  /** Thinking level: off | minimal | low | medium | high | xhigh | max. */
+  thinkingLevel?: string;
+  /** Explicit extension file paths to load into the child (hermetic otherwise). */
+  extensionPaths?: string[];
+  /** Explicit SKILL.md paths to load into the child (hermetic otherwise). */
+  skillPaths?: string[];
+  /** Load AGENTS.md / project context files. Default false. */
+  includeContextFiles?: boolean;
+  /**
+   * TypeBox schema for the child's final message. The final text is parsed
+   * as JSON (fences stripped) and validated; failures produce
+   * kind: 'schema_invalid' — distinct from a schema-valid answer that
+   * merely reports failure inside its fields.
+   */
+  outputSchema?: TSchema;
+  /**
+   * Parent-side supervisor channel. When set, the child gets a
+   * `<namespace>_contact_supervisor` tool whose calls invoke this handler
+   * and return its string as the tool result. In-process closure — no
+   * filesystem, no polling.
+   */
+  onSupervisorRequest?: SupervisorHandler;
+  /** Working directory for the child's tools. Default: process.cwd(). */
+  cwd?: string;
+  /** Wall-clock limit. Default 15 minutes; pass 0 to disable. */
+  timeoutMs?: number;
+  /** Aborts the child session (session.abort()) when fired. */
+  signal?: AbortSignal;
+}
+
+export interface SpawnUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cost?: number | undefined;
+}
+
+export type SpawnFailureKind = 'crashed' | 'empty' | 'schema_invalid' | 'aborted';
+
+export type SpawnFailure = {
+  ok: false;
+  runId: string;
+  kind: SpawnFailureKind;
+  error: string;
+  text: string;
+  usage: SpawnUsage;
+  durationMs: number;
+};
+
+export type SpawnResult =
+  | { ok: true; runId: string; text: string; data?: unknown; usage: SpawnUsage; durationMs: number }
+  | SpawnFailure;
+
+export interface RunRecord {
+  runId: string;
+  namespace: string;
+  agent?: string | undefined;
+  model?: string | undefined;
+  status: 'queued' | 'running' | 'completed' | 'failed' | 'aborted';
+  promptPreview: string;
+  startedAt: number;
+  endedAt?: number | undefined;
+  usage?: SpawnUsage | undefined;
+  error?: string | undefined;
+}
+
+export interface SubagentRuntime {
+  readonly namespace: string;
+  spawn(options: SpawnOptions): Promise<SpawnResult>;
+  /** Snapshot of recent runs, newest first. */
+  listRuns(): RunRecord[];
+  /** Currently executing (not queued) spawns. */
+  activeCount(): number;
+}
+
+// ── Internals ──────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_CONCURRENT = 4;
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+const MAX_RETAINED_RUNS = 200;
+
+function fail(runId: string, kind: SpawnFailureKind, error: string, startedAt: number): SpawnFailure {
+  return {
+    ok: false,
+    runId,
+    kind,
+    error,
+    text: '',
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    durationMs: Date.now() - startedAt,
+  };
+}
+
+/** Extract the text of the last assistant message that produced any. */
+function lastAssistantText(messages: readonly any[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== 'assistant' || !Array.isArray(m.content)) continue;
+    const text = m.content
+      .filter((p: any) => p?.type === 'text' && typeof p.text === 'string')
+      .map((p: any) => p.text)
+      .join('')
+      .trim();
+    if (text) return text;
+  }
+  return '';
+}
+
+function sumUsage(messages: readonly any[]): SpawnUsage {
+  const usage: SpawnUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  let cost = 0;
+  let hasCost = false;
+  for (const m of messages) {
+    if (m?.role !== 'assistant' || !m.usage) continue;
+    usage.inputTokens += m.usage.input ?? 0;
+    usage.outputTokens += m.usage.output ?? 0;
+    usage.totalTokens += m.usage.totalTokens ?? 0;
+    if (typeof m.usage.cost?.total === 'number') {
+      cost += m.usage.cost.total;
+      hasCost = true;
+    }
+  }
+  if (hasCost) usage.cost = cost;
+  return usage;
+}
+
+/** Parse JSON out of a final message: fenced block, whole body, or outermost {...}/[...] slice. */
+function extractJson(text: string): { ok: true; value: unknown } | { ok: false } {
+  const candidates: string[] = [];
+  const fenced = /```(?:json)?\s*\n?([\s\S]*?)```/.exec(text);
+  if (fenced?.[1]) candidates.push(fenced[1]);
+  candidates.push(text.trim());
+  const start = text.search(/[{[]/);
+  const end = Math.max(text.lastIndexOf('}'), text.lastIndexOf(']'));
+  if (start !== -1 && end > start) candidates.push(text.slice(start, end + 1));
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      return { ok: true, value: JSON.parse(candidate) };
+    } catch {
+      // try next candidate
+    }
+  }
+  return { ok: false };
+}
+
+function validateOutput(schema: TSchema, raw: unknown): { ok: true; data: unknown } | { ok: false; error: string } {
+  if (Value.Check(schema, raw)) return { ok: true, data: raw };
+  // One normalization pass: drop unknown properties, coerce convertible
+  // scalars, then re-check. Keeps 'additionalProperties: false' schemas
+  // tolerant of chatty models without engine-side string surgery.
+  try {
+    const normalized = Value.Convert(schema, Value.Clean(schema, structuredClone(raw)));
+    if (Value.Check(schema, normalized)) return { ok: true, data: normalized };
+  } catch {
+    // fall through to error reporting
+  }
+  const errors = [...Value.Errors(schema, raw)]
+    .slice(0, 3)
+    .map((e) => `${e.instancePath || '/'}: ${e.message}`)
+    .join('; ');
+  return { ok: false, error: errors || 'output did not match schema' };
+}
+
+/**
+ * Resolve a bare resource name under the agent dir to a contained absolute
+ * path, or null if the name could escape. Untrusted config (e.g. project-local
+ * config files) must never smuggle path separators or '..' into a path handed
+ * to a child's loader.
+ */
+export function resolveContainedAgentResource(
+  kind: 'extensions' | 'skills',
+  name: string,
+  leaf: string,
+): string | null {
+  if (typeof name !== 'string' || name.length === 0) return null;
+  if (name.includes('/') || name.includes('\\') || name === '..' || name === '.') return null;
+  const baseDir = path.join(getAgentDir(), kind);
+  const resolved = path.resolve(baseDir, name, leaf);
+  if (!resolved.startsWith(path.resolve(baseDir) + path.sep)) return null;
+  return resolved;
+}
+
+// ── Runtime ────────────────────────────────────────────────────────────────
+
+export function createSubagentRuntime(options: { namespace: string; maxConcurrent?: number }): SubagentRuntime {
+  const namespace = options.namespace;
+  const maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  const toolNamespace = namespace.replace(/[^a-zA-Z0-9]/g, '_');
+
+  const runs: RunRecord[] = [];
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  let modelRuntimePromise: Promise<ModelRuntime> | undefined;
+
+  function modelRuntime(): Promise<ModelRuntime> {
+    modelRuntimePromise ??= ModelRuntime.create();
+    return modelRuntimePromise;
+  }
+
+  function acquire(): Promise<void> {
+    if (active < maxConcurrent) {
+      active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => waiters.push(resolve));
+  }
+
+  function release(): void {
+    active--;
+    const next = waiters.shift();
+    if (next) {
+      active++;
+      next();
+    }
+  }
+
+  function recordRun(record: RunRecord): void {
+    runs.unshift(record);
+    if (runs.length > MAX_RETAINED_RUNS) runs.length = MAX_RETAINED_RUNS;
+  }
+
+  async function spawn(opts: SpawnOptions): Promise<SpawnResult> {
+    const runId = randomUUID();
+    const startedAt = Date.now();
+    const record: RunRecord = {
+      runId,
+      namespace,
+      status: 'queued',
+      promptPreview: opts.prompt.replace(/\s+/g, ' ').trim().slice(0, 80),
+      startedAt,
+    };
+    if (opts.agent) record.agent = opts.agent;
+    if (opts.model) record.model = opts.model;
+    recordRun(record);
+
+    // Ecosystem recursion guard — honored, not namespaced. See header.
+    if (process.env.PI_SUBAGENT_DEPTH || process.env.PI_SUBAGENT_CHILD) {
+      const result = fail(
+        runId,
+        'crashed',
+        'Refusing to spawn: PI_SUBAGENT_DEPTH/PI_SUBAGENT_CHILD present (nested orchestration is an ecosystem-level guard).',
+        startedAt,
+      );
+      record.status = 'failed';
+      record.endedAt = Date.now();
+      record.error = result.error;
+      return result;
+    }
+
+    if (
+      opts.thinkingLevel !== undefined &&
+      !THINKING_LEVELS.includes(opts.thinkingLevel as (typeof THINKING_LEVELS)[number])
+    ) {
+      const result = fail(
+        runId,
+        'crashed',
+        `Invalid thinkingLevel ${JSON.stringify(opts.thinkingLevel)}; expected one of ${THINKING_LEVELS.join(', ')}.`,
+        startedAt,
+      );
+      record.status = 'failed';
+      record.endedAt = Date.now();
+      record.error = result.error;
+      return result;
+    }
+
+    await acquire();
+    record.status = 'running';
+    try {
+      return await runChild(runId, opts, startedAt, record);
+    } finally {
+      release();
+    }
+  }
+
+  async function runChild(
+    runId: string,
+    opts: SpawnOptions,
+    startedAt: number,
+    record: RunRecord,
+  ): Promise<SpawnResult> {
+    const cwd = opts.cwd ?? process.cwd();
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    // Supervisor channel: a closure tool, not a protocol.
+    const customTools = [];
+    let supervisorToolName: string | undefined;
+    if (opts.onSupervisorRequest) {
+      const handler = opts.onSupervisorRequest;
+      supervisorToolName = `${toolNamespace}_contact_supervisor`;
+      customTools.push(
+        defineTool({
+          name: supervisorToolName,
+          label: 'Contact Supervisor',
+          description:
+            'Contact the parent/supervisor session for a decision, clarification, or progress update. The reply arrives as the tool result.',
+          parameters: Type.Object({
+            message: Type.String({ description: 'What you need from the supervisor' }),
+            reason: Type.Optional(Type.String({ description: 'e.g. need_decision, progress_update' })),
+          }),
+          execute: async (_id, params) => {
+            const request: SupervisorRequest = { message: params.message };
+            if (params.reason !== undefined) request.reason = params.reason;
+            const reply = await handler(request);
+            return { content: [{ type: 'text' as const, text: String(reply) }], details: {} };
+          },
+        }),
+      );
+    }
+
+    // Tool allowlist: undefined → pi defaults; array → exactly those (+ supervisor tool).
+    let tools: string[] | undefined;
+    if (opts.tools !== undefined) {
+      tools = [...opts.tools];
+      if (supervisorToolName && !tools.includes(supervisorToolName)) tools.push(supervisorToolName);
+    }
+
+    const runtime = await modelRuntime();
+
+    let model: ReturnType<typeof resolveCliModel>['model'];
+    let thinkingLevel = opts.thinkingLevel;
+    if (opts.model !== undefined) {
+      const resolved = resolveCliModel({ cliModel: opts.model, modelRuntime: runtime });
+      if (resolved.error || !resolved.model) {
+        const result = fail(runId, 'crashed', resolved.error ?? `Unknown model: ${opts.model}`, startedAt);
+        record.status = 'failed';
+        record.endedAt = Date.now();
+        record.error = result.error;
+        return result;
+      }
+      model = resolved.model;
+      thinkingLevel ??= resolved.thinkingLevel;
+    }
+
+    const loader = new DefaultResourceLoader({
+      cwd,
+      agentDir: getAgentDir(),
+      settingsManager: SettingsManager.inMemory(),
+      noExtensions: true,
+      noSkills: true,
+      noPromptTemplates: true,
+      noThemes: true,
+      noContextFiles: !opts.includeContextFiles,
+      additionalExtensionPaths: opts.extensionPaths ?? [],
+      additionalSkillPaths: opts.skillPaths ?? [],
+      ...(opts.systemPrompt !== undefined
+        ? opts.replaceSystemPrompt
+          ? { systemPrompt: opts.systemPrompt }
+          : { appendSystemPrompt: [opts.systemPrompt] }
+        : {}),
+    });
+    await loader.reload();
+
+    const { session } = await createAgentSession({
+      cwd,
+      agentDir: getAgentDir(),
+      modelRuntime: runtime,
+      ...(model !== undefined ? { model } : {}),
+      ...(thinkingLevel !== undefined ? { thinkingLevel: thinkingLevel as never } : {}),
+      ...(tools !== undefined ? { tools } : {}),
+      customTools,
+      resourceLoader: loader,
+      sessionManager: SessionManager.inMemory(cwd),
+      settingsManager: SettingsManager.inMemory(),
+    });
+
+    let abortedBy: 'signal' | 'timeout' | undefined;
+    const onSignalAbort = () => {
+      abortedBy = 'signal';
+      void session.abort();
+    };
+    if (opts.signal) {
+      if (opts.signal.aborted) onSignalAbort();
+      else opts.signal.addEventListener('abort', onSignalAbort, { once: true });
+    }
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            abortedBy = 'timeout';
+            void session.abort();
+          }, timeoutMs)
+        : undefined;
+
+    let promptError: unknown;
+    try {
+      await session.prompt(opts.prompt);
+    } catch (err) {
+      promptError = err;
+    } finally {
+      if (timer) clearTimeout(timer);
+      opts.signal?.removeEventListener('abort', onSignalAbort);
+    }
+
+    const messages = session.messages as readonly any[];
+    const text = lastAssistantText(messages);
+    const usage = sumUsage(messages);
+    const stateError = session.agent.state.errorMessage;
+    session.dispose();
+
+    const durationMs = Date.now() - startedAt;
+    record.endedAt = Date.now();
+    record.usage = usage;
+
+    const finish = (result: SpawnResult): SpawnResult => {
+      if (result.ok) {
+        record.status = 'completed';
+      } else {
+        record.status = result.kind === 'aborted' ? 'aborted' : 'failed';
+        record.error = result.error;
+      }
+      return result;
+    };
+
+    if (abortedBy) {
+      return finish({
+        ok: false,
+        runId,
+        kind: 'aborted',
+        error: abortedBy === 'timeout' ? `Timed out after ${timeoutMs}ms` : 'Aborted by caller',
+        text,
+        usage,
+        durationMs,
+      });
+    }
+    if (promptError) {
+      return finish({
+        ok: false,
+        runId,
+        kind: 'crashed',
+        error: promptError instanceof Error ? promptError.message : String(promptError),
+        text,
+        usage,
+        durationMs,
+      });
+    }
+    if (!text) {
+      return finish({
+        ok: false,
+        runId,
+        kind: 'empty',
+        error: stateError ? `Child produced no output (session error: ${stateError})` : 'Child produced no output',
+        text: '',
+        usage,
+        durationMs,
+      });
+    }
+    if (opts.outputSchema) {
+      const parsed = extractJson(text);
+      if (!parsed.ok) {
+        return finish({
+          ok: false,
+          runId,
+          kind: 'schema_invalid',
+          error: 'Final message did not contain parseable JSON',
+          text,
+          usage,
+          durationMs,
+        });
+      }
+      const validated = validateOutput(opts.outputSchema, parsed.value);
+      if (!validated.ok) {
+        return finish({ ok: false, runId, kind: 'schema_invalid', error: validated.error, text, usage, durationMs });
+      }
+      return finish({ ok: true, runId, text, data: validated.data, usage, durationMs });
+    }
+    return finish({ ok: true, runId, text, usage, durationMs });
+  }
+
+  return {
+    namespace,
+    spawn,
+    listRuns: () => runs.map((r) => ({ ...r })),
+    activeCount: () => active,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,11 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
-  packages/shared: {}
+  packages/shared:
+    dependencies:
+      typebox:
+        specifier: ^1.1.0
+        version: 1.3.7
 
   packages/spinner: {}
 


### PR DESCRIPTION
## What

Adds `packages/shared/subagents.ts`: an in-process subagent runtime for pi extensions — `createSubagentRuntime({ namespace })` → `spawn(options)` — that spawns hermetic child agent sessions through pi's SDK (`createAgentSession`). No subprocesses, no dependency on pi-subagents.

Because pi's extension loader aliases `@earendil-works/*` imports to the running host, children are version-matched to the pi that loaded the extension by construction.

## Design rules baked in

- **Hermetic children** — no user extensions/skills/prompts/themes/context files unless explicitly requested (`extensionPaths`, `skillPaths`, `includeContextFiles`)
- **Tool scoping by construction** — children get exactly the allowlist; no spawn capability exists as a tool, so children can't spawn children
- **Never rejects** — discriminated result union `ok | crashed | empty | schema_invalid | aborted`; `schema_invalid` (bad JSON) is distinct from a schema-valid answer reporting failure
- **Supervisor channel is a closure** — `onSupervisorRequest` gives the child a `<namespace>_contact_supervisor` tool wired to the parent handler; no filesystem protocol
- **Ecosystem recursion guard** — spawning refused when `PI_SUBAGENT_DEPTH`/`PI_SUBAGENT_CHILD` are set
- **Run registry + concurrency cap** — `listRuns()`, `activeCount()`, `maxConcurrent` (default 4)
- **`outputSchema`** — TypeBox validation of the final message (fences stripped, Clean+Convert normalization, first 3 errors reported)
- Also exports `resolveContainedAgentResource` (containment-checked bare-name resolution for untrusted config)

## Verification

- Spike-proven before implementation (hermetic loader, tool scoping, supervisor round-trip, streaming, ~2ms abort, model/auth inheritance against pi 0.84.1)
- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build` all green
- Live end-to-end smoke test via the llm-council consumer (see the PR stacked above)

## Notes

- `typebox` added as a runtime dependency of shared (matches llm-council's existing pattern; aliased to pi's bundled copy at load time)
- The full platform roadmap this is phase 1 of is tracked in #20