### PR TITLE
feat(subagents): add first-party dispatch + fleet extension

### DIFF
--- a/.changeset/platform-package.md
+++ b/.changeset/platform-package.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-subagents': minor
+---
+
+New package: first-party subagent dispatch and fleet. `dispatch` fans out up to 8 hermetic in-process child agents in parallel (per-task prompts, models, tool allowlists, background flag); `fleet` (tool) and `/fleet` (command) inspect live and persisted runs across extensions using the shared runtime. No pi-subagents dependency.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Local paths are added to pi's settings without copying — edits in the repo are
 | [answer](packages/answer/)           | Extracts questions from the last assistant message via a side LLM call, answers them in a tab-through overlay, sends one formatted reply | `/answer`, `ctrl+.`, Q&A overlay             |
 | [btw](packages/btw/)                 | Side-channel LLM chat in a floating window — sees branch context, never touches the main agent's context; promote or fork the thread     | `/btw`, overlay, `btw-answer` entry type     |
 | [handoff](packages/handoff/)         | Transfers context to a new linked session with a model-generated, editable prompt instead of compacting                                  | `/handoff <goal>`                            |
-| [llm-council](packages/llm-council/) | Multiple models answer in parallel as headless pi subprocesses; a chairman synthesizes                                                   | `llm_council` tool with live inline progress |
+| [llm-council](packages/llm-council/) | Multiple models answer in parallel as in-process child sessions; a chairman synthesizes                                                  | `llm_council` tool with live inline progress |
+| [subagents](packages/subagents/)     | First-party subagent dispatch + fleet: fan out parallel hermetic child agents, inspect live/persisted runs — no pi-subagents dependency  | `dispatch` and `fleet` tools, `/fleet`       |
 | [orchestrate](packages/orchestrate/) | `/goal` keeps working until a condition holds; `/loop` re-runs a prompt on a timer                                                       | `/goal`, `/loop`                             |
 | [save-md](packages/save-md/)         | Export the latest assistant response to a markdown file                                                                                  | `/save-md <name>`                            |
 
@@ -54,9 +55,9 @@ Local paths are added to pi's settings without copying — edits in the repo are
 
 ### Library
 
-| Package                    | What it does                                                                                                                                                                                                                                                                           |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [shared](packages/shared/) | `@nicknisi/pi-shared` — helper library (not an extension): `getModelProvider` for one-off LLM calls, TUI utilities (gradient text, tree section removal, two-column layout, escape sanitization, render dispatcher), `SearchableSelectList`. Consumed via `workspace:*` by 6 packages. |
+| Package                    | What it does                                                                                                                                                                                                                                                                                                                                          |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [shared](packages/shared/) | `@nicknisi/pi-shared` — helper library (not an extension): `getModelProvider` for one-off LLM calls, TUI utilities (gradient text, tree section removal, two-column layout, escape sanitization, render dispatcher), `SearchableSelectList`, and the in-process subagent runtime (`createSubagentRuntime`). Consumed via `workspace:*` by 7 packages. |
 
 ## Development
 

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -1,0 +1,52 @@
+# @nicknisi/pi-subagents
+
+First-party subagent dispatch and fleet for pi — fan out parallel child agents and inspect their runs, with **no dependency on pi-subagents**. Children are hermetic in-process agent sessions spawned through `@nicknisi/pi-shared`'s runtime (`createAgentSession` under the hood): fast to start, version-matched to the running pi, and unable to spawn children of their own.
+
+## What it adds
+
+- **`dispatch` tool** (model-facing) — fan out up to 8 child agents in parallel. Each task gets its own prompt, optional label/model/system-prompt, and a tool allowlist (default read-only: `read`, `grep`, `find`, `ls`). Typed per-task results aggregate into one tool result. `background: true` runs detached and surfaces completion via a transcript message.
+- **`fleet` tool** (model-facing) — `list` recent runs (live + persisted, across extensions using the shared runtime) or fetch a `result` by runId. This is how the model checks on background dispatches.
+- **`/fleet` command** — user-facing run table.
+
+## Usage
+
+Ask naturally:
+
+```text
+Dispatch three reviewers: one for correctness, one for tests, one for unnecessary complexity.
+```
+
+```text
+Dispatch a background scout to map the auth module while we keep working.
+```
+
+```text
+Check the fleet for that background run's result.
+```
+
+or directly:
+
+```text
+/fleet
+```
+
+## How it works
+
+`dispatch` maps each task to a `spawn()` call on a shared in-process runtime (`namespace: "subagents"`). Foreground tasks run concurrently (the runtime caps parallelism, default 4) and their results return as the tool output. Background tasks use `spawnDetached()` and report completion via a transcript message.
+
+Every run persists a record to `~/.pi/agent/subagent-runs/subagents/<runId>.json` (status, timing, usage, bounded output). Because pi isolates module state per extension, this directory is the cross-extension fleet view: any extension using `@nicknisi/pi-shared` with the same artifacts root shows up in `/fleet`.
+
+Children are **hermetic by construction**: no user extensions, skills, prompt templates, themes, or `AGENTS.md` context load unless explicitly requested. Tool scoping is likewise by construction — a child receives exactly its allowlist, and no spawn capability exists as a tool, so children cannot recurse. The ecosystem recursion guard (`PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_CHILD`) is honored: inside a pi-subagents child, spawns are refused.
+
+`spawn()` never rejects; results are a discriminated union (`ok | crashed | empty | schema_invalid | aborted`). See `packages/shared/README.md` for the full runtime API.
+
+## Configuration
+
+None. No config files, no environment variables.
+
+## Caveats
+
+- **In-process means no crash isolation.** Children share the parent session's event loop and memory; a pathological child can hurt the host. Untrusted or heavy parallel work should stay on pi-subagents (or a future RPC transport) until this platform grows an isolation option.
+- **Background completion is a notification, not a turn.** The completion message lands in the transcript but doesn't drive the agent — the model learns results when it next acts (or when asked to check `fleet`).
+- **The fleet is per-machine, per-agent-dir.** Records live under `~/.pi/agent/subagent-runs/`; nothing prunes old records yet.
+- Depends on pi SDK internals (`createAgentSession`, `DefaultResourceLoader` flags, `SessionManager.inMemory`) that could change across pi versions — runtime-aliased to the host at load time, but type-level drift would surface at extension load.

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -1,0 +1,236 @@
+/**
+ * First-party subagent dispatch + fleet for pi.
+ *
+ * `dispatch` — model-facing fan-out: run N focused child agents in parallel
+ *   with per-task tool allowlists, models, and prompts; typed results
+ *   aggregate back. Children are hermetic in-process sessions spawned through
+ *   @nicknisi/pi-shared's runtime — no pi-subagents dependency, and children
+ *   cannot themselves spawn.
+ * `fleet` (tool) / `/fleet` (command) — inspect live and persisted runs,
+ *   including background ones. Run records persist to
+ *   <agentDir>/subagent-runs/<namespace>/<runId>.json, so runs from other
+ *   extensions using the shared runtime show up here too.
+ */
+
+import * as path from 'node:path';
+import type { ExtensionAPI, ExtensionCommandContext } from '@earendil-works/pi-coding-agent';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { createSubagentRuntime, readRunArtifacts, type RunArtifact, type SpawnOptions } from '@nicknisi/pi-shared';
+import { Type } from 'typebox';
+
+const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
+const MAX_TASKS = 8;
+const DEFAULT_TOOLS = ['read', 'grep', 'find', 'ls'];
+const MAX_TASK_OUTPUT_CHARS = 4000;
+const MAX_FLEET_LIST = 20;
+
+interface TaskSpec {
+  task: string;
+  agent?: string | undefined;
+  model?: string | undefined;
+  tools?: string[] | undefined;
+  systemPrompt?: string | undefined;
+  background?: boolean | undefined;
+}
+
+function toSpawnOptions(spec: TaskSpec, cwd: string): SpawnOptions {
+  const opts: SpawnOptions = {
+    prompt: spec.task,
+    tools: spec.tools ?? DEFAULT_TOOLS,
+    cwd,
+  };
+  if (spec.agent) opts.agent = spec.agent;
+  if (spec.model) opts.model = spec.model;
+  if (spec.systemPrompt) opts.systemPrompt = spec.systemPrompt;
+  return opts;
+}
+
+function short(text: string, max: number): string {
+  const oneLine = text.replace(/\s+/g, ' ').trim();
+  return oneLine.length <= max ? oneLine : `${oneLine.slice(0, max - 1)}…`;
+}
+
+function formatTokens(usage: { totalTokens: number } | undefined): string {
+  if (!usage) return '';
+  const k = usage.totalTokens / 1000;
+  return `, ${k >= 10 ? Math.round(k) : k.toFixed(1)}k tok`;
+}
+
+function formatSeconds(startedAt: number, endedAt?: number): string {
+  const end = endedAt ?? Date.now();
+  return `${((end - startedAt) / 1000).toFixed(1)}s`;
+}
+
+function formatRunLine(run: RunArtifact): string {
+  const bits = [run.status, formatSeconds(run.startedAt, run.endedAt) + (run.endedAt ? '' : '…')];
+  const tokens = formatTokens(run.usage);
+  return `- ${run.runId.slice(0, 8)} [${run.namespace}]${run.agent ? ` ${run.agent}` : ''} — ${bits.join(', ')}${tokens} · ${short(run.promptPreview, 60)}`;
+}
+
+function collectFleet(live: RunArtifact[]): RunArtifact[] {
+  const byId = new Map<string, RunArtifact>();
+  for (const record of readRunArtifacts(ARTIFACTS_ROOT)) byId.set(record.runId, record);
+  for (const record of live) byId.set(record.runId, record); // live wins over disk
+  return [...byId.values()].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+function postText(pi: ExtensionAPI, ctx: ExtensionCommandContext, text: string) {
+  pi.sendMessage({
+    customType: 'subagents:fleet',
+    content: text,
+    display: true,
+    details: { kind: 'subagents-fleet' },
+  });
+}
+
+function toolResult(text: string, details: Record<string, unknown> = {}) {
+  return { content: [{ type: 'text' as const, text }], details };
+}
+
+export default function subagents(pi: ExtensionAPI) {
+  const runtime = createSubagentRuntime({ namespace: 'subagents', artifactsDir: ARTIFACTS_ROOT });
+
+  pi.registerTool({
+    name: 'dispatch',
+    label: 'Dispatch Subagents',
+    description: [
+      'Fan out focused child agents in parallel: independent research questions, parallel reviews,',
+      'second opinions, or scoped file investigations. Each child runs hermetically (no user',
+      'extensions/skills/context files) with a read-only tool allowlist unless overridden, and',
+      'returns its final answer. Children cannot spawn children. Not for trivial questions or',
+      'sequential work — dispatch only when tasks are independent and parallel.',
+    ].join(' '),
+    promptSnippet: 'Fan out parallel child agents for independent subtasks',
+    promptGuidelines: [
+      `Use dispatch for independent parallel subtasks (max ${MAX_TASKS}); never for sequential work or trivial questions.`,
+      'Children default to read-only tools (read, grep, find, ls). Pass tools explicitly for builders.',
+      'Set background: true for long-running tasks; results surface via the fleet tool.',
+    ],
+    parameters: Type.Object({
+      tasks: Type.Array(
+        Type.Object({
+          task: Type.String({ description: 'The full prompt for this child agent' }),
+          agent: Type.Optional(Type.String({ description: 'Label, e.g. "reviewer"' })),
+          model: Type.Optional(Type.String({ description: 'Model spec, e.g. "anthropic/claude-haiku-4-5"' })),
+          tools: Type.Optional(
+            Type.Array(Type.String(), { description: 'Tool allowlist; default read-only (read, grep, find, ls)' }),
+          ),
+          systemPrompt: Type.Optional(Type.String({ description: 'Appended to the child system prompt' })),
+          background: Type.Optional(Type.Boolean({ description: 'Run detached; check results via the fleet tool' })),
+        }),
+      ),
+    }),
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const specs = params.tasks as TaskSpec[];
+      if (specs.length === 0) {
+        return toolResult('dispatch requires at least one task.');
+      }
+      if (specs.length > MAX_TASKS) {
+        return toolResult(`Too many tasks (${specs.length}); max is ${MAX_TASKS}. Split into multiple dispatch calls.`);
+      }
+
+      const background = specs.filter((s) => s.background);
+      const foreground = specs.filter((s) => !s.background);
+      const lines: string[] = [];
+
+      for (const spec of background) {
+        const { runId, done } = runtime.spawnDetached(toSpawnOptions(spec, ctx.cwd));
+        lines.push(
+          `⏳ ${spec.agent ?? short(spec.task, 40)} — background run ${runId.slice(0, 8)} (check the fleet tool)`,
+        );
+        void done.then((result) => {
+          pi.sendMessage({
+            customType: 'subagents:background',
+            content: `Background subagent ${runId.slice(0, 8)} (${spec.agent ?? 'task'}) ${result.ok ? 'completed' : `failed: ${result.error}`}`,
+            display: true,
+            details: { runId, ok: result.ok },
+          });
+        });
+      }
+
+      if (foreground.length > 0) {
+        const results = await Promise.all(
+          foreground.map((spec) =>
+            runtime.spawn({
+              ...toSpawnOptions(spec, ctx.cwd),
+              ...(signal ? { signal } : {}),
+            }),
+          ),
+        );
+        for (let i = 0; i < results.length; i++) {
+          const result = results[i]!;
+          const spec = foreground[i]!;
+          const label = spec.agent ?? short(spec.task, 40);
+          if (result.ok) {
+            lines.push(
+              `## ✓ ${label} — ${formatSeconds(0, result.durationMs)}${formatTokens(result.usage)}\n\n${result.text.slice(0, MAX_TASK_OUTPUT_CHARS)}`,
+            );
+          } else {
+            lines.push(
+              `## ✗ ${label} — ${result.kind} (${formatSeconds(0, result.durationMs)})\n\n${result.error}${result.text ? `\n\nPartial output:\n${result.text.slice(0, 1000)}` : ''}`,
+            );
+          }
+        }
+      }
+
+      return toolResult(lines.join('\n\n'));
+    },
+  });
+
+  pi.registerTool({
+    name: 'fleet',
+    label: 'Subagent Fleet',
+    description:
+      'Inspect subagent runs: list recent runs (live and persisted, across extensions using the shared runtime) or fetch a specific run result by runId. Use to check background dispatch results.',
+    promptSnippet: 'List or inspect subagent runs',
+    parameters: Type.Object({
+      action: Type.Union([Type.Literal('list'), Type.Literal('result')], {
+        description: 'list runs or fetch one result',
+      }),
+      runId: Type.Optional(Type.String({ description: 'Run id (or unique prefix) for action=result' })),
+    }),
+    async execute(_toolCallId, params) {
+      const live = runtime.listRuns() as RunArtifact[];
+      const all = collectFleet(live);
+      if (params.action === 'list') {
+        if (all.length === 0) return toolResult('No subagent runs found.');
+        const text = all.slice(0, MAX_FLEET_LIST).map(formatRunLine).join('\n');
+        return toolResult(text, { runs: all.slice(0, MAX_FLEET_LIST) });
+      }
+      if (!params.runId) {
+        return toolResult('action=result requires a runId (or prefix).');
+      }
+      const matches = all.filter((r) => r.runId.startsWith(params.runId!));
+      if (matches.length === 0) return toolResult(`No run matches '${params.runId}'.`);
+      if (matches.length > 1) {
+        return toolResult(`Ambiguous runId prefix; matches: ${matches.map((m) => m.runId.slice(0, 8)).join(', ')}`);
+      }
+      const run = matches[0]!;
+      const text = [
+        formatRunLine(run),
+        run.error ? `error: ${run.error}` : undefined,
+        run.output
+          ? `\n${run.output}`
+          : run.status === 'running' || run.status === 'queued'
+            ? '\n(still running — no output yet)'
+            : '\n(no output recorded)',
+      ]
+        .filter(Boolean)
+        .join('\n');
+      return toolResult(text, { run });
+    },
+  });
+
+  pi.registerCommand('fleet', {
+    description: 'Show recent subagent runs (live + persisted, across extensions using the shared runtime)',
+    handler: async (_args, ctx) => {
+      const all = collectFleet(runtime.listRuns() as RunArtifact[]);
+      postText(
+        pi,
+        ctx,
+        all.length === 0 ? 'No subagent runs found.' : all.slice(0, MAX_FLEET_LIST).map(formatRunLine).join('\n'),
+      );
+    },
+  });
+}

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@nicknisi/pi-subagents",
+  "version": "0.0.0",
+  "description": "First-party subagent dispatch and fleet: fan out parallel child agents and inspect their runs — no pi-subagents dependency",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/subagents#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/subagents"
+  },
+  "files": [
+    "dist",
+    "index.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@nicknisi/pi-shared": "workspace:*",
+    "typebox": "^1.1.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,15 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/subagents:
+    dependencies:
+      '@nicknisi/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+      typebox:
+        specifier: ^1.1.0
+        version: 1.3.7
+
   packages/turn-timer: {}
 
 packages:


### PR DESCRIPTION
## What

New package `@nicknisi/pi-subagents` — the first-party platform surface (phase 2a, layer 2):

- **`dispatch` tool** (model-facing) — fan out up to 8 hermetic in-process child agents in parallel; per-task prompt/label/model/system-prompt/tool-allowlist (default read-only); typed aggregate results; `background: true` detaches and reports completion in the transcript
- **`fleet` tool** — `list` recent runs (live + persisted, across extensions using the shared runtime) or fetch a `result` by runId prefix
- **`/fleet` command** — user-facing run table

Tool names deliberately avoid pi-subagents' `subagent`/`/subagents-fleet` so both extensions coexist without the fatal duplicate-tool conflict. Children default to read-only tools, cannot spawn children, and honor the ecosystem recursion guard.

## Verification

Live smoke test: two-way fan-out via `pi -p` (both children answered correctly), run artifacts persisted to `~/.pi/agent/subagent-runs/subagents/` with status/usage/output. All repo checks green. Tracking: #20