### PR TITLE
feat(llm-council): spawn council sessions via shared subagent runtime

### DIFF
--- a/.changeset/council-shared-runtime.md
+++ b/.changeset/council-shared-runtime.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-llm-council': minor
+---
+
+Spawn council members and the chairman through `@nicknisi/pi-shared`'s in-process subagent runtime instead of headless `pi` subprocesses. Behavior changes: children are hermetic — `extensions: null` / `skills: null` no longer inherit ambient resources (both mean "none"; named resources still load, containment-checked); member text is the child's final assistant message rather than a concatenation of all assistant messages (fixes wrong output when members use tools); spawning is refused inside pi-subagents child sessions (`PI_SUBAGENT_DEPTH`/`PI_SUBAGENT_CHILD`).

--- a/packages/llm-council/README.md
+++ b/packages/llm-council/README.md
@@ -1,6 +1,6 @@
 # llm-council
 
-An LLM Council tool for pi: multiple models answer the same question independently, in parallel, as headless `pi` subprocesses, then a chairman model synthesizes their (anonymized) answers into one unified response. Useful for questions that benefit from multiple perspectives or cross-checking — divergent answers flag uncertainty. Not for simple factual questions or routine tasks. Progress streams inline in the tool result with animated spinners, per-member status, and elapsed times; expanding the result shows the full markdown of every member response plus the chairman's synthesis.
+An LLM Council tool for pi: multiple models answer the same question independently, in parallel, as in-process child agent sessions (via `@nicknisi/pi-shared`'s subagent runtime), then a chairman model synthesizes their (anonymized) answers into one unified response. Useful for questions that benefit from multiple perspectives or cross-checking — divergent answers flag uncertainty. Not for simple factual questions or routine tasks. Progress streams inline in the tool result with animated spinners, per-member status, and elapsed times; expanding the result shows the full markdown of every member response plus the chairman's synthesis.
 
 ## Install
 
@@ -23,32 +23,30 @@ Prompt guidance registered with the tool tells the agent to use it for complex q
 
 ## How it works
 
-1. **Members** — each council member receives the same question and answers independently, in parallel (`Promise.all`). Each runs as `pi --mode json -p --no-session --model <model> ... <question>`; assistant text is collected from `message_end` JSON events on stdout.
+1. **Members** — each council member receives the same question and answers independently, in parallel (`Promise.all`). Each runs as a hermetic in-process child session spawned through pi's SDK (`createAgentSession`), shared via `@nicknisi/pi-shared`'s `createSubagentRuntime`; the answer is the child's final assistant message.
 2. **Chairman** — receives the question plus all successful member answers (labeled Member A/B/C) and synthesizes a unified answer. If `chairman.exposePersonas` is `true`, each member's system prompt is included as `(persona: "...")`. The chairman's text is the tool's final content.
 3. If every member fails, the tool returns an error result; the chairman never runs. If the chairman fails, its error text is returned.
 
-### Exec config → subprocess flags
+### Exec config → spawn options
 
-The `tools` / `thinking` / `extensions` / `skills` / `contextFiles` options on `member` and `chairman` map to pi CLI flags (`buildExecArgs` in `index.ts`):
+The `tools` / `thinking` / `extensions` / `skills` / `contextFiles` options on `member` and `chairman` map onto the shared runtime's spawn options:
 
-| Option         | Value       | Flags emitted                                                              |
-| -------------- | ----------- | -------------------------------------------------------------------------- |
-| `tools`        | `null`/`[]` | `--no-tools`                                                               |
-| `tools`        | `[...]`     | `--tools <comma-joined>`                                                   |
-| `thinking`     | `null`      | _(none)_                                                                   |
-| `thinking`     | `"..."`     | `--thinking <level>`                                                       |
-| `extensions`   | `null`      | _(none — pi defaults)_                                                     |
-| `extensions`   | `[]`        | `--no-extensions`                                                          |
-| `extensions`   | `[name]`    | `--no-extensions -e ~/.pi/agent/extensions/<name>/src/index.ts` (per name) |
-| `skills`       | `null`      | _(none)_                                                                   |
-| `skills`       | `[]`        | `--no-skills`                                                              |
-| `skills`       | `[name]`    | `--no-skills --skill ~/.pi/agent/skills/<name>/SKILL.md` (per name)        |
-| `contextFiles` | `false`     | `--no-context-files`                                                       |
-| `contextFiles` | `true`      | _(none)_                                                                   |
+| Option         | Value       | Effect                                                                            |
+| -------------- | ----------- | --------------------------------------------------------------------------------- |
+| `tools`        | `null`/`[]` | No tools                                                                          |
+| `tools`        | `[...]`     | Exactly those built-in tools (allowlist)                                          |
+| `thinking`     | `null`      | _(pi default)_                                                                    |
+| `thinking`     | `"..."`     | Thinking level (`off`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`)              |
+| `extensions`   | `null`/`[]` | _(none — children are hermetic)_                                                  |
+| `extensions`   | `[name]`    | Load `~/.pi/agent/extensions/<name>/src/index.ts` (per name, containment-checked) |
+| `skills`       | `null`/`[]` | _(none — children are hermetic)_                                                  |
+| `skills`       | `[name]`    | Load `~/.pi/agent/skills/<name>/SKILL.md` (per name, containment-checked)         |
+| `contextFiles` | `false`     | No AGENTS.md / project context files                                              |
+| `contextFiles` | `true`      | Context files load                                                                |
 
-Per-member system prompts are passed via `--append-system-prompt <tmpfile>` — written to a `pi-council-*` dir under `os.tmpdir()` with mode `0600`, deleted after the run.
+> **Behavior change from the subprocess era:** `extensions: null` / `skills: null` used to mean "inherit pi defaults" (ambient extensions/skills loaded into the child). Children are now hermetic by construction — `null` and `[]` both mean _none_; only explicitly named resources load.
 
-Subprocesses run with `PI_SUBAGENT_DEPTH=1`; any member/chairman attempt while that var is set throws `Subagents cannot spawn further subprocesses`, so councils can't recurse.
+System prompts are appended to pi's default system prompt through the child's resource loader (no temp files). The runtime honors the ecosystem recursion guard: when `PI_SUBAGENT_DEPTH`/`PI_SUBAGENT_CHILD` are set (i.e. the council itself is running inside a pi-subagents child), spawns are refused with a typed `crashed` result.
 
 ## Default council
 
@@ -90,7 +88,7 @@ No environment variables are read for configuration. (`PI_SUBAGENT_DEPTH` is set
 | `defaultSystemPrompt` | `string`           | _(built-in; see `config.ts`)_ | System prompt for members without their own. The built-in default forbids spawning subprocesses                   |
 | `display.labelColor`  | `string`           | `"accent"`                    | Member label color                                                                                                |
 | `display.modelColor`  | `string`           | `"dim"`                       | Model name color                                                                                                  |
-| `tools`               | `string[] \| null` | `["read","grep","find","ls"]` | Tool set for member subprocesses (`null`/`[]` → `--no-tools`)                                                     |
+| `tools`               | `string[] \| null` | `["read","grep","find","ls"]` | Tool allowlist for member child sessions (`null`/`[]` → no tools)                                                 |
 | `thinking`            | `string \| null`   | `"medium"`                    | Thinking level (`null` → pi default)                                                                              |
 | `extensions`          | `string[] \| null` | `[]`                          | Extension names, resolved to `~/.pi/agent/extensions/<name>/src/index.ts` (`null` → pi defaults)                  |
 | `skills`              | `string[] \| null` | `[]`                          | Skill names, resolved to `~/.pi/agent/skills/<name>/SKILL.md` (`null` → pi defaults)                              |
@@ -107,7 +105,7 @@ No environment variables are read for configuration. (`PI_SUBAGENT_DEPTH` is set
 | `display.icon`       | `string`           | `""`                          | Icon prefix before the "Chairman" label                            |
 | `display.labelColor` | `string`           | `"accent"`                    | Chairman label color                                               |
 | `display.modelColor` | `string`           | `"dim"`                       | Chairman model name color                                          |
-| `tools`              | `string[] \| null` | `[]`                          | Chairman tools (none by default → `--no-tools`)                    |
+| `tools`              | `string[] \| null` | `[]`                          | Chairman tool allowlist (none by default)                          |
 | `thinking`           | `string \| null`   | `"medium"`                    | Thinking level                                                     |
 | `extensions`         | `string[] \| null` | `[]`                          | Extensions (`null` → pi defaults)                                  |
 | `skills`             | `string[] \| null` | `[]`                          | Skills (`null` → pi defaults)                                      |
@@ -143,14 +141,14 @@ Any color field accepts a pi theme token (`"text"`, `"accent"`, `"success"`, `"e
 - `@earendil-works/pi-coding-agent` (peer) — `ExtensionAPI` (`pi.registerTool`), `Theme`/`ThemeColor`, `getMarkdownTheme`.
 - `@earendil-works/pi-tui` (peer) — `Markdown` and `Text` render components, `getKeybindings` (for the expand-hint key label).
 - `typebox` — tool parameter schema (`Type.Object`).
-- No workspace deps (no `@nicknisi/pi-shared`). Requires the `pi` binary on `PATH` (or the current `process.argv[1]` script) to spawn member/chairman subprocesses.
+- `@nicknisi/pi-shared` (workspace) — the in-process subagent runtime (`createSubagentRuntime`) that members and the chairman spawn through.
+- No `pi` binary requirement: children are in-process SDK sessions, not subprocesses.
 
 ## Caveats
 
 - **Extension resolution path is hardcoded.** `extensions: ["name"]` resolves to `~/.pi/agent/extensions/<name>/src/index.ts` — only directory-style extensions with that layout work. Single-file `.ts` extensions and npm-package extensions don't match; the code comments recommend keeping `extensions: []` for members. Same for `skills` → `~/.pi/agent/skills/<name>/SKILL.md`.
-- **Depends on pi's headless CLI contract:** flags `--mode json -p --no-session --model --tools/--no-tools --thinking --no-extensions/-e --no-skills/--skill --no-context-files --append-system-prompt`, and the `message_end` event shape in `--mode json` stdout (`event.message.role === "assistant"`, `content[]` parts with `type: "text"`). A pi version that changes any of these breaks the tool.
+- **Depends on pi's SDK surface:** `createAgentSession`, `DefaultResourceLoader` (its `noExtensions`/`additionalExtensionPaths` semantics), `SessionManager.inMemory`, `SettingsManager.inMemory`, `ModelRuntime`/`resolveCliModel`. These are pi internals that could change across versions; the runtime is version-matched at runtime because pi aliases `@earendil-works/*` imports to the host, but type-level drift would surface at extension load.
 - **Pi internals:** the spinner relies on the `renderCall`/`renderResult` `ctx.state` bag and `ctx.invalidate()`. A module-level `liveDetails` bridges `onUpdate` → `renderCall` as a workaround for an `isPartial` bug (per code comment); only one council can render live at a time.
-- **Subprocess detection:** re-invokes pi via `process.argv[1]` when it exists on disk and isn't a bun virtual script (`/$bunfs/root/...`); if the executable is a renamed non-`node`/`bun` binary it runs that directly, otherwise falls back to `pi` on `PATH`.
-- **Recursion guard:** members/chairman run with `PI_SUBAGENT_DEPTH=1` and refuse to spawn when it's set — this tool won't work if invoked from inside a pi subprocess that already set that var.
+- **Recursion guard:** the shared runtime refuses to spawn when `PI_SUBAGENT_DEPTH`/`PI_SUBAGENT_CHILD` are set — this tool won't work if invoked from inside a pi-subagents child session.
 - Global config is read **once at module load** — edits to `~/.pi/agent/configs/llm-council.json` require a pi restart; project-local config is re-read on every tool call.
 - Members and chairman run with the current working directory as `cwd`; `contextFiles: false` keeps CLAUDE.md/AGENTS.md out of member context by default.

--- a/packages/llm-council/index.ts
+++ b/packages/llm-council/index.ts
@@ -11,13 +11,11 @@
  * ~/.pi/agent/configs/llm-council.json
  */
 
-import { spawn } from 'node:child_process';
-import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtensionAPI, Theme } from '@earendil-works/pi-coding-agent';
-import { getAgentDir, getMarkdownTheme } from '@earendil-works/pi-coding-agent';
+import { getMarkdownTheme } from '@earendil-works/pi-coding-agent';
 import { Markdown, Text } from '@earendil-works/pi-tui';
+import { createSubagentRuntime, resolveContainedAgentResource, type SubagentRuntime } from '@nicknisi/pi-shared';
 import { Type } from 'typebox';
 import { CONFIG, loadCouncil, type ResolvedCouncil } from './config.js';
 import { applyColor, formatElapsed, getExpandToggleKey, getVisibleWidth } from './utils.js';
@@ -263,246 +261,41 @@ interface CouncilDetails {
   };
 }
 
-interface SubagentResult {
-  text: string;
-  exitCode: number;
-  stderr: string;
-  error?: string;
-}
-
-interface ExecConfig {
-  tools: string[] | null;
-  thinking: string | null;
-  extensions: string[] | null;
-  skills: string[] | null;
-  contextFiles: boolean;
-}
-
-// ── Subprocess ───────────────────────────────────────────────────────────
-
 // Council `extensions`/`skills` entries are bare resource names resolved under
 // the user's own agent dir. Project-local config (<cwd>/.pi/configs/llm-council.json)
-// is untrusted repository input, so a name must never contain path separators or
-// `..` segments: otherwise `path.join` collapses a crafted name into an arbitrary
-// filesystem path passed to pi as `-e`/`--skill`, loading repo-controlled code
-// outside pi's project-trust gate. Reject anything that isn't a contained bare name.
-function resolveContainedResourcePath(kind: 'extensions' | 'skills', name: string, leaf: string): string | null {
-  if (typeof name !== 'string' || name.length === 0) return null;
-  if (name.includes('/') || name.includes('\\') || name === '..' || name === '.') return null;
-  const baseDir = path.join(getAgentDir(), kind);
-  const resolved = path.resolve(baseDir, name, leaf);
-  const containmentRoot = path.resolve(baseDir) + path.sep;
-  if (!resolved.startsWith(containmentRoot)) return null;
-  return resolved;
-}
-
-function buildExecArgs(exec: ExecConfig): string[] {
-  const args: string[] = [];
-
-  // tools: null/[] → --no-tools, [items] → --tools <comma-separated>
-  if (!exec.tools || exec.tools.length === 0) {
-    args.push('--no-tools');
-  } else {
-    args.push('--tools', exec.tools.join(','));
-  }
-
-  // thinking: null → omit, string → --thinking <level>
-  if (exec.thinking) {
-    args.push('--thinking', exec.thinking);
-  }
-
-  // extensions: null → no flags, [] → --no-extensions, [items] → --no-extensions -e <path>...
-  if (exec.extensions === null) {
-    // keep defaults, no flags
-  } else if (exec.extensions.length === 0) {
-    args.push('--no-extensions');
-  } else {
-    args.push('--no-extensions');
-    for (const name of exec.extensions) {
-      const extPath = resolveContainedResourcePath('extensions', name, path.join('src', 'index.ts'));
-      if (extPath === null) {
-        console.error(
-          `[llm-council] ignoring extension ${JSON.stringify(name)}: names must be bare (no path separators or "..")`,
-        );
-        continue;
-      }
-      args.push('-e', extPath);
+// is untrusted repository input, so names are containment-checked by the shared
+// resolver before reaching the child's resource loader.
+function resolveResourceNames(kind: 'extensions' | 'skills', names: string[] | null, leaf: string): string[] {
+  if (!names?.length) return [];
+  const out: string[] = [];
+  for (const name of names) {
+    const resolved = resolveContainedAgentResource(kind, name, leaf);
+    if (resolved === null) {
+      console.error(
+        `[llm-council] ignoring ${kind} ${JSON.stringify(name)}: names must be bare (no path separators or "..")`,
+      );
+      continue;
     }
+    out.push(resolved);
   }
-
-  // skills: null → no flags, [] → --no-skills, [items] → --no-skills --skill <path>...
-  if (exec.skills === null) {
-    // keep defaults, no flags
-  } else if (exec.skills.length === 0) {
-    args.push('--no-skills');
-  } else {
-    args.push('--no-skills');
-    for (const name of exec.skills) {
-      const skillPath = resolveContainedResourcePath('skills', name, 'SKILL.md');
-      if (skillPath === null) {
-        console.error(
-          `[llm-council] ignoring skill ${JSON.stringify(name)}: names must be bare (no path separators or "..")`,
-        );
-        continue;
-      }
-      args.push('--skill', skillPath);
-    }
-  }
-
-  // contextFiles: false → --no-context-files, true → omit flag
-  if (exec.contextFiles === false) {
-    args.push('--no-context-files');
-  }
-
-  return args;
-}
-
-function getPiInvocation(args: string[]): { command: string; args: string[] } {
-  const currentScript = process.argv[1];
-  const isBunVirtualScript = currentScript?.startsWith('/$bunfs/root/');
-  if (currentScript && !isBunVirtualScript && fs.existsSync(currentScript)) {
-    return { command: process.execPath, args: [currentScript, ...args] };
-  }
-  const execName = path.basename(process.execPath).toLowerCase();
-  const isGenericRuntime = /^(node|bun)(\.exe)?$/.test(execName);
-  if (!isGenericRuntime) {
-    return { command: process.execPath, args };
-  }
-  return { command: 'pi', args };
-}
-
-async function runSubagent(
-  model: string,
-  prompt: string,
-  systemPrompt: string | undefined,
-  cwd: string,
-  execConfig: ExecConfig,
-  signal?: AbortSignal,
-): Promise<SubagentResult> {
-  const baseArgs: string[] = ['--mode', 'json', '-p', '--no-session', '--model', model];
-  const execArgs = buildExecArgs(execConfig);
-  const args: string[] = [...baseArgs, ...execArgs];
-
-  let tmpDir: string | null = null;
-  let tmpFile: string | null = null;
-
-  try {
-    if (systemPrompt) {
-      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-council-'));
-      tmpFile = path.join(tmpDir, 'system-prompt.md');
-      fs.writeFileSync(tmpFile, systemPrompt, { mode: 0o600 });
-      args.push('--append-system-prompt', tmpFile);
-    }
-
-    if (process.env.PI_SUBAGENT_DEPTH) {
-      throw new Error('Subagents cannot spawn further subprocesses');
-    }
-
-    args.push(prompt);
-
-    const result: SubagentResult = { text: '', exitCode: 0, stderr: '' };
-
-    result.exitCode = await new Promise<number>((resolve) => {
-      const invocation = getPiInvocation(args);
-      const proc = spawn(invocation.command, invocation.args, {
-        cwd,
-        shell: false,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        env: { ...process.env, PI_SUBAGENT_DEPTH: '1' },
-      });
-
-      let buffer = '';
-
-      const processLine = (line: string) => {
-        if (!line.trim()) return;
-        let event: any;
-        try {
-          event = JSON.parse(line);
-        } catch {
-          return;
-        }
-        if (event.type === 'message_end' && event.message) {
-          const msg = event.message;
-          if (msg.role === 'assistant') {
-            for (const part of msg.content) {
-              if (part.type === 'text') {
-                result.text += part.text;
-              }
-            }
-          }
-        }
-      };
-
-      proc.stdout.on('data', (data: Buffer) => {
-        buffer += data.toString();
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) processLine(line);
-      });
-
-      proc.stderr.on('data', (data: Buffer) => {
-        result.stderr += data.toString();
-      });
-
-      proc.on('close', (code) => {
-        if (buffer.trim()) processLine(buffer);
-        resolve(code ?? 0);
-      });
-
-      proc.on('error', () => {
-        resolve(1);
-      });
-
-      if (signal) {
-        const killProc = () => {
-          proc.kill('SIGTERM');
-          setTimeout(() => {
-            if (!proc.killed) proc.kill('SIGKILL');
-          }, 5000);
-        };
-        if (signal.aborted) killProc();
-        else signal.addEventListener('abort', killProc, { once: true });
-      }
-    });
-
-    if (result.exitCode !== 0 && !result.text && result.stderr) {
-      result.error = result.stderr.split('\n').filter(Boolean).pop() || 'Process failed';
-    }
-
-    return result;
-  } finally {
-    if (tmpFile) {
-      try {
-        fs.unlinkSync(tmpFile);
-      } catch {
-        /* ignore */
-      }
-    }
-    if (tmpDir) {
-      try {
-        fs.rmdirSync(tmpDir);
-      } catch {
-        /* ignore */
-      }
-    }
-  }
+  return out;
 }
 
 // ── Council logic ─────────────────────────────────────────────────────────
 
 async function runCouncil(
+  subagents: SubagentRuntime,
   question: string,
   cwd: string,
   council: ResolvedCouncil,
   signal: AbortSignal | undefined,
   onUpdate: (details: CouncilDetails) => void,
 ): Promise<{ content: { type: 'text'; text: string }[]; details: CouncilDetails }> {
-  const memberExecConfig: ExecConfig = {
-    tools: council.member.tools,
-    thinking: council.member.thinking,
-    extensions: council.member.extensions,
-    skills: council.member.skills,
-    contextFiles: council.member.contextFiles,
+  const memberSpawn = {
+    tools: council.member.tools ?? [],
+    extensionPaths: resolveResourceNames('extensions', council.member.extensions, path.join('src', 'index.ts')),
+    skillPaths: resolveResourceNames('skills', council.member.skills, 'SKILL.md'),
+    includeContextFiles: council.member.contextFiles,
   };
 
   const details: CouncilDetails = {
@@ -532,8 +325,17 @@ async function runCouncil(
     m.status = 'working';
     m.startedAt = Date.now();
     emit();
-    const result = await runSubagent(m.model, question, m.systemPrompt, cwd, memberExecConfig, signal);
-    if (result.exitCode === 0 && result.text) {
+    const result = await subagents.spawn({
+      agent: `member-${m.label}`,
+      model: m.model,
+      prompt: question,
+      systemPrompt: m.systemPrompt,
+      cwd,
+      ...(signal ? { signal } : {}),
+      ...(council.member.thinking ? { thinkingLevel: council.member.thinking } : {}),
+      ...memberSpawn,
+    });
+    if (result.ok) {
       m.status = 'done';
       m.doneAt = Date.now();
       m.text = result.text;
@@ -582,24 +384,21 @@ async function runCouncil(
   }
   chairmanPrompt += '\n---\nSynthesize a unified answer incorporating the best points from each response.';
 
-  const chairmanExecConfig: ExecConfig = {
-    tools: council.chairman.tools,
-    thinking: council.chairman.thinking,
-    extensions: council.chairman.extensions,
-    skills: council.chairman.skills,
-    contextFiles: council.chairman.contextFiles,
-  };
-
-  const chairmanResult = await runSubagent(
-    council.chairman.model,
-    chairmanPrompt,
-    council.chairman.systemPrompt,
+  const chairmanResult = await subagents.spawn({
+    agent: 'chairman',
+    model: council.chairman.model,
+    prompt: chairmanPrompt,
+    systemPrompt: council.chairman.systemPrompt,
     cwd,
-    chairmanExecConfig,
-    signal,
-  );
+    ...(signal ? { signal } : {}),
+    ...(council.chairman.thinking ? { thinkingLevel: council.chairman.thinking } : {}),
+    tools: council.chairman.tools ?? [],
+    extensionPaths: resolveResourceNames('extensions', council.chairman.extensions, path.join('src', 'index.ts')),
+    skillPaths: resolveResourceNames('skills', council.chairman.skills, 'SKILL.md'),
+    includeContextFiles: council.chairman.contextFiles,
+  });
 
-  if (chairmanResult.exitCode === 0 && chairmanResult.text) {
+  if (chairmanResult.ok) {
     chairman.status = 'done';
     chairman.doneAt = Date.now();
     chairman.text = chairmanResult.text;
@@ -626,6 +425,7 @@ let liveDetails: CouncilDetails | null = null;
 // ── Tool registration ────────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+  const subagents = createSubagentRuntime({ namespace: 'llm-council' });
   pi.registerTool({
     name: 'llm_council',
     label: 'LLM Council',
@@ -646,7 +446,7 @@ export default function (pi: ExtensionAPI) {
 
     async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const council = loadCouncil(ctx.cwd);
-      return runCouncil(params.question, ctx.cwd, council, signal, (details) => {
+      return runCouncil(subagents, params.question, ctx.cwd, council, signal, (details) => {
         liveDetails = details;
         const stageLabels: Record<string, string> = {
           members: CONFIG.shared.status.waitingLabel,

--- a/packages/llm-council/package.json
+++ b/packages/llm-council/package.json
@@ -32,6 +32,7 @@
     }
   },
   "dependencies": {
+    "@nicknisi/pi-shared": "workspace:*",
     "typebox": "^1.1.0"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,9 @@ importers:
 
   packages/llm-council:
     dependencies:
+      '@nicknisi/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
       typebox:
         specifier: ^1.1.0
         version: 1.3.7


### PR DESCRIPTION
## What

Refactors llm-council onto the shared subagent runtime from the PR below (`@nicknisi/pi-shared`). Deletes ~250 lines of subprocess machinery: `runSubagent`, `buildExecArgs`, `getPiInvocation`, the temp system-prompt files, and the SIGTERM/SIGKILL dance. Net −274/+81.

## Behavior changes

- **Hermetic children.** Config `extensions: null` / `skills: null` used to mean "inherit pi's ambient resources" — both now mean *none*. Explicitly named resources still load (containment-checked, same as before).
- **Last-message extraction.** Member text is the child's final assistant message instead of a concatenation of every assistant message — the old behavior glued intermediate narration onto the answer when members used tools.
- **Recursion guard inverted.** The council no longer sets `PI_SUBAGENT_DEPTH`; the runtime refuses to spawn when it's *present* (i.e. the council itself is running inside a pi-subagents child).

Config file format, tool name, rendering, and council defaults are unchanged.

## Verification

Live end-to-end runs via `pi -p` with a scratch all-haiku council config: members returned real independent answers, chairman synthesized, tool execution clean. `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build` all green.
Part of the subagent platform roadmap — tracking: #20