### PR TITLE
feat: subagents/codemode

### DIFF
--- a/.changeset/codemode-workflow.md
+++ b/.changeset/codemode-workflow.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-codemode': minor
+---
+
+The `codemode` tool gains a third injected binding: `runWorkflow(spec, opts?)` — the shared declarative workflow engine (needs/foreach/gates/retries, sharesTree tree-diff handoff, control artifacts + resume), bound to the codemode runtime with the tool's abort signals threaded into every stage spawn.

--- a/.changeset/codemode.md
+++ b/.changeset/codemode.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-codemode': minor
+---
+
+New package: codemode rebuilt on the first-party subagent platform. The `codemode` tool executes model-written TypeScript in-process (via bundle-require) with an injected `spawn` binding over the shared in-process runtime — compositional orchestration (Promise.all fan-out, pipelines, map/reduce) with typed SpawnResults, bounded results/logs, timeout with child abort, and no pi-subagents dependency.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Local paths are added to pi's settings without copying — edits in the repo are
 
 ### Productivity
 
-| Package                              | What it does                                                                                                                             | Adds                                         |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| [answer](packages/answer/)           | Extracts questions from the last assistant message via a side LLM call, answers them in a tab-through overlay, sends one formatted reply | `/answer`, `ctrl+.`, Q&A overlay             |
-| [btw](packages/btw/)                 | Side-channel LLM chat in a floating window — sees branch context, never touches the main agent's context; promote or fork the thread     | `/btw`, overlay, `btw-answer` entry type     |
-| [handoff](packages/handoff/)         | Transfers context to a new linked session with a model-generated, editable prompt instead of compacting                                  | `/handoff <goal>`                            |
-| [llm-council](packages/llm-council/) | Multiple models answer in parallel as in-process child sessions; a chairman synthesizes                                                  | `llm_council` tool with live inline progress |
-| [subagents](packages/subagents/)     | First-party subagent dispatch + fleet: fan out parallel hermetic child agents, inspect live/persisted runs — no pi-subagents dependency  | `dispatch` and `fleet` tools, `/fleet`       |
-| [orchestrate](packages/orchestrate/) | `/goal` keeps working until a condition holds; `/loop` re-runs a prompt on a timer                                                       | `/goal`, `/loop`                             |
-| [save-md](packages/save-md/)         | Export the latest assistant response to a markdown file                                                                                  | `/save-md <name>`                            |
+| Package                              | What it does                                                                                                                                      | Adds                                         |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| [answer](packages/answer/)           | Extracts questions from the last assistant message via a side LLM call, answers them in a tab-through overlay, sends one formatted reply          | `/answer`, `ctrl+.`, Q&A overlay             |
+| [btw](packages/btw/)                 | Side-channel LLM chat in a floating window — sees branch context, never touches the main agent's context; promote or fork the thread              | `/btw`, overlay, `btw-answer` entry type     |
+| [codemode](packages/codemode/)       | Model-written TypeScript orchestrates subagents compositionally (Promise.all fan-out, pipelines) — executed in-process, returns the module result | `codemode` tool                              |
+| [handoff](packages/handoff/)         | Transfers context to a new linked session with a model-generated, editable prompt instead of compacting                                           | `/handoff <goal>`                            |
+| [llm-council](packages/llm-council/) | Multiple models answer in parallel as in-process child sessions; a chairman synthesizes                                                           | `llm_council` tool with live inline progress |
+| [subagents](packages/subagents/)     | First-party subagent dispatch + fleet: fan out parallel hermetic child agents, inspect live/persisted runs — no pi-subagents dependency           | `dispatch` and `fleet` tools, `/fleet`       |
+| [orchestrate](packages/orchestrate/) | `/goal` keeps working until a condition holds; `/loop` re-runs a prompt on a timer                                                                | `/goal`, `/loop`                             |
+| [save-md](packages/save-md/)         | Export the latest assistant response to a markdown file                                                                                           | `/save-md <name>`                            |
 
 ### UI & appearance
 

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -1,0 +1,70 @@
+# @nicknisi/pi-codemode
+
+Codemode for the first-party subagent platform: the model writes TypeScript that orchestrates subagents **compositionally** — `Promise.all` fan-out, sequential pipelines, map/reduce over files — and the `codemode` tool compiles and runs it in-process, returning the module's default export as the result. Rebuilt on `@nicknisi/pi-shared`'s in-process runtime; no pi-subagents dependency, no pi-mcp-adapter.
+
+## What it adds
+
+- **`codemode` tool** (model-facing) — params: `{ code: string; label?: string; timeoutMs?: number }` (default 10 min, capped at 30 min). The snippet gets two injected bindings and must `export default` its result.
+
+## The snippet API
+
+```ts
+spawn(options: SpawnOptions): Promise<SpawnResult>;
+log(...args: unknown[]): void;
+```
+
+- `spawn` launches a hermetic in-process child agent through the shared runtime (namespace `codemode`). Children are version-matched to the host, cannot themselves spawn, and honor the ecosystem recursion guard. Run artifacts persist to `~/.pi/agent/subagent-runs/codemode/`, so codemode children appear in the `fleet` tool / `/fleet` command from `@nicknisi/pi-subagents`.
+- `spawn` **never rejects**. Check `result.ok`; failures carry `kind: 'crashed' | 'empty' | 'schema_invalid' | 'aborted'` plus `error`.
+- `SpawnOptions` highlights: `prompt` (required), `agent` (label), `model` (`'provider/id'`), `tools` (allowlist — pass `['read','grep','find','ls']` for read-only children; `undefined` = pi defaults `read/bash/edit/write`), `systemPrompt`, `outputSchema` (validated; parsed JSON lands in `result.data`), `cwd`, `timeoutMs`, `maxTurns`, `maxToolCalls`, `thinkingLevel`.
+- `log` output comes back in the tool result's `details.logs`.
+
+No imports resolve inside the snippet (it's bundled standalone from a temp dir) — `spawn` and `log` are the whole API. Composition is plain code: that's the point.
+
+## Usage examples
+
+Parallel research fan-out:
+
+```ts
+const questions = [
+  'How does the auth refresh flow work?',
+  'Where are sessions persisted?',
+  'What breaks if the token endpoint 500s?',
+];
+const results = await Promise.all(questions.map((q) => spawn({ prompt: q, tools: ['read', 'grep', 'find', 'ls'] })));
+export default results.map((r, i) => ({
+  question: questions[i],
+  answer: r.ok ? r.text.slice(0, 500) : `FAILED (${r.kind}): ${r.error}`,
+}));
+```
+
+Map/reduce over files with a pipeline:
+
+```ts
+const files = ['src/a.ts', 'src/b.ts', 'src/c.ts'];
+const summaries = [];
+for (const f of files) {
+  const r = await spawn({ prompt: `Summarize the public API of ${f} in 3 bullets.`, tools: ['read'] });
+  summaries.push({ file: f, summary: r.ok ? r.text : `failed: ${r.error}` });
+}
+const rollup = await spawn({
+  prompt: `Combine these module summaries into one architecture paragraph:\n${JSON.stringify(summaries)}`,
+  tools: [],
+});
+export default { rollup: rollup.ok ? rollup.text : 'rollup failed', summaries };
+```
+
+## Security model
+
+The snippet executes **in-process with the host's full privileges**. This is the same trust boundary as any `bash` tool call and as the original pi-codemode: it's your model, writing code for your session, on your machine. There is no sandbox. Do not point it at untrusted prompt sources.
+
+## Configuration
+
+None.
+
+## Caveats
+
+- **No crash isolation.** A pathological snippet (memory bomb, infinite sync loop) hurts the host. The timeout cannot preempt CPU-bound synchronous code — it aborts in-flight subagents and stops awaiting, but JS can't be killed mid-`while(true)`.
+- **Timeout semantics:** on expiry, in-flight `spawn` calls are aborted (children stop quickly) and the tool returns a timeout error with captured logs; the detached snippet promise settles later and is discarded.
+- **`export default` is required.** A missing/undefined default export returns a notice, not an error.
+- **Results are bounded** (16 KB), logs are bounded (200 entries × 2 KB), stacks are bounded (4 KB).
+- **bundle-require/ESM interop quirks:** the snippet is esbuild-bundled as ESM with target es2022 (top-level await works); bare imports fail by design.

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -10,15 +10,17 @@ Codemode for the first-party subagent platform: the model writes TypeScript that
 
 ```ts
 spawn(options: SpawnOptions): Promise<SpawnResult>;
+runWorkflow(spec: WorkflowSpec, opts?): Promise<WorkflowResult>;
 log(...args: unknown[]): void;
 ```
 
 - `spawn` launches a hermetic in-process child agent through the shared runtime (namespace `codemode`). Children are version-matched to the host, cannot themselves spawn, and honor the ecosystem recursion guard. Run artifacts persist to `~/.pi/agent/subagent-runs/codemode/`, so codemode children appear in the `fleet` tool / `/fleet` command from `@nicknisi/pi-subagents`.
 - `spawn` **never rejects**. Check `result.ok`; failures carry `kind: 'crashed' | 'empty' | 'schema_invalid' | 'aborted'` plus `error`.
+- `runWorkflow` runs a declarative multi-stage DAG over `spawn` (from `@nicknisi/pi-shared`'s engine): per-stage `needs` deps (default linear), `foreach` fan-out, `gate` revise-feedback loops, `retries`, `tokenBudget`, and `sharesTree` stages that never overlap other work and hand their bounded `git diff HEAD` to dependents. Control artifacts land in `~/.pi/agent/workflow-runs/`; `opts.resumeFrom` skips previously-ok stages. Also never rejects — per-stage outcomes carry `ok`/`kind`. Prefer it over hand-rolled `Promise.all` when stages depend on each other, need gates/retries, or edit the working tree.
 - `SpawnOptions` highlights: `prompt` (required), `agent` (label), `model` (`'provider/id'`), `tools` (allowlist — pass `['read','grep','find','ls']` for read-only children; `undefined` = pi defaults `read/bash/edit/write`), `systemPrompt`, `outputSchema` (validated; parsed JSON lands in `result.data`), `cwd`, `timeoutMs`, `maxTurns`, `maxToolCalls`, `thinkingLevel`.
 - `log` output comes back in the tool result's `details.logs`.
 
-No imports resolve inside the snippet (it's bundled standalone from a temp dir) — `spawn` and `log` are the whole API. Composition is plain code: that's the point.
+No imports resolve inside the snippet (it's bundled standalone from a temp dir) — `spawn`, `runWorkflow`, and `log` are the whole API. Composition is plain code: that's the point.
 
 ## Usage examples
 
@@ -64,7 +66,7 @@ None.
 ## Caveats
 
 - **No crash isolation.** A pathological snippet (memory bomb, infinite sync loop) hurts the host. The timeout cannot preempt CPU-bound synchronous code — it aborts in-flight subagents and stops awaiting, but JS can't be killed mid-`while(true)`.
-- **Timeout semantics:** on expiry, in-flight `spawn` calls are aborted (children stop quickly) and the tool returns a timeout error with captured logs; the detached snippet promise settles later and is discarded.
+- **Timeout semantics:** on expiry, in-flight `spawn` calls (including every stage of an in-flight `runWorkflow`) are aborted (children stop quickly) and the tool returns a timeout error with captured logs; the detached snippet promise settles later and is discarded.
 - **`export default` is required.** A missing/undefined default export returns a notice, not an error.
 - **Results are bounded** (16 KB), logs are bounded (200 entries × 2 KB), stacks are bounded (4 KB).
 - **bundle-require/ESM interop quirks:** the snippet is esbuild-bundled as ESM with target es2022 (top-level await works); bare imports fail by design.

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -1,0 +1,188 @@
+/**
+ * codemode for the first-party subagent platform.
+ *
+ * One tool, `codemode`: the model writes TypeScript that orchestrates
+ * subagents compositionally (Promise.all fan-out, pipelines, map/reduce),
+ * and the tool compiles + runs it in-process via bundle-require, returning
+ * the module's default export as the result.
+ *
+ * The snippet runs standalone — no imports resolve from the temp dir. Its
+ * entire API is two injected bindings:
+ *
+ *   spawn(options: SpawnOptions): Promise<SpawnResult>  — shared-runtime
+ *     spawn (namespace 'codemode'); never rejects, check result.ok.
+ *   log(...args): void — captured into the tool result's details.
+ *
+ * Safety posture: this executes model-written code with the host process's
+ * full privileges. That is the accepted model (your model, your session) —
+ * the same trust boundary as pi-codemode and any bash tool call.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { createSubagentRuntime, type SpawnOptions, type SpawnResult } from '@nicknisi/pi-shared';
+import { bundleRequire } from 'bundle-require';
+import { Type } from 'typebox';
+
+const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_TIMEOUT_MS = 30 * 60 * 1000;
+const MAX_RESULT_CHARS = 16 * 1024;
+const MAX_STACK_CHARS = 4000;
+const MAX_LOG_ENTRIES = 200;
+const MAX_LOG_CHARS = 2000;
+
+const BINDINGS_PRELUDE = 'const { spawn, log } = (globalThis as any).__piCodemode;\n';
+const GLOBAL_KEY = '__piCodemode';
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max)}\n…[truncated at ${max} chars]`;
+}
+
+function mergeSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => s !== undefined);
+  if (present.length === 0) return undefined;
+  if (present.length === 1) return present[0];
+  const controller = new AbortController();
+  const fire = () => controller.abort();
+  for (const s of present) {
+    if (s.aborted) {
+      controller.abort();
+      break;
+    }
+    s.addEventListener('abort', fire, { once: true });
+  }
+  return controller.signal;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return `${err.message}${err.stack ? `\n\n${truncate(err.stack, MAX_STACK_CHARS)}` : ''}`;
+  return String(err);
+}
+
+export default function codemode(pi: ExtensionAPI) {
+  const runtime = createSubagentRuntime({ namespace: 'codemode', artifactsDir: ARTIFACTS_ROOT });
+
+  pi.registerTool({
+    name: 'codemode',
+    label: 'Codemode',
+    description: [
+      'Execute a TypeScript snippet that orchestrates subagents compositionally and returns a result.',
+      'The snippet runs in-process with two injected bindings — spawn(options) and log(...args) — and',
+      'MUST `export default` its result. spawn(options) launches a hermetic child agent session',
+      '(in-process, no user extensions/skills/context) and resolves to a SpawnResult: on success',
+      '{ ok: true, text, data?, usage, durationMs, runId }; on failure { ok: false, kind:',
+      "'crashed'|'empty'|'schema_invalid'|'aborted', error, text, usage, durationMs, runId }.",
+      'spawn never rejects — check result.ok. SpawnOptions: { prompt: string (required); agent?:',
+      "string label; model?: string 'provider/id'; tools?: string[] allowlist (undefined = pi defaults",
+      'read/bash/edit/write — pass [read, grep, find, ls] for read-only children); systemPrompt?:',
+      'string; replaceSystemPrompt?: boolean; extensionPaths?: string[]; skillPaths?: string[];',
+      'includeContextFiles?: boolean; outputSchema?: TypeBox-like JSON schema object (validated;',
+      'parsed JSON lands in result.data); cwd?: string; timeoutMs?: number (default 15 min);',
+      'maxTurns?: number; maxToolCalls?: number; thinkingLevel?: string }. Composition — Promise.all',
+      'fan-out, sequential pipelines, map/reduce over files — is your code. No imports resolve;',
+      'spawn and log are the whole API. Keep the default export SMALL (summaries, counts, key',
+      'findings) — never raw file dumps.',
+    ].join(' '),
+    promptSnippet: 'Run TypeScript that orchestrates subagents compositionally',
+    promptGuidelines: [
+      'ALWAYS `export default` a small summary — counts, key findings, short lists — never raw file contents.',
+      'spawn never rejects: check result.ok and read result.error/result.kind on failure instead of try/catch around spawn.',
+      'Fan out independent work with Promise.all([...]) and pass read-only tool allowlists (read, grep, find, ls) to research children.',
+      'Wrap risky non-spawn steps (parsing, arithmetic on untrusted shapes) in try/catch — a thrown error fails the whole run.',
+      'Use log(...) for progress notes; they come back in the result details.',
+      'Do not attempt imports — the snippet is bundled standalone and only spawn/log are available.',
+    ],
+    parameters: Type.Object({
+      code: Type.String({ description: 'TypeScript source. Must `export default` the result.' }),
+      label: Type.Optional(Type.String({ description: 'Short label for this run (result heading).' })),
+      timeoutMs: Type.Optional(Type.Number({ description: 'Wall-clock cap. Default 10 min, max 30 min.' })),
+    }),
+
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const label = params.label ?? 'codemode';
+      const timeoutMs = Math.min(Math.max(params.timeoutMs ?? DEFAULT_TIMEOUT_MS, 1000), MAX_TIMEOUT_MS);
+      const logs: string[] = [];
+      const controller = new AbortController();
+
+      const log = (...args: unknown[]) => {
+        if (logs.length >= MAX_LOG_ENTRIES) return;
+        const line = args
+          .map((a) => {
+            if (typeof a === 'string') return a;
+            try {
+              return JSON.stringify(a);
+            } catch {
+              return String(a);
+            }
+          })
+          .join(' ');
+        logs.push(truncate(line, MAX_LOG_CHARS));
+      };
+
+      const spawn = (options: SpawnOptions): Promise<SpawnResult> => {
+        const merged = mergeSignals(options.signal, signal ?? undefined, controller.signal);
+        const { signal: _userSignal, ...rest } = options;
+        const opts: SpawnOptions = { ...rest, cwd: options.cwd ?? ctx.cwd };
+        if (merged) opts.signal = merged;
+        return runtime.spawn(opts);
+      };
+
+      const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-codemode-'));
+      const file = path.join(dir, 'snippet.ts');
+      fs.writeFileSync(file, BINDINGS_PRELUDE + params.code);
+      const startedAt = Date.now();
+
+      const runSnippet = async (): Promise<unknown> => {
+        const { mod } = await bundleRequire({
+          filepath: file,
+          format: 'esm',
+          esbuildOptions: { target: 'es2022' },
+        });
+        return mod.default;
+      };
+
+      (globalThis as any)[GLOBAL_KEY] = { spawn, log };
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const execPromise = runSnippet();
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            controller.abort(); // in-flight spawns abort; the JS itself can't be preempted
+            reject(new Error(`Timed out after ${timeoutMs}ms (in-flight subagents were aborted)`));
+          }, timeoutMs);
+        });
+        const value = await Promise.race([execPromise, timeoutPromise]);
+        execPromise.catch(() => {}); // if we raced ahead, swallow any late rejection
+        const text =
+          typeof value === 'string'
+            ? truncate(value, MAX_RESULT_CHARS)
+            : value === undefined
+              ? '(undefined — did you forget `export default`?)'
+              : truncate(JSON.stringify(value, null, 2) ?? String(value), MAX_RESULT_CHARS);
+        return {
+          content: [{ type: 'text' as const, text }],
+          details: { label, logs, durationMs: Date.now() - startedAt },
+        };
+      } catch (err) {
+        const logText = logs.length > 0 ? `\n\nCaptured logs (${logs.length}):\n${logs.join('\n')}` : '';
+        return {
+          content: [{ type: 'text' as const, text: `${label} failed:\n\n${formatError(err)}${logText}` }],
+          details: {
+            label,
+            logs,
+            durationMs: Date.now() - startedAt,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        };
+      } finally {
+        if (timer) clearTimeout(timer);
+        delete (globalThis as any)[GLOBAL_KEY];
+        fs.rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  });
+}

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -7,10 +7,13 @@
  * the module's default export as the result.
  *
  * The snippet runs standalone — no imports resolve from the temp dir. Its
- * entire API is two injected bindings:
+ * entire API is three injected bindings:
  *
  *   spawn(options: SpawnOptions): Promise<SpawnResult>  — shared-runtime
  *     spawn (namespace 'codemode'); never rejects, check result.ok.
+ *   runWorkflow(spec: WorkflowSpec, opts?): Promise<WorkflowResult> —
+ *     declarative multi-stage DAGs over spawn (needs/foreach/gates/retries,
+ *     sharesTree tree-diff handoff, control artifacts); never rejects.
  *   log(...args): void — captured into the tool result's details.
  *
  * Safety posture: this executes model-written code with the host process's
@@ -23,7 +26,15 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
-import { createSubagentRuntime, type SpawnOptions, type SpawnResult } from '@nicknisi/pi-shared';
+import {
+  createSubagentRuntime,
+  runWorkflow,
+  type RunWorkflowOptions,
+  type SpawnOptions,
+  type SpawnResult,
+  type WorkflowResult,
+  type WorkflowSpec,
+} from '@nicknisi/pi-shared';
 import { bundleRequire } from 'bundle-require';
 import { Type } from 'typebox';
 
@@ -35,7 +46,7 @@ const MAX_STACK_CHARS = 4000;
 const MAX_LOG_ENTRIES = 200;
 const MAX_LOG_CHARS = 2000;
 
-const BINDINGS_PRELUDE = 'const { spawn, log } = (globalThis as any).__piCodemode;\n';
+const BINDINGS_PRELUDE = 'const { spawn, log, runWorkflow } = (globalThis as any).__piCodemode;\n';
 const GLOBAL_KEY = '__piCodemode';
 
 function truncate(text: string, max: number): string {
@@ -83,8 +94,16 @@ export default function codemode(pi: ExtensionAPI) {
       'includeContextFiles?: boolean; outputSchema?: TypeBox-like JSON schema object (validated;',
       'parsed JSON lands in result.data); cwd?: string; timeoutMs?: number (default 15 min);',
       'maxTurns?: number; maxToolCalls?: number; thinkingLevel?: string }. Composition — Promise.all',
-      'fan-out, sequential pipelines, map/reduce over files — is your code. No imports resolve;',
-      'spawn and log are the whole API. Keep the default export SMALL (summaries, counts, key',
+      'Composition — Promise.all',
+      'fan-out, sequential pipelines, map/reduce over files — is your code. For dependent multi-stage',
+      'work use runWorkflow(spec, opts?): { name, stages: [{ id, prompt (string or (ctx, item?, index?)',
+      '=> string; ctx = { results, treeDiffs, cwd, runDir }), needs?: string[] (default: previous stage),',
+      'model?, tools?, systemPrompt?, outputSchema?, foreach?: unknown[] | { from: stageId, pick?: (outcome)',
+      '=> unknown[] }, gate?: (outcome, ctx) => true | { revise: feedback }, maxGateAttempts?, retries?,',
+      'sharesTree?: boolean (never overlaps other stages; its git diff HEAD flows to dependents via',
+      'treeDiffs), maxTurns?, maxToolCalls?, timeoutMs? }], concurrency?, tokenBudget? } — resolves to',
+      '{ ok, outcomes, usage, runDir }; never rejects. No imports resolve;',
+      'spawn, runWorkflow, and log are the whole API. Keep the default export SMALL (summaries, counts, key',
       'findings) — never raw file dumps.',
     ].join(' '),
     promptSnippet: 'Run TypeScript that orchestrates subagents compositionally',
@@ -93,8 +112,9 @@ export default function codemode(pi: ExtensionAPI) {
       'spawn never rejects: check result.ok and read result.error/result.kind on failure instead of try/catch around spawn.',
       'Fan out independent work with Promise.all([...]) and pass read-only tool allowlists (read, grep, find, ls) to research children.',
       'Wrap risky non-spawn steps (parsing, arithmetic on untrusted shapes) in try/catch — a thrown error fails the whole run.',
+      'Prefer runWorkflow over hand-rolled Promise.all when stages depend on each other, need gates/retries, or edit the working tree.',
       'Use log(...) for progress notes; they come back in the result details.',
-      'Do not attempt imports — the snippet is bundled standalone and only spawn/log are available.',
+      'Do not attempt imports — the snippet is bundled standalone and only spawn/runWorkflow/log are available.',
     ],
     parameters: Type.Object({
       code: Type.String({ description: 'TypeScript source. Must `export default` the result.' }),
@@ -131,6 +151,16 @@ export default function codemode(pi: ExtensionAPI) {
         return runtime.spawn(opts);
       };
 
+      const boundRunWorkflow = (
+        spec: WorkflowSpec,
+        wfOpts: Partial<RunWorkflowOptions> = {},
+      ): Promise<WorkflowResult> => {
+        const merged = mergeSignals(wfOpts.signal, signal ?? undefined, controller.signal);
+        const full: RunWorkflowOptions = { cwd: ctx.cwd, ...wfOpts };
+        if (merged) full.signal = merged;
+        return runWorkflow(spec, runtime, full);
+      };
+
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-codemode-'));
       const file = path.join(dir, 'snippet.ts');
       fs.writeFileSync(file, BINDINGS_PRELUDE + params.code);
@@ -145,7 +175,7 @@ export default function codemode(pi: ExtensionAPI) {
         return mod.default;
       };
 
-      (globalThis as any)[GLOBAL_KEY] = { spawn, log };
+      (globalThis as any)[GLOBAL_KEY] = { spawn, log, runWorkflow: boundRunWorkflow };
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
         const execPromise = runSnippet();

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@nicknisi/pi-codemode",
+  "version": "0.0.0",
+  "description": "Execute model-written TypeScript that orchestrates subagents compositionally — one codemode tool over the first-party in-process runtime",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/codemode#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/codemode"
+  },
+  "files": [
+    "dist",
+    "index.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@nicknisi/pi-shared": "workspace:*",
+    "bundle-require": "^5.1.0",
+    "esbuild": "^0.25.0",
+    "typebox": "^1.1.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,21 @@ importers:
 
   packages/cloak: {}
 
+  packages/codemode:
+    dependencies:
+      '@nicknisi/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+      bundle-require:
+        specifier: ^5.1.0
+        version: 5.1.0(esbuild@0.25.12)
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typebox:
+        specifier: ^1.1.0
+        version: 1.3.7
+
   packages/composer: {}
 
   packages/handoff:
@@ -334,16 +349,34 @@ packages:
     resolution: {integrity: sha512-nbs0FeZJ5rWDD6VpKfXXmYbEHnHqb40V9glE2l9f8ftoWpsP8nw0WcXK8jOjfRsDPnT9dJHy3dItOHdn/AFGjA==}
     engines: {node: '>=22.19.0'}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -352,16 +385,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -370,10 +421,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -382,10 +445,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -394,10 +469,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -406,10 +493,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -418,10 +517,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -430,16 +541,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -448,10 +577,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -460,11 +601,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -472,16 +625,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -1227,6 +1398,12 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1292,6 +1469,11 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -1488,6 +1670,10 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -2393,79 +2579,157 @@ snapshots:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -2980,6 +3244,11 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  bundle-require@5.1.0(esbuild@0.25.12):
+    dependencies:
+      esbuild: 0.25.12
+      load-tsconfig: 0.2.5
+
   cac@6.7.14: {}
 
   chai@5.3.3:
@@ -3035,6 +3304,35 @@ snapshots:
       strip-ansi: 6.0.1
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -3264,6 +3562,8 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
     dependencies:


### PR DESCRIPTION
## What

New package `@nicknisi/pi-codemode` (phase 3): codemode rebuilt on the first-party platform, replacing the stale third-party pi-codemode.

One `codemode` tool: the model writes TypeScript that orchestrates subagents compositionally (`Promise.all` fan-out, pipelines — composition is user code, that's the point). Executed in-process via bundle-require with three injected bindings, all never-rejecting:

- **`spawn(options)`** — full `SpawnOptions` surface over the shared runtime
- **`runWorkflow(spec, opts?)`** — the declarative workflow engine from #23 (needs/foreach/gates/retries, `sharesTree` tree-diff handoff, control artifacts + resume), so multi-stage DAGs are model-reachable in generated code
- **`log(...)`** — captured into result details

The module must `export default` its result (bounded 16KB). Three-signal abort merge (tool abort, timeout controller, user signal) threads into every spawn — including every stage of an in-flight workflow. Compile errors and exceptions become typed tool errors, never host crashes. ~200 lines + thorough README (usage, security model, caveats).

Built by a worker subagent in an isolated worktree; integrated and re-verified by the parent.

## Verification

Live-tested: plain snippet result + log capture; recursion guard correctly refusing nested spawn; real haiku fan-out; **2-stage `runWorkflow` through the codemode binding with typed handoff observed**. Parent re-ran `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build && pnpm test` — all green. Tracking: #20