### PR TITLE
feat(shared): add workflow engine core

### DIFF
--- a/.changeset/workflow-engine.md
+++ b/.changeset/workflow-engine.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-shared': minor
+---
+
+New `workflow.ts`: a declarative workflow engine over the subagent runtime. Stages form a DAG via explicit `needs` (default linear chain), with `foreach` fan-out, `gate` validation loops with revise feedback, crash retries, per-workflow token budgets, and control artifacts under `<agentDir>/workflow-runs/` enabling `resumeFrom`. Two-channel handoff: typed outcomes flow via `StageContext.results`, and `sharesTree` stages hand dependents a bounded `git diff HEAD` — such stages never run concurrently with anything else (conservative resource exclusion). Ships with vitest coverage driven by a fake runtime (first test infra in the repo: root `pnpm test`).

--- a/.changeset/workflow-signal.md
+++ b/.changeset/workflow-signal.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-shared': minor
+---
+
+`runWorkflow` accepts `signal` in its options and threads it into every stage spawn, so callers (e.g. codemode timeouts, tool aborts) can cancel a whole workflow.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .tsconfig.build.json
 *.log
 .DS_Store
+.pi-subagents/

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Local paths are added to pi's settings without copying — edits in the repo are
 
 ### Library
 
-| Package                    | What it does                                                                                                                                                                                                                                                                                                                                          |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [shared](packages/shared/) | `@nicknisi/pi-shared` — helper library (not an extension): `getModelProvider` for one-off LLM calls, TUI utilities (gradient text, tree section removal, two-column layout, escape sanitization, render dispatcher), `SearchableSelectList`, and the in-process subagent runtime (`createSubagentRuntime`). Consumed via `workspace:*` by 7 packages. |
+| Package                    | What it does                                                                                                                                                                                                                                                                                                                                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [shared](packages/shared/) | `@nicknisi/pi-shared` — helper library (not an extension): `getModelProvider` for one-off LLM calls, TUI utilities (gradient text, tree section removal, two-column layout, escape sanitization, render dispatcher), `SearchableSelectList`, the in-process subagent runtime (`createSubagentRuntime`), and the declarative workflow engine (`runWorkflow`). Consumed via `workspace:*` by 7 packages. |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "oxlint .",
     "format": "oxfmt .",
     "format:check": "oxfmt --check .",
+    "test": "vitest run",
     "fmt": "oxfmt .",
     "fmt:check": "oxfmt --check .",
     "changeset": "changeset",
@@ -25,7 +26,8 @@
     "@types/node": "^24.0.0",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "oxfmt": "^0.62.0",
-    "oxlint": "^1.77.0"
+    "oxlint": "^1.77.0",
+    "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@11.20.0"
 }

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -118,12 +118,64 @@ Design rules baked in:
 - **Never rejects.** `spawn()` resolves a discriminated union. `schema_invalid` (unparseable/invalid JSON) is deliberately distinct from a schema-valid answer whose _content_ reports failure — engines with retry loops key off that distinction.
 - **The supervisor channel is a closure.** `onSupervisorRequest` registers a `<namespace>_contact_supervisor` tool in the child wired straight to the parent handler — no filesystem protocol, no polling.
 - **Ecosystem recursion guard, honored not namespaced.** Spawning is refused when `PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_CHILD` are set (i.e. your extension is itself running inside a pi-subagents child).
-- **Run registry.** `listRuns()` returns recent runs (newest first, capped at 200); `activeCount()` reports in-flight spawns. Concurrency is capped per runtime (`maxConcurrent`, default 4). pi's loader gives every extension its own evaluated copy of this module, so a _cross-extension_ limiter is impossible — size each runtime accordingly.
-- **Timeout/abort.** `timeoutMs` (default 15 min, `0` disables) and `signal` both map to `session.abort()`; both produce `kind: 'aborted'`.
+- **Run registry + background.** `listRuns()` returns recent runs (newest first, capped at 200); `activeCount()` reports in-flight spawns. `spawnDetached()` launches without awaiting, returning `{ runId, done }` for background work. Concurrency is capped per runtime (`maxConcurrent`, default 4). pi's loader gives every extension its own evaluated copy of this module, so a _cross-extension_ limiter is impossible — size each runtime accordingly.
+- **Persisted run artifacts.** With `artifactsDir` on `createSubagentRuntime`, every run persists its record (status, timing, usage, bounded output) to `<dir>/<namespace>/<runId>.json` on each status transition — the cross-extension fleet view, since the on-disk root is the only layer pi's module isolation leaves shared. `readRunArtifacts(rootDir)` reads records across namespaces.
+- **Timeout/abort/budgets.** `timeoutMs` (default 15 min, `0` disables) and `signal` both map to `session.abort()`; `maxTurns` / `maxToolCalls` abort the child when exceeded. All three produce `kind: 'aborted'` with a reason-specific error.
 
 Also exported: `resolveContainedAgentResource(kind, name, leaf)` — containment-checked resolution of a bare name under the agent dir (`~/.pi/agent/extensions/<name>/<leaf>` etc.) for untrusted config input; returns `null` for anything with path separators or `..`.
 
-Non-goals for now: background/detached runs, persisted run artifacts, worktree isolation, and orchestration (chains/workflows) are deliberately out of this module — the registry is in-memory and children share the parent's event loop and memory (no crash isolation; a pathological child can hurt the host session).
+Non-goals for now: worktree isolation and orchestration UI are deliberately out of this module — children share the parent's event loop and memory (no crash isolation; a pathological child can hurt the host session). Orchestration itself lives in `workflow.ts` (below).
+
+### Workflow engine (`workflow.ts`)
+
+```ts
+import { runWorkflow } from '@nicknisi/pi-shared';
+```
+
+Declarative multi-stage workflows over a `SubagentRuntime`. A workflow is a list of stages with explicit (`needs`) or implicit (linear chain — each stage depends on the previously declared one) dependencies; the engine schedules them over the runtime and resolves a `WorkflowResult` (never rejects).
+
+```ts
+const result = await runWorkflow(
+  {
+    name: 'review-pipeline',
+    concurrency: 4, // scheduler cap; default 4
+    tokenBudget: 500_000, // stop starting new stages once exceeded
+    stages: [
+      { id: 'scout', needs: [], agent: 'scout', prompt: 'Map the auth module…' },
+      {
+        id: 'reviewers',
+        needs: ['scout'],
+        foreach: ['correctness', 'tests', 'simplicity'], // one spawn per item
+        prompt: (ctx, lens) => `Review as ${lens}. Context: ${(ctx.results.scout as any)?.output}`,
+        gate: (outcome) => (outcome.output.length > 200 ? true : { revise: 'Too thin — be specific.' }),
+      },
+      {
+        id: 'fix',
+        needs: ['reviewers'],
+        sharesTree: true, // declares it edits the shared working tree
+        tools: ['read', 'edit', 'bash'],
+        prompt: (ctx) => `Apply the feedback. Diff so far:\n${ctx.treeDiffs['fix'] ?? ''}`,
+      },
+    ],
+  },
+  runtime,
+  { cwd: process.cwd(), resumeFrom: previousRunDir },
+);
+```
+
+Full stage schema: `{ id, agent?, prompt (string | (ctx, item?, index?) => string), model?, tools?, systemPrompt?, outputSchema?, needs?, sharesTree?, foreach?, gate?, maxGateAttempts?, retries?, maxTurns?, maxToolCalls?, timeoutMs? }`. `prompt`/`gate` receive a `StageContext`: `results` (typed outcomes of completed stages), `treeDiffs`, `cwd`, `runDir`.
+
+Semantics:
+
+- **Two-channel handoff.** (1) Typed results flow via `ctx.results`. (2) When a `sharesTree` stage completes ok in a git repo, its bounded (64KB) `git diff HEAD` snapshot flows to dependents via `ctx.treeDiffs[stageId]`.
+- **Resource exclusion.** A `sharesTree` stage never runs concurrently with ANY other stage: while one is queued the scheduler pauses new starts and waits for the running set to drain. Non-tree stages overlap freely up to `concurrency`. Conservative by design — declare `sharesTree` on anything that reads or writes the working tree.
+- **Failure containment.** A failed dependency transitively skips dependents (`kind: 'skipped'`). An exhausted `tokenBudget` skips unstarted stages (`kind: 'budget_exceeded'`). Workflow `ok` = every stage ok.
+- **`foreach`.** Static array or `{ from: stageId, pick? }` resolving items from a dependency's ok outcome (`pick` defaults to the outcome's `data`). Each item is an independent spawn counting individually against concurrency; the stage outcome's `output` is the JSON array of per-item outputs (`data` is the array of validated per-item data when `outputSchema` is set). One failed item fails the stage.
+- **`gate` — the vacuous-pass defense.** Runs on each ok outcome; `{ revise: feedback }` re-spawns with the feedback appended (up to `maxGateAttempts`, default 2), exhaustion or a gate exception fails the stage as `gate_failed`. The engine treats runtime `empty` outcomes as failures; use gates to enforce real content contracts ("PASS with no findings" is not a pass).
+- **`retries`.** Re-spawns on `crashed`/`empty` only — `aborted` and `schema_invalid` fail immediately.
+- **Control artifacts + resume.** Every run writes `status.json` and `stages/<id>.json` (outcome + treeDiff) under its runDir — default `<agentDir>/workflow-runs/<name>-<timestamp>` — enabling `resumeFrom` to skip previously-ok stages and reload their outcomes (and tree diffs) from disk.
+
+The engine depends only on the `SubagentRuntime` **type**, so tests drive it with a hand-rolled fake — see `workflow.test.ts` (run: `pnpm test`).
 
 ## Usage
 

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -2,3 +2,4 @@ export * from './llm.js';
 export * from './tui-utils.js';
 export * from './searchable-select-list.js';
 export * from './subagents.js';
+export * from './workflow.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,7 @@
     "index.ts",
     "llm.ts",
     "subagents.ts",
+    "workflow.ts",
     "tui-utils.ts",
     "searchable-select-list.ts"
   ],

--- a/packages/shared/workflow.test.ts
+++ b/packages/shared/workflow.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for the workflow engine, driven by a FAKE SubagentRuntime — no LLM
+ * calls, no pi runtime imports. The engine only depends on the
+ * SubagentRuntime type, so a hand-rolled fake exercises the full scheduler.
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { SpawnOptions, SpawnResult, SpawnUsage, SubagentRuntime } from './subagents.js';
+import { runWorkflow, type WorkflowSpec } from './workflow.js';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function usage(total: number): SpawnUsage {
+  return { inputTokens: total, outputTokens: 0, totalTokens: total };
+}
+
+type Handler = (opts: SpawnOptions, callIndex: number) => Promise<SpawnResult> | SpawnResult;
+
+interface FakeRuntime extends SubagentRuntime {
+  calls: SpawnOptions[];
+  maxActive: number;
+  /** Set by handlers to flag that a non-tree job overlapped a tree job. */
+  treeViolation: boolean;
+  treeActive: number;
+}
+
+function makeFake(handler: Handler): FakeRuntime {
+  let active = 0;
+  const fake: FakeRuntime = {
+    namespace: 'test',
+    calls: [],
+    maxActive: 0,
+    treeViolation: false,
+    treeActive: 0,
+    async spawn(opts: SpawnOptions): Promise<SpawnResult> {
+      fake.calls.push(opts);
+      active++;
+      fake.maxActive = Math.max(fake.maxActive, active);
+      const isTree = opts.systemPrompt === 'TREE';
+      if (isTree) {
+        fake.treeActive++;
+      } else if (fake.treeActive > 0) {
+        fake.treeViolation = true;
+      }
+      try {
+        return await handler(opts, fake.calls.length);
+      } finally {
+        if (isTree) fake.treeActive--;
+        active--;
+      }
+    },
+    spawnDetached(opts: SpawnOptions) {
+      return { runId: 'detached', done: this.spawn(opts) };
+    },
+    listRuns: () => [],
+    activeCount: () => active,
+  };
+  return fake;
+}
+
+function ok(text: string, total = 10): SpawnResult {
+  return { ok: true, runId: 'r', text, usage: usage(total), durationMs: 1 };
+}
+
+function crash(error: string): SpawnResult {
+  return { ok: false, runId: 'r', kind: 'crashed', error, text: '', usage: usage(5), durationMs: 1 };
+}
+
+function tmpRunDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'pi-workflow-test-'));
+}
+
+async function run(spec: WorkflowSpec, fake: FakeRuntime, extra: { runDir?: string; resumeFrom?: string } = {}) {
+  return runWorkflow(spec, fake, { cwd: '/tmp', runDir: extra.runDir ?? tmpRunDir(), ...extra });
+}
+
+describe('runWorkflow', () => {
+  it('runs a linear chain in order and threads results into ctx', async () => {
+    const seen: string[] = [];
+    const fake = makeFake(async (opts) => {
+      seen.push(opts.prompt);
+      await sleep(5);
+      return ok(`done:${opts.prompt}`);
+    });
+    const result = await run(
+      {
+        name: 'chain',
+        stages: [
+          { id: 'a', prompt: 'first' },
+          {
+            id: 'b',
+            prompt: (ctx) => {
+              const a = ctx.results['a'];
+              return `second after ${a?.ok ? a.output : '?'}`;
+            },
+          },
+          { id: 'c', prompt: 'third' },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(seen).toEqual(['first', 'second after done:first', 'third']);
+    expect(result.outcomes['c']?.ok).toBe(true);
+  });
+
+  it('overlaps independent stages', async () => {
+    const fake = makeFake(async () => {
+      await sleep(20);
+      return ok('x');
+    });
+    const result = await run(
+      {
+        name: 'parallel',
+        stages: [
+          { id: 'a', needs: [], prompt: 'a' },
+          { id: 'b', needs: [], prompt: 'b' },
+          { id: 'c', needs: [], prompt: 'c' },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(fake.maxActive).toBeGreaterThan(1);
+  });
+
+  it('never runs a sharesTree stage concurrently with anything', async () => {
+    const fake = makeFake(async () => {
+      await sleep(15);
+      return ok('x');
+    });
+    const result = await run(
+      {
+        name: 'tree',
+        stages: [
+          { id: 'a', needs: [], prompt: 'a' },
+          { id: 'edit', needs: [], prompt: 'edit', sharesTree: true, systemPrompt: 'TREE' },
+          { id: 'b', needs: [], prompt: 'b' },
+          { id: 'c', needs: [], prompt: 'c' },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(fake.treeViolation).toBe(false);
+  });
+
+  it('transitively skips dependents of a failed stage', async () => {
+    const fake = makeFake((opts) => (opts.prompt === 'explode' ? crash('boom') : ok('fine')));
+    const result = await run(
+      {
+        name: 'skip',
+        stages: [
+          { id: 'a', needs: [], prompt: 'explode' },
+          { id: 'b', needs: ['a'], prompt: 'b' },
+          { id: 'c', needs: ['b'], prompt: 'c' },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.outcomes['a']).toMatchObject({ ok: false, kind: 'crashed' });
+    expect(result.outcomes['b']).toMatchObject({ ok: false, kind: 'skipped' });
+    expect(result.outcomes['c']).toMatchObject({ ok: false, kind: 'skipped' });
+    expect(fake.calls).toHaveLength(1);
+  });
+
+  it('expands foreach with per-item concurrency and aggregates output', async () => {
+    const fake = makeFake(async (opts) => {
+      await sleep(10);
+      return ok(`out:${opts.prompt}`);
+    });
+    const result = await run(
+      {
+        name: 'foreach',
+        concurrency: 2,
+        stages: [{ id: 'fan', needs: [], foreach: [1, 2, 3, 4], prompt: (_ctx, item) => `item-${item}` }],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(fake.calls).toHaveLength(4);
+    expect(fake.maxActive).toBe(2);
+    const outcome = result.outcomes['fan'];
+    expect(outcome?.ok).toBe(true);
+    if (outcome?.ok) {
+      expect(JSON.parse(outcome.output)).toEqual(['out:item-1', 'out:item-2', 'out:item-3', 'out:item-4']);
+      expect(outcome.attempts).toBe(4);
+    }
+  });
+
+  it('resolves foreach items from a dependency outcome via pick', async () => {
+    const fake = makeFake((opts) => (opts.prompt === 'produce' ? ok('ignored') : ok(`handled:${opts.prompt}`)));
+    const result = await run(
+      {
+        name: 'foreach-from',
+        stages: [
+          { id: 'a', needs: [], prompt: 'produce' },
+          {
+            id: 'b',
+            needs: ['a'],
+            foreach: { from: 'a', pick: () => ['x', 'y'] },
+            prompt: (_ctx, item) => `handle-${item}`,
+          },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(fake.calls.map((c) => c.prompt)).toEqual(['produce', 'handle-x', 'handle-y']);
+  });
+
+  it('revises via gate feedback and passes on a later attempt', async () => {
+    let gateCalls = 0;
+    const fake = makeFake(() => ok('draft'));
+    const result = await run(
+      {
+        name: 'gate',
+        stages: [
+          {
+            id: 'a',
+            needs: [],
+            prompt: 'write',
+            gate: () => {
+              gateCalls++;
+              return gateCalls >= 2 ? true : { revise: 'make it better' };
+            },
+          },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(true);
+    expect(fake.calls).toHaveLength(2);
+    expect(fake.calls[1]?.prompt).toContain('make it better');
+    expect(result.outcomes['a']).toMatchObject({ ok: true, attempts: 2 });
+  });
+
+  it('fails as gate_failed when the gate never passes', async () => {
+    const fake = makeFake(() => ok('draft'));
+    const result = await run(
+      {
+        name: 'gate-fail',
+        stages: [{ id: 'a', needs: [], prompt: 'write', gate: () => ({ revise: 'again' }), maxGateAttempts: 3 }],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.outcomes['a']).toMatchObject({ ok: false, kind: 'gate_failed', attempts: 3 });
+    expect(fake.calls).toHaveLength(3);
+  });
+
+  it('fails as gate_failed when the gate throws', async () => {
+    const fake = makeFake(() => ok('draft'));
+    const result = await run(
+      {
+        name: 'gate-throw',
+        stages: [
+          {
+            id: 'a',
+            needs: [],
+            prompt: 'write',
+            gate: () => {
+              throw new Error('gate exploded');
+            },
+          },
+        ],
+      },
+      fake,
+    );
+    expect(result.outcomes['a']).toMatchObject({ ok: false, kind: 'gate_failed' });
+    const oa = result.outcomes['a'];
+    if (oa && !oa.ok) expect(oa.error).toContain('gate exploded');
+    expect(oa?.ok).toBe(false);
+  });
+
+  it('retries crashed spawns but not aborted ones', async () => {
+    let n = 0;
+    const fake = makeFake((opts) => {
+      if (opts.prompt === 'flaky') {
+        n++;
+        return n < 3 ? crash('transient') : ok('recovered');
+      }
+      return {
+        ok: false as const,
+        runId: 'r',
+        kind: 'aborted' as const,
+        error: 'stop',
+        text: '',
+        usage: usage(5),
+        durationMs: 1,
+      };
+    });
+    const result = await run(
+      {
+        name: 'retries',
+        stages: [
+          { id: 'a', needs: [], prompt: 'flaky', retries: 3 },
+          { id: 'b', needs: [], prompt: 'abort-me', retries: 3 },
+        ],
+      },
+      fake,
+    );
+    expect(result.outcomes['a']).toMatchObject({ ok: true, attempts: 3 });
+    expect(result.outcomes['b']).toMatchObject({ ok: false, kind: 'aborted', attempts: 1 });
+  });
+
+  it('stops scheduling once the token budget is exceeded', async () => {
+    const fake = makeFake(() => ok('x', 1000));
+    const result = await run(
+      {
+        name: 'budget',
+        tokenBudget: 500,
+        stages: [
+          { id: 'a', needs: [], prompt: 'a' },
+          { id: 'b', needs: ['a'], prompt: 'b' },
+        ],
+      },
+      fake,
+    );
+    expect(result.ok).toBe(false);
+    expect(result.outcomes['a']?.ok).toBe(true);
+    expect(result.outcomes['b']).toMatchObject({ ok: false, kind: 'budget_exceeded' });
+    expect(fake.calls).toHaveLength(1);
+  });
+
+  it('captures a bounded git diff for sharesTree stages and hands it to dependents', async () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-workflow-git-'));
+    execFileSync('git', ['init'], { cwd: repo });
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.email=test@test',
+        '-c',
+        'user.name=test',
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '--allow-empty',
+        '-m',
+        'init',
+      ],
+      { cwd: repo },
+    );
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'hello\n');
+    execFileSync('git', ['add', '.'], { cwd: repo });
+    execFileSync(
+      'git',
+      ['-c', 'user.email=test@test', '-c', 'user.name=test', '-c', 'commit.gpgsign=false', 'commit', '-m', 'add file'],
+      { cwd: repo },
+    );
+    fs.writeFileSync(path.join(repo, 'file.txt'), 'hello\nworld\n');
+
+    let dependentSawDiff = '';
+    const fake = makeFake(() => ok('x'));
+    const result = await runWorkflow(
+      {
+        name: 'tree-diff',
+        stages: [
+          { id: 'edit', needs: [], prompt: 'edit', sharesTree: true },
+          {
+            id: 'review',
+            needs: ['edit'],
+            prompt: (ctx) => {
+              dependentSawDiff = ctx.treeDiffs['edit'] ?? '';
+              return 'review';
+            },
+          },
+        ],
+      },
+      fake,
+      { cwd: repo, runDir: tmpRunDir() },
+    );
+    expect(result.ok).toBe(true);
+    expect(dependentSawDiff).toContain('+world');
+  });
+
+  it('writes control artifacts and resumes by skipping previously-ok stages', async () => {
+    const runDir = tmpRunDir();
+    const first = makeFake((opts) => (opts.prompt === 'fail-first' ? crash('boom') : ok('good')));
+    const r1 = await run(
+      {
+        name: 'resumable',
+        stages: [
+          { id: 'a', needs: [], prompt: 'fine' },
+          { id: 'b', needs: ['a'], prompt: 'fail-first' },
+        ],
+      },
+      first,
+      { runDir },
+    );
+    expect(r1.ok).toBe(false);
+    expect(fs.existsSync(path.join(runDir, 'status.json'))).toBe(true);
+    const stageArtifact = JSON.parse(fs.readFileSync(path.join(runDir, 'stages', 'a.json'), 'utf8'));
+    expect(stageArtifact.outcome.ok).toBe(true);
+
+    const second = makeFake(() => ok('now it works'));
+    const r2 = await run(
+      {
+        name: 'resumable',
+        stages: [
+          { id: 'a', needs: [], prompt: 'fine' },
+          { id: 'b', needs: ['a'], prompt: 'fail-first' },
+        ],
+      },
+      second,
+      { runDir: tmpRunDir(), resumeFrom: runDir },
+    );
+    expect(r2.ok).toBe(true);
+    expect(second.calls.map((c) => c.prompt)).toEqual(['fail-first']);
+    expect(r2.outcomes['a']?.ok).toBe(true);
+  });
+});

--- a/packages/shared/workflow.test.ts
+++ b/packages/shared/workflow.test.ts
@@ -74,7 +74,11 @@ function tmpRunDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'pi-workflow-test-'));
 }
 
-async function run(spec: WorkflowSpec, fake: FakeRuntime, extra: { runDir?: string; resumeFrom?: string } = {}) {
+async function run(
+  spec: WorkflowSpec,
+  fake: FakeRuntime,
+  extra: { runDir?: string; resumeFrom?: string; signal?: AbortSignal } = {},
+) {
   return runWorkflow(spec, fake, { cwd: '/tmp', runDir: extra.runDir ?? tmpRunDir(), ...extra });
 }
 
@@ -414,5 +418,23 @@ describe('runWorkflow', () => {
     expect(r2.ok).toBe(true);
     expect(second.calls.map((c) => c.prompt)).toEqual(['fail-first']);
     expect(r2.outcomes['a']?.ok).toBe(true);
+  });
+
+  it('threads opts.signal into every stage spawn', async () => {
+    const fake = makeFake(() => ok('done'));
+    const controller = new AbortController();
+    await run(
+      {
+        name: 'signal',
+        stages: [
+          { id: 'a', needs: [], prompt: 'A' },
+          { id: 'b', needs: ['a'], prompt: 'B', foreach: [1, 2] },
+        ],
+      },
+      fake,
+      { signal: controller.signal },
+    );
+    expect(fake.calls.length).toBe(3);
+    for (const call of fake.calls) expect(call.signal).toBe(controller.signal);
   });
 });

--- a/packages/shared/workflow.ts
+++ b/packages/shared/workflow.ts
@@ -119,6 +119,8 @@ export interface RunWorkflowOptions {
   runDir?: string;
   /** A prior run's directory; stages recorded ok there are skipped and their outcomes loaded. */
   resumeFrom?: string;
+  /** Aborts every stage spawn (threaded into each runtime.spawn call). */
+  signal?: AbortSignal;
   onProgress?: (event: WorkflowEvent) => void;
 }
 
@@ -324,6 +326,7 @@ export async function runWorkflow(
       if (stage.maxTurns !== undefined) spawnOpts.maxTurns = stage.maxTurns;
       if (stage.maxToolCalls !== undefined) spawnOpts.maxToolCalls = stage.maxToolCalls;
       if (stage.timeoutMs !== undefined) spawnOpts.timeoutMs = stage.timeoutMs;
+      if (opts.signal !== undefined) spawnOpts.signal = opts.signal;
 
       let res: SpawnResult;
       try {

--- a/packages/shared/workflow.ts
+++ b/packages/shared/workflow.ts
@@ -1,0 +1,667 @@
+/**
+ * Declarative workflow engine over the subagent runtime.
+ *
+ * A workflow is a list of stages with explicit (`needs`) or implicit (linear
+ * chain) dependencies. The engine schedules stages over a SubagentRuntime,
+ * honors the platform's two-channel handoff, and never rejects — per-stage
+ * failures are typed outcomes, not exceptions.
+ *
+ * Semantics baked in:
+ * - Two-channel handoff: (1) typed results flow to dependents via
+ *   `StageContext.results`; (2) when a stage that declares `sharesTree`
+ *   completes ok in a git repo, its `git diff HEAD` snapshot (bounded) flows
+ *   to dependents via `StageContext.treeDiffs`.
+ * - Resource exclusion: `sharesTree` stages never run concurrently with ANY
+ *   other stage — they wait for the running set to drain and block new
+ *   starts while queued/running. Non-sharesTree stages overlap freely.
+ * - Failure containment: a failed dependency transitively skips its
+ *   dependents (kind 'skipped'); an exhausted token budget skips unstarted
+ *   stages (kind 'budget_exceeded'); gates that never pass fail the stage
+ *   (kind 'gate_failed'). Runtime 'empty' outcomes are failures — use a
+ *   `gate` to enforce content contracts and avoid vacuous passes.
+ * - Control artifacts: every run persists status.json + stages/<id>.json
+ *   under its runDir, enabling `resumeFrom` to skip previously-ok stages.
+ *
+ * The engine depends only on the SubagentRuntime TYPE (never pi runtime
+ * modules), so tests drive it with a fake runtime.
+ */
+
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { promisify } from 'node:util';
+import type { TSchema } from 'typebox';
+import type { SpawnFailureKind, SpawnOptions, SpawnResult, SpawnUsage, SubagentRuntime } from './subagents.js';
+
+const execFileAsync = promisify(execFile);
+
+// ── Public types ───────────────────────────────────────────────────────────
+
+export type StageOutcome =
+  | { ok: true; output: string; data?: unknown; usage: SpawnUsage; durationMs: number; attempts: number }
+  | {
+      ok: false;
+      kind: SpawnFailureKind | 'gate_failed' | 'skipped' | 'budget_exceeded';
+      error: string;
+      durationMs: number;
+      attempts: number;
+    };
+
+export type StageOk = Extract<StageOutcome, { ok: true }>;
+
+export interface StageContext {
+  /** Outcomes of all completed stages so far, by stage id. */
+  results: Record<string, StageOutcome>;
+  /** Bounded `git diff HEAD` snapshots from completed sharesTree stages. */
+  treeDiffs: Record<string, string>;
+  cwd: string;
+  runDir: string;
+}
+
+export interface WorkflowStage {
+  id: string;
+  /** Label, e.g. "reviewer". */
+  agent?: string;
+  /** Static prompt or function of dependency context (item/index set for foreach jobs). */
+  prompt: string | ((ctx: StageContext, item?: unknown, index?: number) => string);
+  model?: string;
+  tools?: string[];
+  systemPrompt?: string;
+  /** Typebox schema, passed through to the runtime; validated per spawn (per item for foreach). */
+  outputSchema?: TSchema;
+  /** Explicit dependencies. Default: the previously declared stage (linear chain). Explicit [] = no deps. */
+  needs?: string[];
+  /** Declares the stage edits/reads the shared working tree. Default false. See header for exclusion semantics. */
+  sharesTree?: boolean;
+  /** Fan out one spawn per item: static array, or items picked from a dependency's ok outcome. */
+  foreach?: unknown[] | { from: string; pick?: (outcome: StageOk) => unknown[] };
+  /**
+   * Validation gate on an ok outcome. Return true to pass, or { revise: feedback }
+   * to re-spawn with the feedback appended to the prompt (up to maxGateAttempts
+   * total attempts). Gate exceptions fail the stage as 'gate_failed'.
+   */
+  gate?: (outcome: StageOk, ctx: StageContext) => true | { revise: string };
+  /** Total gate-evaluated attempts before failing as 'gate_failed'. Default 2. */
+  maxGateAttempts?: number;
+  /** Re-spawn on crashed/empty outcomes, up to this many times. Default 0. */
+  retries?: number;
+  maxTurns?: number;
+  maxToolCalls?: number;
+  timeoutMs?: number;
+}
+
+export interface WorkflowSpec {
+  name: string;
+  stages: WorkflowStage[];
+  /** Scheduler cap on concurrent spawns. Default 4. */
+  concurrency?: number;
+  /** Stop starting new stages once summed usage exceeds this many total tokens. */
+  tokenBudget?: number;
+}
+
+export interface WorkflowResult {
+  ok: boolean;
+  outcomes: Record<string, StageOutcome>;
+  usage: SpawnUsage;
+  runDir: string;
+}
+
+export interface WorkflowEvent {
+  type: 'stage_start' | 'stage_complete' | 'stage_failed' | 'stage_skipped' | 'workflow_complete';
+  stageId?: string;
+  outcome?: StageOutcome;
+}
+
+export interface RunWorkflowOptions {
+  cwd: string;
+  /** Override the run directory (default: <agentDir>/workflow-runs/<name>-<timestamp>). */
+  runDir?: string;
+  /** A prior run's directory; stages recorded ok there are skipped and their outcomes loaded. */
+  resumeFrom?: string;
+  onProgress?: (event: WorkflowEvent) => void;
+}
+
+// ── Internals ──────────────────────────────────────────────────────────────
+
+const DEFAULT_CONCURRENCY = 4;
+const DEFAULT_GATE_ATTEMPTS = 2;
+const MAX_TREE_DIFF_CHARS = 64 * 1024;
+
+interface JobOk {
+  ok: true;
+  output: string;
+  data?: unknown;
+  usage: SpawnUsage;
+  durationMs: number;
+  attempts: number;
+}
+
+interface JobFail {
+  ok: false;
+  kind: SpawnFailureKind | 'gate_failed';
+  error: string;
+  durationMs: number;
+  attempts: number;
+}
+
+interface PendingJob {
+  stageId: string;
+  item: unknown;
+  index: number;
+}
+
+interface ItemResult {
+  index: number;
+  res: JobOk | JobFail;
+}
+
+function zeroUsage(): SpawnUsage {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+function addUsage(a: SpawnUsage, b: SpawnUsage): void {
+  a.inputTokens += b.inputTokens;
+  a.outputTokens += b.outputTokens;
+  a.totalTokens += b.totalTokens;
+  if (b.cost !== undefined) a.cost = (a.cost ?? 0) + b.cost;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function defaultRunRoot(): string {
+  const agentDir = process.env.PI_CODING_AGENT_DIR ?? path.join(os.homedir(), '.pi', 'agent');
+  return path.join(agentDir, 'workflow-runs');
+}
+
+function sanitize(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+/** Capture the shared-tree channel: bounded `git diff HEAD` for cwd, '' when not a repo. */
+async function captureTreeDiff(cwd: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', cwd, 'diff', 'HEAD'], {
+      maxBuffer: MAX_TREE_DIFF_CHARS * 2,
+    });
+    return stdout.slice(0, MAX_TREE_DIFF_CHARS);
+  } catch {
+    return '';
+  }
+}
+
+export async function runWorkflow(
+  spec: WorkflowSpec,
+  runtime: SubagentRuntime,
+  opts: RunWorkflowOptions,
+): Promise<WorkflowResult> {
+  const startedAt = Date.now();
+  const runDir =
+    opts.runDir ??
+    path.join(defaultRunRoot(), `${sanitize(spec.name)}-${new Date().toISOString().replace(/[:.]/g, '-')}`);
+  const onProgress = opts.onProgress;
+  const concurrency = spec.concurrency ?? DEFAULT_CONCURRENCY;
+
+  const stages = spec.stages;
+  const stageById = new Map<string, WorkflowStage>();
+  const state = new Map<string, 'pending' | 'running' | 'settled'>();
+  const outcomes: Record<string, StageOutcome> = {};
+  const treeDiffs: Record<string, string> = {};
+  const stageStartedAt = new Map<string, number>();
+  const expectedJobs = new Map<string, number>();
+  const itemResults = new Map<string, ItemResult[]>();
+  let queue: PendingJob[] = [];
+  const running = new Set<Promise<void>>();
+  let treeRunning = 0;
+  let budgetUsed = 0;
+  const totalUsage = zeroUsage();
+
+  const makeCtx = (): StageContext => ({
+    results: { ...outcomes },
+    treeDiffs: { ...treeDiffs },
+    cwd: opts.cwd,
+    runDir,
+  });
+
+  const emit = (event: WorkflowEvent): void => {
+    try {
+      onProgress?.(event);
+    } catch {
+      // progress callbacks must never break a run
+    }
+  };
+
+  const persistArtifacts = (done: boolean): void => {
+    try {
+      fs.mkdirSync(path.join(runDir, 'stages'), { recursive: true });
+      fs.writeFileSync(
+        path.join(runDir, 'status.json'),
+        JSON.stringify(
+          {
+            name: spec.name,
+            startedAt,
+            updatedAt: Date.now(),
+            done,
+            ok: done ? stages.every((s) => outcomes[s.id]?.ok === true) : undefined,
+            stages: Object.fromEntries(
+              stages.map((s) => [s.id, { status: state.get(s.id) ?? 'pending', outcome: outcomes[s.id] }]),
+            ),
+          },
+          null,
+          2,
+        ),
+      );
+    } catch {
+      // artifact persistence is best-effort
+    }
+  };
+
+  const persistStageArtifact = (stageId: string): void => {
+    try {
+      fs.mkdirSync(path.join(runDir, 'stages'), { recursive: true });
+      fs.writeFileSync(
+        path.join(runDir, 'stages', `${sanitize(stageId)}.json`),
+        JSON.stringify(
+          {
+            stageId,
+            outcome: outcomes[stageId],
+            ...(treeDiffs[stageId] !== undefined ? { treeDiff: treeDiffs[stageId] } : {}),
+          },
+          null,
+          2,
+        ),
+      );
+    } catch {
+      // artifact persistence is best-effort
+    }
+  };
+
+  const settle = (stage: WorkflowStage, outcome: StageOutcome): void => {
+    state.set(stage.id, 'settled');
+    outcomes[stage.id] = outcome;
+    if (outcome.ok) addUsage(totalUsage, outcome.usage);
+    emit({
+      type: outcome.ok
+        ? 'stage_complete'
+        : outcome.kind === 'skipped' || outcome.kind === 'budget_exceeded'
+          ? 'stage_skipped'
+          : 'stage_failed',
+      stageId: stage.id,
+      outcome,
+    });
+    persistStageArtifact(stage.id);
+    persistArtifacts(false);
+  };
+
+  const buildPrompt = (stage: WorkflowStage, item: unknown, index: number, feedback: string | undefined): string => {
+    let prompt = typeof stage.prompt === 'function' ? stage.prompt(makeCtx(), item, index) : stage.prompt;
+    if (feedback !== undefined) {
+      prompt += `\n\nRevision feedback from the gate:\n${feedback}\n\nAddress this feedback and try again.`;
+    }
+    return prompt;
+  };
+
+  const runJob = async (stage: WorkflowStage, item: unknown, index: number): Promise<JobOk | JobFail> => {
+    const jobStart = Date.now();
+    const usage = zeroUsage();
+    const maxGateAttempts = stage.maxGateAttempts ?? DEFAULT_GATE_ATTEMPTS;
+    const maxRetries = stage.retries ?? 0;
+    let attempts = 0;
+    let gateTries = 0;
+    let retriesUsed = 0;
+    let feedback: string | undefined;
+
+    for (;;) {
+      attempts++;
+      const spawnOpts: SpawnOptions = { prompt: buildPrompt(stage, item, index, feedback), cwd: opts.cwd };
+      if (stage.agent !== undefined) spawnOpts.agent = stage.agent;
+      if (stage.model !== undefined) spawnOpts.model = stage.model;
+      if (stage.tools !== undefined) spawnOpts.tools = stage.tools;
+      if (stage.systemPrompt !== undefined) spawnOpts.systemPrompt = stage.systemPrompt;
+      if (stage.outputSchema !== undefined) spawnOpts.outputSchema = stage.outputSchema;
+      if (stage.maxTurns !== undefined) spawnOpts.maxTurns = stage.maxTurns;
+      if (stage.maxToolCalls !== undefined) spawnOpts.maxToolCalls = stage.maxToolCalls;
+      if (stage.timeoutMs !== undefined) spawnOpts.timeoutMs = stage.timeoutMs;
+
+      let res: SpawnResult;
+      try {
+        res = await runtime.spawn(spawnOpts);
+      } catch (err) {
+        // spawn() never rejects by contract; defend against foreign runtimes anyway
+        res = {
+          ok: false as const,
+          runId: 'unknown',
+          kind: 'crashed' as const,
+          error: errorMessage(err),
+          text: '',
+          usage: zeroUsage(),
+          durationMs: Date.now() - jobStart,
+        };
+      }
+      addUsage(usage, res.usage);
+      budgetUsed += res.usage.totalTokens;
+
+      if (res.ok) {
+        const outcome: StageOk = {
+          ok: true,
+          output: res.text,
+          ...(res.data !== undefined ? { data: res.data } : {}),
+          usage: { ...usage },
+          durationMs: Date.now() - jobStart,
+          attempts,
+        };
+        if (!stage.gate) return outcome;
+        gateTries++;
+        let verdict: true | { revise: string };
+        try {
+          verdict = stage.gate(outcome, makeCtx());
+        } catch (err) {
+          return {
+            ok: false,
+            kind: 'gate_failed',
+            error: `Gate threw: ${errorMessage(err)}`,
+            durationMs: Date.now() - jobStart,
+            attempts,
+          };
+        }
+        if (verdict === true) return outcome;
+        feedback = verdict.revise;
+        if (gateTries >= maxGateAttempts) {
+          return {
+            ok: false,
+            kind: 'gate_failed',
+            error: `Gate did not pass after ${gateTries} attempt(s). Last feedback: ${feedback}`,
+            durationMs: Date.now() - jobStart,
+            attempts,
+          };
+        }
+        continue;
+      }
+
+      if ((res.kind === 'crashed' || res.kind === 'empty') && retriesUsed < maxRetries) {
+        retriesUsed++;
+        continue;
+      }
+      return { ok: false, kind: res.kind, error: res.error, durationMs: Date.now() - jobStart, attempts };
+    }
+  };
+
+  const aggregateAndSettle = async (stage: WorkflowStage): Promise<void> => {
+    const results = (itemResults.get(stage.id) ?? []).sort((a, b) => a.index - b.index);
+    const durationMs = Date.now() - (stageStartedAt.get(stage.id) ?? Date.now());
+    const attempts = results.reduce((n, r) => n + r.res.attempts, 0);
+    const failed = results.find((r) => !r.res.ok);
+
+    let outcome: StageOutcome;
+    if (failed && !failed.res.ok) {
+      const prefix = stage.foreach ? `item ${failed.index}: ` : '';
+      outcome = { ok: false, kind: failed.res.kind, error: `${prefix}${failed.res.error}`, durationMs, attempts };
+    } else {
+      const oks = results.filter((r): r is { index: number; res: JobOk } => r.res.ok);
+      const usage = zeroUsage();
+      for (const r of oks) addUsage(usage, r.res.usage);
+      outcome = stage.foreach
+        ? {
+            ok: true,
+            output: JSON.stringify(
+              oks.map((r) => r.res.output),
+              null,
+              2,
+            ),
+            ...(stage.outputSchema !== undefined ? { data: oks.map((r) => r.res.data) } : {}),
+            usage,
+            durationMs,
+            attempts,
+          }
+        : { ...oks[0]!.res, durationMs };
+    }
+
+    if (outcome.ok && stage.sharesTree) {
+      const diff = await captureTreeDiff(opts.cwd);
+      if (diff) treeDiffs[stage.id] = diff;
+    }
+    settle(stage, outcome);
+  };
+
+  const launch = (job: PendingJob): void => {
+    const stage = stageById.get(job.stageId)!;
+    if (!stageStartedAt.has(stage.id)) stageStartedAt.set(stage.id, Date.now());
+    if (stage.sharesTree) treeRunning++;
+    const p = (async () => {
+      try {
+        const res = await runJob(stage, job.item, job.index);
+        const list = itemResults.get(stage.id) ?? [];
+        list.push({ index: job.index, res });
+        itemResults.set(stage.id, list);
+        if (list.length === (expectedJobs.get(stage.id) ?? 1)) {
+          await aggregateAndSettle(stage);
+        }
+      } catch (err) {
+        // runJob never throws; belt-and-braces so a bug can never wedge the scheduler
+        settle(stage, {
+          ok: false,
+          kind: 'crashed',
+          error: `engine error: ${errorMessage(err)}`,
+          durationMs: Date.now() - (stageStartedAt.get(stage.id) ?? Date.now()),
+          attempts: 0,
+        });
+      }
+    })();
+    const tracked = p.finally(() => {
+      running.delete(tracked);
+      if (stage.sharesTree) treeRunning--;
+    });
+    running.add(tracked);
+  };
+
+  const needsOf = (index: number): string[] => {
+    const stage = stages[index]!;
+    return stage.needs ?? (index === 0 ? [] : [stages[index - 1]!.id]);
+  };
+
+  // ── Spec validation ──────────────────────────────────────────────────────
+
+  for (const stage of stages) {
+    if (stageById.has(stage.id)) {
+      state.set(stage.id, 'settled');
+      outcomes[stage.id] = {
+        ok: false,
+        kind: 'skipped',
+        error: `duplicate stage id '${stage.id}'`,
+        durationMs: 0,
+        attempts: 0,
+      };
+    } else {
+      stageById.set(stage.id, stage);
+      state.set(stage.id, 'pending');
+    }
+  }
+
+  // Resume: preload previously-ok stages from a prior run's artifacts.
+  if (opts.resumeFrom) {
+    try {
+      const dir = path.join(opts.resumeFrom, 'stages');
+      for (const file of fs.readdirSync(dir)) {
+        if (!file.endsWith('.json')) continue;
+        try {
+          const parsed = JSON.parse(fs.readFileSync(path.join(dir, file), 'utf8'));
+          const stageId = parsed?.stageId;
+          if (typeof stageId !== 'string' || parsed?.outcome?.ok !== true) continue;
+          if (state.get(stageId) !== 'pending') continue;
+          state.set(stageId, 'settled');
+          outcomes[stageId] = parsed.outcome as StageOutcome;
+          if (typeof parsed.treeDiff === 'string' && parsed.treeDiff) treeDiffs[stageId] = parsed.treeDiff;
+        } catch {
+          // skip unreadable stage artifact
+        }
+      }
+    } catch {
+      // no resumable artifacts — run fresh
+    }
+  }
+
+  const budgetExceeded = (): boolean => spec.tokenBudget !== undefined && budgetUsed >= spec.tokenBudget;
+
+  /** Settle pending stages whose deps failed, or that the exhausted budget strands. */
+  const settleSkips = (): void => {
+    for (let i = 0; i < stages.length; i++) {
+      const stage = stages[i]!;
+      if (state.get(stage.id) !== 'pending') continue;
+      const needs = needsOf(i);
+      const unknown = needs.find((id) => !stageById.has(id));
+      if (unknown) {
+        settle(stage, {
+          ok: false,
+          kind: 'skipped',
+          error: `unknown dependency '${unknown}'`,
+          durationMs: 0,
+          attempts: 0,
+        });
+        continue;
+      }
+      const failedDep = needs.find((id) => {
+        const o = outcomes[id];
+        return o !== undefined && !o.ok;
+      });
+      if (failedDep) {
+        settle(stage, {
+          ok: false,
+          kind: 'skipped',
+          error: `dependency '${failedDep}' did not succeed`,
+          durationMs: 0,
+          attempts: 0,
+        });
+        continue;
+      }
+      if (budgetExceeded()) {
+        settle(stage, {
+          ok: false,
+          kind: 'budget_exceeded',
+          error: `token budget ${spec.tokenBudget} exceeded`,
+          durationMs: 0,
+          attempts: 0,
+        });
+      }
+    }
+  };
+
+  /** Materialize pending stages whose deps are all ok into per-item jobs. */
+  const materializeReady = (): void => {
+    for (let i = 0; i < stages.length; i++) {
+      const stage = stages[i]!;
+      if (state.get(stage.id) !== 'pending') continue;
+      if (!needsOf(i).every((id) => outcomes[id]?.ok === true)) continue;
+
+      let items: unknown[];
+      if (stage.foreach === undefined) {
+        items = [undefined];
+      } else if (Array.isArray(stage.foreach)) {
+        items = stage.foreach;
+      } else {
+        const dep = outcomes[stage.foreach.from];
+        try {
+          if (dep === undefined || !dep.ok) throw new Error(`dependency '${stage.foreach.from}' has no ok outcome`);
+          const picked = stage.foreach.pick ? stage.foreach.pick(dep) : dep.data;
+          if (!Array.isArray(picked)) throw new Error(`foreach items from '${stage.foreach.from}' are not an array`);
+          items = picked;
+        } catch (err) {
+          settle(stage, {
+            ok: false,
+            kind: 'crashed',
+            error: `foreach resolution failed: ${errorMessage(err)}`,
+            durationMs: 0,
+            attempts: 0,
+          });
+          continue;
+        }
+      }
+
+      state.set(stage.id, 'running');
+      expectedJobs.set(stage.id, items.length);
+      itemResults.set(stage.id, []);
+      items.forEach((item, index) => queue.push({ stageId: stage.id, item, index }));
+      emit({ type: 'stage_start', stageId: stage.id });
+    }
+  };
+
+  /** Start queued jobs under the concurrency cap and tree-exclusion rules. */
+  const tryStartJobs = (): void => {
+    const kept: PendingJob[] = [];
+    for (const job of queue) {
+      const isTree = stageById.get(job.stageId)!.sharesTree === true;
+      const treeWaiting = queue.some((j) => stageById.get(j.stageId)!.sharesTree === true);
+      if (running.size >= concurrency) {
+        kept.push(job);
+      } else if (isTree) {
+        // Tree jobs need an empty stage; while one waits, non-tree starts pause too (drain faster, no starvation).
+        if (running.size === 0) launch(job);
+        else kept.push(job);
+      } else if (treeWaiting || treeRunning > 0) {
+        kept.push(job);
+      } else {
+        launch(job);
+      }
+    }
+    queue = kept;
+  };
+
+  // ── Scheduler loop ───────────────────────────────────────────────────────
+
+  try {
+    for (;;) {
+      settleSkips();
+      materializeReady();
+      tryStartJobs();
+
+      const pendingStages = stages.some((s) => state.get(s.id) === 'pending');
+      if (running.size === 0) {
+        if (!pendingStages && queue.length === 0) break;
+        if (pendingStages && queue.length === 0) {
+          // Nothing can ever become ready again: dependency cycle.
+          for (const s of stages) {
+            if (state.get(s.id) === 'pending') {
+              settle(s, {
+                ok: false,
+                kind: 'skipped',
+                error: 'dependency cycle detected',
+                durationMs: 0,
+                attempts: 0,
+              });
+            }
+          }
+          break;
+        }
+        if (queue.length > 0) {
+          // Unreachable under the exclusion rules (a queued tree job with an idle
+          // pool launches immediately); break defensively rather than spin.
+          break;
+        }
+      }
+      if (running.size > 0) await Promise.race(running);
+    }
+  } catch (err) {
+    for (const s of stages) {
+      if (state.get(s.id) !== 'settled') {
+        settle(s, {
+          ok: false,
+          kind: 'crashed',
+          error: `engine error: ${errorMessage(err)}`,
+          durationMs: 0,
+          attempts: 0,
+        });
+      }
+    }
+  }
+
+  persistArtifacts(true);
+  const result: WorkflowResult = {
+    ok: stages.every((s) => outcomes[s.id]?.ok === true),
+    outcomes,
+    usage: totalUsage,
+    runDir,
+  };
+  emit({ type: 'workflow_complete' });
+  return result;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       oxlint:
         specifier: ^1.77.0
         version: 1.77.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
 
   packages/agent-urls: {}
 
@@ -331,6 +334,162 @@ packages:
     resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
     engines: {node: '>=22.19.0'}
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@google/genai@1.52.0':
     resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
@@ -348,6 +507,9 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -430,6 +592,13 @@ packages:
     peerDependenciesMeta:
       '@opentelemetry/api':
         optional: true
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -726,6 +895,144 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
   '@silvia-odwyer/photon-node@0.3.4':
     resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
 
@@ -768,6 +1075,15 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -825,6 +1141,35 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -849,6 +1194,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -878,12 +1227,24 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -901,6 +1262,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -925,10 +1290,25 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -942,6 +1322,15 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -966,6 +1355,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   gaxios@7.3.0:
     resolution: {integrity: sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==}
@@ -1068,6 +1462,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@3.15.1:
     resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
@@ -1102,9 +1499,15 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   marked@18.0.5:
     resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
@@ -1133,6 +1536,11 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
@@ -1234,6 +1642,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1241,9 +1656,17 @@ packages:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -1283,6 +1706,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1305,6 +1733,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -1316,11 +1747,21 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1330,13 +1771,38 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -1362,6 +1828,79 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -1369,6 +1908,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   ws@8.21.2:
@@ -1849,6 +2393,84 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
   '@google/genai@1.52.0':
     dependencies:
       google-auth-library: 10.9.1
@@ -1866,6 +2488,8 @@ snapshots:
       iconv-lite: 0.7.3
     optionalDependencies:
       '@types/node': 24.13.3
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -1938,6 +2562,9 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2093,6 +2720,81 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
   '@silvia-odwyer/photon-node@0.3.4': {}
 
   '@smithy/core@3.31.1':
@@ -2148,6 +2850,15 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@24.13.3':
@@ -2187,6 +2898,48 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   abbrev@1.1.1: {}
 
   agent-base@7.1.4: {}
@@ -2202,6 +2955,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
 
@@ -2225,9 +2980,21 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@5.6.2: {}
 
   chardet@2.2.0: {}
+
+  check-error@2.1.3: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -2240,6 +3007,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   detect-indent@6.1.0: {}
 
@@ -2265,7 +3034,44 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
   esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -2282,6 +3088,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   fetch-blob@3.2.0:
     dependencies:
@@ -2312,6 +3122,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.3:
+    optional: true
 
   gaxios@7.3.0:
     dependencies:
@@ -2417,6 +3230,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
@@ -2458,7 +3273,13 @@ snapshots:
 
   long@5.3.2: {}
 
+  loupe@3.2.1: {}
+
   lru-cache@11.5.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@18.0.5: {}
 
@@ -2478,6 +3299,8 @@ snapshots:
   mri@1.2.0: {}
 
   ms@2.1.3: {}
+
+  nanoid@3.3.17: {}
 
   node-domexception@1.0.0: {}
 
@@ -2582,11 +3405,23 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.17
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prettier@2.8.8: {}
 
@@ -2629,6 +3464,38 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2645,11 +3512,15 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
 
   spawndamnit@3.0.1:
     dependencies:
@@ -2658,15 +3529,38 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
   strip-bom@3.0.0: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   term-size@2.2.1: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
   tinypool@2.1.0: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -2684,11 +3578,92 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  vite-node@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rollup: 4.62.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
+  vitest@3.2.7(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-streams-polyfill@3.3.3: {}
 
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.21.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,11 +3,14 @@ packages:
 
 allowBuilds:
   '@google/genai': set this to true or false
+  esbuild: set this to true or false
   protobufjs: set this to true or false
 
 # Transitive deps of the pi packages (typecheck-only here); their postinstalls aren't needed.
+# esbuild (via vitest) ships its binary as a platform package; no postinstall needed.
 ignoredBuiltDependencies:
   - '@google/genai'
+  - esbuild
   - protobufjs
 minimumReleaseAgeExclude:
   - '@earendil-works/pi-agent-core@0.84.0'


### PR DESCRIPTION
## What

Declarative multi-stage workflow engine in `@nicknisi/pi-shared` (phase 2b core), built on the subagent runtime:

- **DAG scheduling** over `needs` (default linear chain), concurrency-capped; cycles/unknown deps/duplicate ids settle as typed skips — `runWorkflow` never rejects
- **Resource exclusion**: `sharesTree` stages launch only into an empty pool and block other starts while running (conservative, correctness-first)
- **Two-channel handoff**: typed outcomes via `ctx.results` + bounded (64KB) `git diff HEAD` captured when `sharesTree` stages complete → `ctx.treeDiffs` for dependents
- **`foreach`** fan-out (static or derived from a dependency's outcome) with per-item concurrency and aggregated output; **`gate`** revise-feedback loops (`maxGateAttempts`); **retries** on crashed/empty; **`tokenBudget`** strands unstarted stages as `budget_exceeded`
- **Control artifacts** (`status.json` + `stages/<id>.json`) under `~/.pi/agent/workflow-runs/` + `resumeFrom` that skips previously-ok stages
- **Abort threading**: `opts.signal` is passed into every stage spawn, so callers can cancel a whole workflow
- **First repo test infra**: vitest + `pnpm test`; 14 cases over a hand-rolled fake runtime (no LLM calls), incl. a real temp-git-repo diff-capture test

Built by a worker subagent in an isolated worktree; integrated and re-verified by the parent.

## Verification

`pnpm typecheck && pnpm lint && pnpm format:check && pnpm build && pnpm test` all green (14/14). **Live smoke**: real 2-stage workflow through the actual runtime — typed handoff observed, control artifacts persisted. Tracking: #20