### PR TITLE
feat: TUI surfaces for the subagent platform

### DIFF
--- a/.changeset/ui-pack.md
+++ b/.changeset/ui-pack.md
@@ -1,0 +1,7 @@
+---
+'@nicknisi/pi-subagents': minor
+'@nicknisi/pi-codemode': minor
+'@nicknisi/pi-intercom': minor
+---
+
+TUI surfaces for the platform: dispatch gets live per-task progress (renderCall/renderResult with council-style status trees) plus a background-runs widget; `/fleet` is now an interactive overlay with drill-down run details (text fallback when headless); intercom deliveries render as styled peer-mail cards with an aligned `/intercom` listing; codemode gets renderCall/renderResult with collapsed output, log tree, and error states.

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -25,8 +25,9 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import type { ExtensionAPI, Theme, ThemeColor } from '@earendil-works/pi-coding-agent';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { getKeybindings, Text } from '@earendil-works/pi-tui';
 import {
   createSubagentRuntime,
   runWorkflow,
@@ -73,6 +74,103 @@ function mergeSignals(...signals: Array<AbortSignal | undefined>): AbortSignal |
 function formatError(err: unknown): string {
   if (err instanceof Error) return `${err.message}${err.stack ? `\n\n${truncate(err.stack, MAX_STACK_CHARS)}` : ''}`;
   return String(err);
+}
+
+// ── TUI rendering ────────────────────────────────────────────────────────
+// Presentation only — the tool's text content stays authoritative for the
+// model. Visual vocabulary matches llm-council: ✓/✗ prefixes, └─ branch
+// lines, indented sub-lines, dim metadata, one accent color (the label).
+
+interface CodemodeDetails {
+  label: string;
+  logs: string[];
+  durationMs: number;
+  error?: string;
+  stack?: string;
+}
+
+const SPINNER_CHARS = ['·', '✢', '✳', '✶', '✻', '✽'];
+const SPINNER_FRAMES = [...SPINNER_CHARS, ...[...SPINNER_CHARS].reverse()];
+const SPINNER_INTERVAL_MS = 80;
+const BRANCH_PREFIX = '└─';
+const INDENT = '   '; // visible width of '└─' + 1
+const RESULT_PREVIEW_LINES = 10;
+const CODE_PREVIEW_MAX = 60;
+
+function fg(theme: Theme, color: ThemeColor, text: string): string {
+  try {
+    return theme.fg(color, text);
+  } catch {
+    return text;
+  }
+}
+
+function makeText(lastComponent: unknown, text: string): Text {
+  const comp = lastComponent instanceof Text ? lastComponent : new Text('', 0, 0);
+  comp.setText(text);
+  return comp;
+}
+
+function branchLine(theme: Theme, text: string): string {
+  return `${fg(theme, 'muted', BRANCH_PREFIX)} ${text}`;
+}
+
+function indentLine(text: string): string {
+  return `${INDENT}${text}`;
+}
+
+function expandHint(theme: Theme): string {
+  const key = getKeybindings().getKeys('app.tools.expand')[0] ?? 'ctrl+o';
+  return fg(theme, 'dim', ` • ${key} to expand`);
+}
+
+function formatDuration(ms: number | undefined): string {
+  if (ms === undefined) return '';
+  if (ms < 1000) return `(${Math.round(ms)}ms)`;
+  if (ms < 60_000) return `(${(ms / 1000).toFixed(1)}s)`;
+  return `(${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s)`;
+}
+
+/** First meaningful (non-blank) code line, trimmed and capped, plus total lines. */
+function codePreview(code: string | undefined): { line: string; count: number } {
+  if (!code) return { line: '...', count: 0 };
+  const lines = code.split('\n');
+  const first = lines.find((l) => l.trim().length > 0)?.trim() ?? '...';
+  return {
+    line: first.length > CODE_PREVIEW_MAX ? `${first.slice(0, CODE_PREVIEW_MAX)}…` : first,
+    count: lines.length,
+  };
+}
+
+function appendLogTree(lines: string[], logs: string[], theme: Theme): void {
+  if (logs.length === 0) return;
+  lines.push('');
+  lines.push(branchLine(theme, `${fg(theme, 'muted', 'logs')} ${fg(theme, 'dim', `(${logs.length})`)}`));
+  for (const entry of logs) {
+    for (const line of entry.split('\n')) lines.push(indentLine(fg(theme, 'dim', line)));
+  }
+}
+
+function ensureSpinner(ctx: any): number {
+  if (ctx?.state?.spinnerInterval) return ctx.state.spinnerFrame ?? 0;
+  if (!ctx?.state) ctx.state = {};
+  ctx.state.spinnerFrame = 0;
+  ctx.state.spinnerInterval = setInterval(() => {
+    ctx.state.spinnerFrame = (ctx.state.spinnerFrame + 1) % SPINNER_FRAMES.length;
+    ctx.invalidate?.();
+  }, SPINNER_INTERVAL_MS);
+  return 0;
+}
+
+function clearSpinner(ctx: any) {
+  if (ctx?.state?.spinnerInterval) {
+    clearInterval(ctx.state.spinnerInterval);
+    ctx.state.spinnerInterval = undefined;
+  }
+}
+
+function spinnerDot(theme: Theme, frame: number): string {
+  return `${fg(theme, 'muted', SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!)} `;
 }
 
 export default function codemode(pi: ExtensionAPI) {
@@ -223,6 +321,7 @@ export default function codemode(pi: ExtensionAPI) {
             logs,
             durationMs: Date.now() - startedAt,
             error: err instanceof Error ? err.message : String(err),
+            ...(err instanceof Error && err.stack ? { stack: truncate(err.stack, MAX_STACK_CHARS) } : {}),
           },
         };
       } finally {
@@ -231,6 +330,76 @@ export default function codemode(pi: ExtensionAPI) {
         fs.rmSync(dir, { recursive: true, force: true });
         release(); // let the next queued run set its own bindings
       }
+    },
+
+    renderCall(args, theme, ctx) {
+      const label = args.label?.trim() || 'codemode';
+      const preview = codePreview(args.code);
+      const header = `${fg(theme, 'toolTitle', theme.bold('Codemode'))} ${fg(theme, 'accent', label)}`;
+      const meta = fg(theme, 'dim', `${preview.line} · ${preview.count} ${preview.count === 1 ? 'line' : 'lines'}`);
+      const body = `${header}\n${branchLine(theme, meta)}`;
+
+      if (!ctx?.isPartial) {
+        clearSpinner(ctx);
+        return makeText(ctx?.lastComponent, `${fg(theme, 'success', '✓')} ${body}`);
+      }
+      return makeText(ctx.lastComponent, `${spinnerDot(theme, ensureSpinner(ctx))}${body}`);
+    },
+
+    renderResult(result, options, theme, ctx) {
+      const details = result.details as CodemodeDetails | undefined;
+      const expanded = options?.expanded ?? false;
+      const content = result.content[0];
+      const fullText = content?.type === 'text' ? content.text : '';
+
+      // No details — plain text fallback
+      if (!details) {
+        return makeText(ctx?.lastComponent, fullText || '(no output)');
+      }
+
+      const logs = details.logs ?? [];
+      const label = fg(theme, 'accent', details.label);
+      const duration = fg(theme, 'dim', formatDuration(details.durationMs));
+
+      // ── Error state ──────────────────────────────────────────────
+      if (details.error) {
+        const header = `${fg(theme, 'error', '✗')} ${label} ${duration}`;
+        const firstLine = details.error.split('\n')[0] ?? details.error;
+        if (!expanded) {
+          const lines = [header, `${branchLine(theme, fg(theme, 'error', firstLine))}${expandHint(theme)}`];
+          return makeText(ctx?.lastComponent, lines.join('\n'));
+        }
+        const lines = [header, branchLine(theme, fg(theme, 'error', firstLine))];
+        if (details.stack) {
+          for (const line of details.stack.split('\n')) lines.push(indentLine(fg(theme, 'dim', line)));
+        }
+        appendLogTree(lines, logs, theme);
+        return makeText(ctx?.lastComponent, lines.join('\n'));
+      }
+
+      // ── Success ──────────────────────────────────────────────────
+      const header = `${fg(theme, 'success', '✓')} ${label} ${duration}`;
+      const resultLines = fullText.split('\n');
+
+      // Collapsed: first ~10 lines + dim overflow marker
+      if (!expanded) {
+        const shown = resultLines.slice(0, RESULT_PREVIEW_LINES);
+        const remaining = resultLines.length - shown.length;
+        const lines = [header];
+        shown.forEach((line, i) => lines.push(i === 0 ? branchLine(theme, line) : indentLine(line)));
+        if (remaining > 0) {
+          lines.push(`${indentLine(fg(theme, 'dim', `+${remaining} more lines`))}${expandHint(theme)}`);
+        } else if (logs.length > 0) {
+          lines[0] = `${header}${expandHint(theme)}`;
+        }
+        return makeText(ctx?.lastComponent, lines.join('\n'));
+      }
+
+      // Expanded: full result + captured logs as an indented tree section
+      const lines = [header];
+      resultLines.forEach((line, i) => lines.push(i === 0 ? branchLine(theme, line) : indentLine(line)));
+      appendLogTree(lines, logs, theme);
+      return makeText(ctx?.lastComponent, lines.join('\n'));
     },
   });
 }

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -32,7 +32,8 @@
     "typebox": "^1.1.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "pi": {
     "extensions": [

--- a/packages/intercom/format.ts
+++ b/packages/intercom/format.ts
@@ -23,7 +23,7 @@ function age(ts: number, now: number): string {
 
 /** Delivery text injected into the receiving session. */
 export function formatDelivery(letter: Letter, now: number = Date.now()): string {
-  const header = `📨 From pi session "${letter.from.name}" (${letter.from.cwd})`;
+  const header = `From pi session "${letter.from.name}" (${letter.from.cwd})`;
   const meta = `_id ${letter.id} · ${letter.kind} · sent ${age(letter.ts, now)}_`;
   const hint =
     letter.kind === 'ask'

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -17,7 +17,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
-import { getKeybindings, Text } from '@earendil-works/pi-tui';
+import { Box, getKeybindings, Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 import {
   formatDelivery,
@@ -536,7 +536,10 @@ export default function intercom(pi: ExtensionAPI) {
       return undefined; // pre-renderer entries: keep pi's default custom-message box
     }
     const id8 = d.id.slice(0, 8);
-    const header = `📨 ${theme.fg('accent', theme.bold(displayName(d.from.name)))} ${theme.fg('dim', `(${shortCwd(d.from.cwd)})`)} ${theme.fg('dim', `[${d.kind}]`)}`;
+    // Header: bold accent name + dim cwd + an inverse kind chip — the chip is
+    // what makes a delivery pop from ordinary transcript text at a glance.
+    const chip = theme.inverse(` ${d.kind.toUpperCase()} `);
+    const header = `${theme.fg('accent', theme.bold(displayName(d.from.name)))} ${theme.fg('dim', `(${shortCwd(d.from.cwd)})`)} ${chip}`;
 
     // Compact by default: cap the body, with council-style progressive disclosure.
     const MAX_LINES = 6;
@@ -563,7 +566,11 @@ export default function intercom(pi: ExtensionAPI) {
     if (truncated) {
       out.push(theme.fg('dim', `… ${expandToggleKey()} to expand`));
     }
-    return new Text(out.join('\n'), 0, 0);
+    // Whole card on the theme's custom-message background, full width —
+    // peer mail is visually a different thing from user/assistant text.
+    const box = new Box(1, 1, (t) => theme.bg('customMessageBg', t));
+    box.addChild(new Text(out.join('\n'), 0, 0));
+    return box;
   });
 
   // ── /intercom listing ──────────────────────────────────────────────────

--- a/packages/intercom/index.ts
+++ b/packages/intercom/index.ts
@@ -13,9 +13,11 @@
 
 import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
+import { getKeybindings, Text } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 import {
   formatDelivery,
@@ -39,12 +41,86 @@ import {
   type Letter,
 } from './mailbox.js';
 import { OutboundPolicy, inboundAccepts } from './policy.js';
-import { deriveAddr, ensureRoot, listRecords, presenceOf, sweep, writeRecord, type SessionRecord } from './registry.js';
+import {
+  deriveAddr,
+  ensureRoot,
+  listRecords,
+  presenceOf,
+  sweep,
+  writeRecord,
+  type Presence,
+  type SessionRecord,
+} from './registry.js';
 
 type AskOutcome = { replied: true; body: string; from: string } | { replied: false; reason: string };
 
 function toolResult(text: string, details: Record<string, unknown> = {}) {
   return { content: [{ type: 'text' as const, text }], details };
+}
+
+// ── Transcript rendering (TUI presentation only) ────────────────────────
+// The delivery CONTENT string (formatDelivery) is what the model reads and
+// stays byte-for-byte complete; these renderers only change how the entries
+// look in the terminal. Visual vocabulary matches llm-council: one accent,
+// dim metadata, └─ hints, ✓/✗-family status glyphs.
+
+const DELIVERY_TYPE = 'intercom:delivery';
+const LIST_TYPE = 'intercom:list';
+
+/** Presentation metadata for a delivery. `details` is never sent to the LLM. */
+interface DeliveryDetails {
+  id: string;
+  kind: Letter['kind'];
+  from: { addr: string; name: string; cwd: string };
+  ts: number;
+  body: string;
+  replyTo?: string;
+}
+
+interface IntercomListRow {
+  name: string;
+  addr: string;
+  cwd: string;
+  presence: Presence;
+  status: SessionRecord['status'];
+}
+
+/** Strip peer-supplied ANSI escapes/control chars before they reach the terminal. */
+function sanitizeTerminal(text: string): string {
+  return (
+    text
+      // eslint-disable-next-line no-control-regex -- intentionally strips CSI sequences
+      .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '')
+      // eslint-disable-next-line no-control-regex -- intentionally strips OSC sequences
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g, '')
+      // eslint-disable-next-line no-control-regex -- intentionally strips C0 controls (keeps \n \t)
+      .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, '')
+  );
+}
+
+/** One-line display name, length-capped. */
+function displayName(name: string): string {
+  return sanitizeTerminal(name.replace(/\s+/g, ' ')).slice(0, 40);
+}
+
+/** Collapse $HOME to ~ for display. */
+function shortCwd(cwd: string): string {
+  const home = os.homedir();
+  const display = cwd === home ? '~' : cwd.startsWith(`${home}/`) ? `~/${cwd.slice(home.length + 1)}` : cwd;
+  return sanitizeTerminal(display);
+}
+
+/** "12s ago" / "3m ago" / "2h ago" — mirrors format.ts's age(). */
+function relativeTime(ts: number, now: number = Date.now()): string {
+  const s = Math.max(0, Math.round((now - ts) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.round(m / 60)}h ago`;
+}
+
+function expandToggleKey(): string {
+  return getKeybindings().getKeys('app.tools.expand')[0] ?? 'ctrl+o';
 }
 
 // ── Resumability (for sweep) ─────────────────────────────────────────────
@@ -113,11 +189,21 @@ export default function intercom(pi: ExtensionAPI) {
       }
     }
     if (letter.kind === 'ask') trackIncomingAsk(root, self!.addr, letter);
+    // details feeds the TUI renderer only (never sent to the LLM); content
+    // remains the full model-facing delivery text.
+    const details: DeliveryDetails = {
+      id: letter.id,
+      kind: letter.kind,
+      from: letter.from,
+      ts: letter.ts,
+      body: letter.body,
+      ...(letter.replyTo !== undefined ? { replyTo: letter.replyTo } : {}),
+    };
     const message = {
-      customType: 'intercom:delivery',
+      customType: DELIVERY_TYPE,
       content: formatDelivery(letter),
       display: true,
-      details: { id: letter.id, kind: letter.kind, from: letter.from },
+      details,
     };
     // steer lands between tool calls mid-run; triggerTurn wakes an idle
     // session. A busy agent rejects triggerTurn ("Agent is already
@@ -440,18 +526,92 @@ export default function intercom(pi: ExtensionAPI) {
     throw err;
   }
 
+  // ── Delivery card ──────────────────────────────────────────────────────
+  // Deliveries are custom MESSAGES (they must stay in LLM context), so the
+  // TUI renders them via registerMessageRenderer — an entry renderer would
+  // never fire for them.
+  pi.registerMessageRenderer<DeliveryDetails>(DELIVERY_TYPE, (message, { expanded }, theme) => {
+    const d = message.details;
+    if (!d || typeof d.id !== 'string' || typeof d.ts !== 'number' || typeof d.body !== 'string' || !d.from) {
+      return undefined; // pre-renderer entries: keep pi's default custom-message box
+    }
+    const id8 = d.id.slice(0, 8);
+    const header = `📨 ${theme.fg('accent', theme.bold(displayName(d.from.name)))} ${theme.fg('dim', `(${shortCwd(d.from.cwd)})`)} ${theme.fg('dim', `[${d.kind}]`)}`;
+
+    // Compact by default: cap the body, with council-style progressive disclosure.
+    const MAX_LINES = 6;
+    const MAX_CHARS = 1200;
+    let body = sanitizeTerminal(d.body);
+    let truncated = false;
+    if (!expanded) {
+      const lines = body.split('\n');
+      if (lines.length > MAX_LINES) {
+        body = lines.slice(0, MAX_LINES).join('\n');
+        truncated = true;
+      }
+      if (body.length > MAX_CHARS) {
+        body = `${body.slice(0, MAX_CHARS)}…`;
+        truncated = true;
+      }
+    }
+
+    const footer = theme.fg('dim', `id ${id8} · ${d.kind} · ${relativeTime(d.ts)}`);
+    const out = [header, body, '', footer];
+    if (d.kind === 'ask') {
+      out.push(theme.fg('dim', `└─ reply via intercom { action: "reply", replyTo: "${id8}" }`));
+    }
+    if (truncated) {
+      out.push(theme.fg('dim', `… ${expandToggleKey()} to expand`));
+    }
+    return new Text(out.join('\n'), 0, 0);
+  });
+
+  // ── /intercom listing ──────────────────────────────────────────────────
+  // A custom ENTRY (appendEntry): the listing is for the human, never the
+  // model — the tool's list action already serves context.
+  pi.registerEntryRenderer<{ rows: IntercomListRow[] }>(LIST_TYPE, (entry, _options, theme) => {
+    const rows = entry.data?.rows;
+    if (!rows) return undefined;
+    if (rows.length === 0) {
+      return new Text(theme.fg('dim', '· No other pi sessions registered.'), 0, 0);
+    }
+    const clean = rows.map((r) => ({ ...r, name: displayName(r.name).slice(0, 24) }));
+    const nameW = Math.max(...clean.map((r) => r.name.length));
+    const lines = [theme.fg('dim', `intercom · ${clean.length} session${clean.length === 1 ? '' : 's'}`)];
+    for (const r of clean) {
+      const dot =
+        r.presence === 'live'
+          ? theme.fg('success', '●')
+          : r.presence === 'stalled'
+            ? theme.fg('warning', '●')
+            : theme.fg('dim', '○');
+      const state = r.presence === 'live' ? r.status : r.presence === 'stalled' ? 'not responding' : 'offline';
+      const meta = theme.fg('dim', `${shortAddr(r.addr)}  ${shortCwd(r.cwd)}  ${state}`);
+      lines.push(`${dot} ${theme.fg('accent', r.name.padEnd(nameW))} ${meta}`);
+    }
+    return new Text(lines.join('\n'), 0, 0);
+  });
+
   pi.registerCommand('intercom', {
     description: 'List registered pi sessions (the intercom mailbox listing)',
-    handler: async (_args, _ctx) => {
-      const text = self
-        ? formatListing(listRecords(root), self.addr, (r) => presenceOf(r))
-        : 'Intercom is not initialized (no session_start yet).';
-      pi.sendMessage({
-        customType: 'intercom:list',
-        content: text,
-        display: true,
-        details: { kind: 'intercom-list' },
-      });
+    handler: async (_args, ctx) => {
+      if (!self || !ctx.hasUI) {
+        // Plain-text fallback (print/rpc mode): the entry renderer never runs there.
+        const text = self
+          ? formatListing(listRecords(root), self.addr, (r) => presenceOf(r))
+          : 'Intercom is not initialized (no session_start yet).';
+        pi.sendMessage({
+          customType: LIST_TYPE,
+          content: text,
+          display: true,
+          details: { kind: 'intercom-list' },
+        });
+        return;
+      }
+      const rows: IntercomListRow[] = listRecords(root)
+        .filter((r) => r.addr !== self!.addr)
+        .map((r) => ({ name: r.name, addr: r.addr, cwd: r.cwd, presence: presenceOf(r), status: r.status }));
+      pi.appendEntry(LIST_TYPE, { rows });
     },
   });
 }

--- a/packages/intercom/package.json
+++ b/packages/intercom/package.json
@@ -33,7 +33,8 @@
     "typebox": "^1.1.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "pi": {
     "extensions": [

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -5,17 +5,50 @@
  *   with per-task tool allowlists, models, and prompts; typed results
  *   aggregate back. Children are hermetic in-process sessions spawned through
  *   @nicknisi/pi-shared's runtime — no pi-subagents dependency, and children
- *   cannot themselves spawn.
+ *   cannot themselves spawn. Live progress streams via renderCall/renderResult
+ *   (✓/✗ rows, └─ sub-lines, spinner), matching llm-council's vocabulary.
  * `fleet` (tool) / `/fleet` (command) — inspect live and persisted runs,
  *   including background ones. Run records persist to
  *   <agentDir>/subagent-runs/<namespace>/<runId>.json, so runs from other
- *   extensions using the shared runtime show up here too.
+ *   extensions using the shared runtime show up here too. In TUI mode `/fleet`
+ *   opens an interactive overlay (searchable list → run detail); otherwise it
+ *   falls back to a plain-text transcript entry.
+ * Background dispatches surface in a one-line widget above the editor while
+ *   any are in flight.
  */
 
 import * as path from 'node:path';
-import type { ExtensionAPI, ExtensionCommandContext, ToolDefinition } from '@earendil-works/pi-coding-agent';
-import { getAgentDir } from '@earendil-works/pi-coding-agent';
-import { createSubagentRuntime, readRunArtifacts, type RunArtifact, type SpawnOptions } from '@nicknisi/pi-shared';
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionUIContext,
+  Theme,
+  ToolDefinition,
+} from '@earendil-works/pi-coding-agent';
+import { getAgentDir, getSelectListTheme } from '@earendil-works/pi-coding-agent';
+import {
+  getKeybindings,
+  Key,
+  matchesKey,
+  Text,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+  type Component,
+  type Focusable,
+  type SelectItem,
+  type TUI,
+} from '@earendil-works/pi-tui';
+import {
+  createSubagentRuntime,
+  readRunArtifacts,
+  sanitizeTerminalLabel,
+  SearchableSelectList,
+  type RunArtifact,
+  type SpawnOptions,
+  type SpawnResult,
+  type SpawnUsage,
+} from '@nicknisi/pi-shared';
 import { Type, type TSchema } from 'typebox';
 
 const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
@@ -24,6 +57,16 @@ const DEFAULT_TOOLS = ['read', 'grep', 'find', 'ls'];
 const TREE_MUTATING_TOOLS = new Set(['edit', 'write', 'bash']);
 const MAX_TASK_OUTPUT_CHARS = 4000;
 const MAX_FLEET_LIST = 20;
+
+// ── Render vocabulary (mirrors llm-council's defaults) ───────────────────
+
+const SPINNER_CHARS = ['·', '✢', '✳', '✶', '✻', '✽'];
+const SPINNER_FRAMES = [...SPINNER_CHARS, ...[...SPINNER_CHARS].reverse()];
+const SPINNER_INTERVAL = 80;
+const BRANCH_PREFIX = '└─';
+const TREE_INDENT = '   '; // visibleWidth('└─') + 1
+const EXPANDED_PREVIEW_LINES = 8;
+const BG_WIDGET_KEY = 'subagents-bg';
 
 interface TaskSpec {
   task: string;
@@ -34,6 +77,25 @@ interface TaskSpec {
   background?: boolean | undefined;
   allowTreeMutation?: boolean | undefined;
 }
+
+type TaskStatus = 'pending' | 'working' | 'done' | 'error' | 'background';
+
+type TaskProgress = {
+  label: string;
+  model?: string | undefined;
+  status: TaskStatus;
+  startedAt?: number | undefined;
+  doneAt?: number | undefined;
+  error?: string | undefined;
+  text?: string | undefined;
+  tokens?: SpawnUsage | undefined;
+  runId?: string | undefined;
+};
+
+type DispatchDetails = {
+  tasks: TaskProgress[];
+  settled: boolean;
+};
 
 function wantsTreeMutation(spec: TaskSpec): boolean {
   return (spec.tools ?? []).some((tool) => TREE_MUTATING_TOOLS.has(tool));
@@ -80,6 +142,16 @@ function formatSeconds(startedAt: number, endedAt?: number): string {
   return `${((end - startedAt) / 1000).toFixed(1)}s`;
 }
 
+function relativeTime(timestamp: number): string {
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
 function formatRunLine(run: RunArtifact): string {
   const bits = [run.status, formatSeconds(run.startedAt, run.endedAt) + (run.endedAt ? '' : '…')];
   const tokens = formatTokens(run.usage);
@@ -89,7 +161,11 @@ function formatRunLine(run: RunArtifact): string {
 function collectFleet(live: RunArtifact[]): RunArtifact[] {
   const byId = new Map<string, RunArtifact>();
   for (const record of readRunArtifacts(ARTIFACTS_ROOT)) byId.set(record.runId, record);
-  for (const record of live) byId.set(record.runId, record); // live wins over disk
+  // Live wins for status/timing, but live records carry no output — keep the artifact's.
+  for (const record of live) {
+    const persisted = byId.get(record.runId);
+    byId.set(record.runId, { ...persisted, ...record, output: record.output ?? persisted?.output });
+  }
   return [...byId.values()].sort((a, b) => b.startedAt - a.startedAt);
 }
 
@@ -105,6 +181,330 @@ function postText(pi: ExtensionAPI, ctx: ExtensionCommandContext, text: string) 
 function toolResult(text: string, details: Record<string, unknown> = {}) {
   return { content: [{ type: 'text' as const, text }], details };
 }
+
+// ── Dispatch tree rendering ──────────────────────────────────────────────
+
+function makeText(lastComponent: unknown, text: string): Text {
+  const comp = lastComponent instanceof Text ? lastComponent : new Text('', 0, 0);
+  comp.setText(text);
+  return comp;
+}
+
+function indentLine(text: string): string {
+  return `${TREE_INDENT}${text}`;
+}
+
+function branchLine(text: string, theme: Theme): string {
+  return `${theme.fg('dim', BRANCH_PREFIX)} ${text}`;
+}
+
+function expandHint(theme: Theme): string {
+  const key = getKeybindings().getKeys('app.tools.expand')[0] ?? 'ctrl+o';
+  return theme.fg('dim', ` • ${key} to expand`);
+}
+
+function dispatchHeader(summary: string, theme: Theme, dot?: string): string {
+  const prefix = dot ?? `${theme.fg('success', '✓')} `;
+  return `${prefix}${theme.fg('toolTitle', theme.bold('Dispatch'))} ${theme.fg('dim', summary)}`;
+}
+
+function taskIcon(status: TaskStatus, theme: Theme, frame: number): string {
+  switch (status) {
+    case 'done':
+      return theme.fg('success', '✓');
+    case 'error':
+      return theme.fg('error', '✗');
+    case 'working':
+      return theme.fg('muted', SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!);
+    case 'background':
+      return theme.fg('accent', '◦');
+    default:
+      return theme.fg('muted', '↪');
+  }
+}
+
+function taskSubLine(task: TaskProgress, theme: Theme): string {
+  const elapsed = task.startedAt ? theme.fg('dim', ` (${formatSeconds(task.startedAt, task.doneAt)})`) : '';
+  switch (task.status) {
+    case 'done':
+      return `${theme.fg('success', 'done')}${elapsed}${theme.fg('dim', formatTokens(task.tokens))}`;
+    case 'error':
+      return `${theme.fg('error', short(task.error ?? 'failed', 60))}${elapsed}`;
+    case 'working':
+      return theme.fg('dim', 'working…');
+    case 'background':
+      return theme.fg('dim', `launched · run ${task.runId?.slice(0, 8) ?? '?'}`);
+    default:
+      return theme.fg('dim', 'waiting');
+  }
+}
+
+function renderTaskTree(tasks: TaskProgress[], theme: Theme, frame: number): string[] {
+  const lines: string[] = [];
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i]!;
+    const model = task.model ? ` ${theme.fg('dim', task.model)}` : '';
+    lines.push(indentLine(`${taskIcon(task.status, theme, frame)} ${theme.fg('accent', task.label)}${model}`));
+    lines.push(indentLine(branchLine(taskSubLine(task, theme), theme)));
+    if (i < tasks.length - 1) lines.push('');
+  }
+  return lines;
+}
+
+/** Expanded view: settled rows plus a short output preview per task. */
+function createExpandedDispatchView(tasks: TaskProgress[], theme: Theme) {
+  let cachedWidth: number | undefined;
+  let cachedLines: string[] | undefined;
+  return {
+    render(width: number): string[] {
+      if (cachedLines && cachedWidth === width) return cachedLines;
+      const contentWidth = Math.max(1, width - TREE_INDENT.length * 2);
+      const lines: string[] = [''];
+      for (const task of tasks) {
+        const model = task.model ? ` ${theme.fg('dim', task.model)}` : '';
+        lines.push(indentLine(`${taskIcon(task.status, theme, 0)} ${theme.fg('accent', task.label)}${model}`));
+        lines.push(indentLine(branchLine(taskSubLine(task, theme), theme)));
+        if (task.status === 'error' && task.error) {
+          lines.push(indentLine(indentLine(theme.fg('error', short(task.error, 200)))));
+        }
+        const body = task.text?.trim();
+        if (body) {
+          const bodyLines = body.split('\n');
+          for (const raw of bodyLines.slice(0, EXPANDED_PREVIEW_LINES)) {
+            lines.push(indentLine(indentLine(truncateToWidth(sanitizeTerminalLabel(raw), contentWidth, '…'))));
+          }
+          if (bodyLines.length > EXPANDED_PREVIEW_LINES) {
+            lines.push(
+              indentLine(indentLine(theme.fg('dim', `… ${bodyLines.length - EXPANDED_PREVIEW_LINES} more lines`))),
+            );
+          }
+        }
+        lines.push('');
+      }
+      cachedWidth = width;
+      cachedLines = lines;
+      return lines;
+    },
+    invalidate() {
+      cachedWidth = undefined;
+      cachedLines = undefined;
+    },
+  };
+}
+
+// ── Live progress bridge (renderCall workaround for isPartial bug) ───────
+
+let liveDispatch: DispatchDetails | null = null;
+
+// ── Background-runs widget ───────────────────────────────────────────────
+
+const backgroundRuns = new Map<string, string>(); // runId → label
+let widgetUi: ExtensionUIContext | null = null;
+let widgetTheme: Theme | null = null; // renderers/overlay capture the live theme
+
+function refreshBackgroundWidget(): void {
+  if (!widgetUi) return;
+  try {
+    if (backgroundRuns.size === 0) {
+      widgetUi.setWidget(BG_WIDGET_KEY, undefined);
+      return;
+    }
+    const count = backgroundRuns.size;
+    const names = [...backgroundRuns.values()].map((name) => short(name, 24)).join(', ');
+    const line = widgetTheme
+      ? `${widgetTheme.fg('dim', '◦ ')}${widgetTheme.fg('accent', String(count))}${widgetTheme.fg('dim', ` background run${count === 1 ? '' : 's'}: ${names}`)}`
+      : `◦ ${count} background run${count === 1 ? '' : 's'}: ${names}`;
+    widgetUi.setWidget(BG_WIDGET_KEY, [line], { placement: 'aboveEditor' });
+  } catch {
+    // The completion callback can fire while the session is ending; a lost
+    // widget update is harmless and must not become an unhandled rejection.
+  }
+}
+
+// ── /fleet overlay ───────────────────────────────────────────────────────
+
+function runTitle(run: RunArtifact): string {
+  return `[${run.namespace}]${run.agent ? ` ${run.agent}` : ''}`;
+}
+
+function runIcon(run: RunArtifact, theme: Theme): string {
+  switch (run.status) {
+    case 'completed':
+      return theme.fg('success', '✓');
+    case 'failed':
+    case 'aborted':
+      return theme.fg('error', '✗');
+    case 'running':
+      return theme.fg('accent', '●');
+    default:
+      return theme.fg('dim', '◦');
+  }
+}
+
+class FleetOverlay implements Component, Focusable {
+  focused = false;
+
+  private mode: 'list' | 'detail' = 'list';
+  private readonly list: SearchableSelectList;
+  private detail: RunArtifact | null = null;
+  private scrollTop = 0;
+  private viewport = 10;
+  private contentTotal = 0;
+  private cachedWidth: number | undefined;
+  private cachedLines: string[] | undefined;
+
+  constructor(
+    private readonly runs: RunArtifact[],
+    initial: RunArtifact | undefined,
+    private readonly tui: TUI,
+    private readonly theme: Theme,
+    private readonly close: () => void,
+  ) {
+    const items: SelectItem[] = runs.map((run) => ({
+      value: run.runId,
+      label: `${runIcon(run, theme)} ${sanitizeTerminalLabel(runTitle(run))}`,
+      description: `${relativeTime(run.startedAt)} · ${short(sanitizeTerminalLabel(run.promptPreview), 60)}`,
+    }));
+    this.list = new SearchableSelectList(items, Math.min(Math.max(items.length, 1), 12), getSelectListTheme());
+    this.list.onSelect = (item) => {
+      const run = this.runs.find((r) => r.runId === item.value);
+      if (run) this.openDetail(run);
+    };
+    this.list.onCancel = () => this.close();
+    if (initial) this.openDetail(initial);
+  }
+
+  private openDetail(run: RunArtifact): void {
+    this.detail = run;
+    this.mode = 'detail';
+    this.scrollTop = 0;
+    this.invalidate();
+    this.tui.requestRender();
+  }
+
+  handleInput(data: string): void {
+    if (this.mode === 'detail') {
+      if (matchesKey(data, Key.escape) || matchesKey(data, Key.left)) {
+        this.mode = 'list';
+        this.detail = null;
+      } else if (matchesKey(data, Key.up)) {
+        this.scrollTop = Math.max(0, this.scrollTop - 1);
+      } else if (matchesKey(data, Key.down)) {
+        this.scrollTop = Math.min(Math.max(0, this.contentTotal - this.viewport), this.scrollTop + 1);
+      } else if (matchesKey(data, Key.pageUp)) {
+        this.scrollTop = Math.max(0, this.scrollTop - this.viewport);
+      } else if (matchesKey(data, Key.pageDown)) {
+        this.scrollTop = Math.min(Math.max(0, this.contentTotal - this.viewport), this.scrollTop + this.viewport);
+      } else {
+        return;
+      }
+      this.invalidate();
+      this.tui.requestRender();
+      return;
+    }
+    this.list.handleInput(data);
+    this.list.invalidate();
+    this.invalidate();
+    this.tui.requestRender();
+  }
+
+  private border(text: string): string {
+    return this.theme.fg('border', text);
+  }
+
+  /** Full (unclipped) content lines for the detail view. */
+  private detailLines(run: RunArtifact, contentWidth: number): string[] {
+    const theme = this.theme;
+    const lines: string[] = [];
+    lines.push(`${runIcon(run, theme)} ${theme.bold(sanitizeTerminalLabel(runTitle(run)))}`);
+    const meta = [
+      run.status,
+      formatSeconds(run.startedAt, run.endedAt) + (run.endedAt ? '' : '…'),
+      relativeTime(run.startedAt),
+    ];
+    if (run.usage) meta.push(`${(run.usage.totalTokens / 1000).toFixed(1)}k tok`);
+    lines.push(theme.fg('muted', meta.join(' · ')));
+    if (run.model) lines.push(theme.fg('muted', `model: ${run.model}`));
+    lines.push(theme.fg('dim', short(sanitizeTerminalLabel(run.promptPreview), Math.max(20, contentWidth))));
+    if (run.error) lines.push(theme.fg('error', `error: ${short(sanitizeTerminalLabel(run.error), 200)}`));
+    lines.push(theme.fg('borderMuted', '─'.repeat(Math.max(1, contentWidth))));
+    const output = run.output?.trim();
+    if (output) {
+      for (const raw of output.split('\n')) {
+        const clean = sanitizeTerminalLabel(raw);
+        if (!clean) {
+          lines.push('');
+          continue;
+        }
+        for (const wrapped of wrapTextWithAnsi(clean, contentWidth)) lines.push(wrapped);
+      }
+    } else {
+      lines.push(
+        theme.fg(
+          'dim',
+          run.status === 'running' || run.status === 'queued'
+            ? '(still running — no output yet)'
+            : '(no output recorded)',
+        ),
+      );
+    }
+    return lines;
+  }
+
+  render(width: number): string[] {
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
+    const boxWidth = Math.min(Math.max(width, 20), 120);
+    const innerWidth = Math.max(1, boxWidth - 2);
+    const contentWidth = Math.max(1, innerWidth - 2);
+    const lines: string[] = [];
+    const pushBoxLine = (content = '') => {
+      const line = truncateToWidth(content, innerWidth, '…');
+      const padding = Math.max(0, innerWidth - visibleWidth(line));
+      lines.push(this.border('│') + line + ' '.repeat(padding) + this.border('│'));
+    };
+
+    lines.push(this.border(`╭${'─'.repeat(innerWidth)}╮`));
+
+    if (this.mode === 'list') {
+      pushBoxLine(
+        ` ${this.theme.fg('accent', this.theme.bold('Fleet'))}${this.theme.fg('dim', ` — ${this.runs.length} run${this.runs.length === 1 ? '' : 's'}`)}`,
+      );
+      for (const line of this.list.render(contentWidth)) pushBoxLine(` ${line}`);
+      pushBoxLine();
+      pushBoxLine(this.theme.fg('dim', ' type to filter • Enter details • Esc close'));
+    } else if (this.detail) {
+      pushBoxLine(
+        ` ${this.theme.fg('accent', this.theme.bold('Run'))}${this.theme.fg('dim', ` ${this.detail.runId.slice(0, 8)}`)}`,
+      );
+      const all = this.detailLines(this.detail, contentWidth);
+      const maxViewport = Math.max(4, Math.floor(this.tui.terminal.rows * 0.7) - 6);
+      const viewport = Math.min(maxViewport, all.length);
+      this.contentTotal = all.length;
+      this.viewport = viewport;
+      this.scrollTop = Math.min(this.scrollTop, Math.max(0, all.length - viewport));
+      const slice = all.slice(this.scrollTop, this.scrollTop + viewport);
+      for (const line of slice) pushBoxLine(` ${line}`);
+      for (let i = slice.length; i < viewport; i++) pushBoxLine();
+      const scrollInfo =
+        all.length > viewport
+          ? ` ${this.scrollTop + 1}–${Math.min(all.length, this.scrollTop + viewport)}/${all.length} •`
+          : '';
+      pushBoxLine(this.theme.fg('dim', `${scrollInfo} ↑↓ scroll • PgUp/PgDn page • Esc back`));
+    }
+
+    lines.push(this.border(`╰${'─'.repeat(innerWidth)}╯`));
+    this.cachedWidth = width;
+    this.cachedLines = lines;
+    return lines;
+  }
+
+  invalidate(): void {
+    this.cachedWidth = undefined;
+    this.cachedLines = undefined;
+  }
+}
+
+// ── Extension ────────────────────────────────────────────────────────────
 
 export default function subagents(pi: ExtensionAPI) {
   const runtime = createSubagentRuntime({ namespace: 'subagents', artifactsDir: ARTIFACTS_ROOT });
@@ -149,7 +549,7 @@ export default function subagents(pi: ExtensionAPI) {
       ),
     }),
 
-    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+    async execute(_toolCallId, params, signal, onUpdate, ctx) {
       const specs = params.tasks as TaskSpec[];
       if (specs.length === 0) {
         return toolResult('dispatch requires at least one task.');
@@ -157,6 +557,40 @@ export default function subagents(pi: ExtensionAPI) {
       if (specs.length > MAX_TASKS) {
         return toolResult(`Too many tasks (${specs.length}); max is ${MAX_TASKS}. Split into multiple dispatch calls.`);
       }
+
+      if (ctx.hasUI) widgetUi = ctx.ui;
+
+      const progress = new Map<TaskSpec, TaskProgress>();
+      const details: DispatchDetails = { tasks: [], settled: false };
+      for (const spec of specs) {
+        const task: TaskProgress = { label: spec.agent ?? short(spec.task, 40), status: 'pending' };
+        if (spec.model) task.model = spec.model;
+        progress.set(spec, task);
+        details.tasks.push(task);
+      }
+
+      const emit = () => {
+        liveDispatch = details;
+        const settledCount = details.tasks.filter((t) => t.status !== 'pending' && t.status !== 'working').length;
+        onUpdate?.({
+          content: [{ type: 'text', text: `[Dispatch] ${settledCount}/${details.tasks.length} done` }],
+          details,
+        });
+      };
+      emit();
+
+      const settle = (task: TaskProgress, result: SpawnResult) => {
+        task.doneAt = Date.now();
+        task.tokens = result.usage;
+        if (result.ok) {
+          task.status = 'done';
+          task.text = result.text;
+        } else {
+          task.status = 'error';
+          task.error = result.error;
+          if (result.text) task.text = result.text;
+        }
+      };
 
       const lines: string[] = [];
 
@@ -168,53 +602,73 @@ export default function subagents(pi: ExtensionAPI) {
           if (spec.allowTreeMutation === true) {
             mutating.push(spec);
           } else {
+            const task = progress.get(spec)!;
+            task.status = 'error';
+            task.error = 'refused: edit/write/bash require allowTreeMutation';
+            task.doneAt = Date.now();
             lines.push(
-              `## ✗ ${spec.agent ?? short(spec.task, 40)} — refused\n\nTools include edit/write/bash, which mutate the shared working tree. Resubmit with allowTreeMutation: true (the task will run sequentially, after the parallel batch).`,
+              `## ✗ ${task.label} — refused\n\nTools include edit/write/bash, which mutate the shared working tree. Resubmit with allowTreeMutation: true (the task will run sequentially, after the parallel batch).`,
             );
           }
         } else {
           runnable.push(spec);
         }
       }
+      emit();
 
       const background = runnable.filter((s) => s.background);
       const foreground = runnable.filter((s) => !s.background);
 
       for (const spec of background) {
+        const task = progress.get(spec)!;
         const { runId, done } = runtime.spawnDetached(toSpawnOptions(spec, ctx.cwd));
-        lines.push(
-          `⏳ ${spec.agent ?? short(spec.task, 40)} — background run ${runId.slice(0, 8)} (check the fleet tool)`,
-        );
+        task.status = 'background';
+        task.runId = runId;
+        task.startedAt = Date.now();
+        lines.push(`⏳ ${task.label} — background run ${runId.slice(0, 8)} (check the fleet tool)`);
+        backgroundRuns.set(runId, task.label);
+        refreshBackgroundWidget();
+        emit();
         // Deliberately no AbortSignal here: pi may abort tool signals after execute returns, which
         // would kill the background child. Swallow late failures — sendMessage throws once the
         // session is ending, and an unhandled rejection is worse than a lost notification.
         void done
           .then((result) => {
+            backgroundRuns.delete(runId);
+            refreshBackgroundWidget();
             pi.sendMessage({
               customType: 'subagents:background',
-              content: `Background subagent ${runId.slice(0, 8)} (${spec.agent ?? 'task'}) ${result.ok ? 'completed' : `failed: ${result.error}`}`,
+              content: `Background subagent ${runId.slice(0, 8)} (${task.label}) ${result.ok ? 'completed' : `failed: ${result.error}`}`,
               display: true,
               details: { runId, ok: result.ok },
             });
           })
           .catch((err) => {
+            backgroundRuns.delete(runId);
+            refreshBackgroundWidget();
             console.error(`[subagents] background run ${runId.slice(0, 8)} completion notice failed:`, err);
           });
       }
 
       if (foreground.length > 0) {
         const results = await Promise.all(
-          foreground.map((spec) =>
-            runtime.spawn({
+          foreground.map(async (spec) => {
+            const task = progress.get(spec)!;
+            task.status = 'working';
+            task.startedAt = Date.now();
+            emit();
+            const result = await runtime.spawn({
               ...toSpawnOptions(spec, ctx.cwd),
               ...(signal ? { signal } : {}),
-            }),
-          ),
+            });
+            settle(task, result);
+            emit();
+            return result;
+          }),
         );
         for (let i = 0; i < results.length; i++) {
           const result = results[i]!;
-          const spec = foreground[i]!;
-          const label = spec.agent ?? short(spec.task, 40);
+          const label = progress.get(foreground[i]!)!.label;
           if (result.ok) {
             lines.push(
               `## ✓ ${label} — ${formatSeconds(0, result.durationMs)}${formatTokens(result.usage)}\n\n${result.text.slice(0, MAX_TASK_OUTPUT_CHARS)}`,
@@ -230,23 +684,79 @@ export default function subagents(pi: ExtensionAPI) {
       // Tree-mutating tasks run strictly sequentially, after the parallel batch, so they never
       // stomp the working tree concurrently with each other or with read-only children.
       for (const spec of mutating) {
+        const task = progress.get(spec)!;
+        task.status = 'working';
+        task.startedAt = Date.now();
+        emit();
         const result = await runtime.spawn({
           ...toSpawnOptions(spec, ctx.cwd),
           ...(signal ? { signal } : {}),
         });
-        const label = spec.agent ?? short(spec.task, 40);
+        settle(task, result);
+        emit();
         if (result.ok) {
           lines.push(
-            `## ✓ ${label} — ${formatSeconds(0, result.durationMs)}${formatTokens(result.usage)}\n\n${result.text.slice(0, MAX_TASK_OUTPUT_CHARS)}`,
+            `## ✓ ${task.label} — ${formatSeconds(0, result.durationMs)}${formatTokens(result.usage)}\n\n${result.text.slice(0, MAX_TASK_OUTPUT_CHARS)}`,
           );
         } else {
           lines.push(
-            `## ✗ ${label} — ${result.kind} (${formatSeconds(0, result.durationMs)})\n\n${result.error}${result.text ? `\n\nPartial output:\n${result.text.slice(0, 1000)}` : ''}`,
+            `## ✗ ${task.label} — ${result.kind} (${formatSeconds(0, result.durationMs)})\n\n${result.error}${result.text ? `\n\nPartial output:\n${result.text.slice(0, 1000)}` : ''}`,
           );
         }
       }
 
-      return toolResult(lines.join('\n\n'));
+      details.settled = true;
+      return toolResult(lines.join('\n\n'), details);
+    },
+
+    renderCall(args, theme, ctx) {
+      widgetTheme = theme;
+      const count = Array.isArray(args?.tasks) ? args.tasks.length : 0;
+
+      if (!ctx?.isPartial) {
+        clearSpinner(ctx);
+        liveDispatch = null;
+        return makeText(ctx?.lastComponent, dispatchHeader(`${count} task${count === 1 ? '' : 's'}`, theme));
+      }
+
+      const frame = ensureSpinner(ctx);
+      const details = liveDispatch;
+      const settled = details
+        ? details.tasks.filter((t) => t.status !== 'pending' && t.status !== 'working').length
+        : 0;
+      const summary = details
+        ? `${settled}/${details.tasks.length} done`
+        : count > 0
+          ? `${count} task${count === 1 ? '' : 's'}`
+          : '...';
+      const spinner = `${theme.fg('muted', SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!)} `;
+      const lines = [dispatchHeader(summary, theme, spinner)];
+      if (details && details.tasks.length > 0) {
+        lines.push('');
+        lines.push(...renderTaskTree(details.tasks, theme, frame));
+      }
+      return makeText(ctx.lastComponent, lines.join('\n'));
+    },
+
+    renderResult(result, options, theme, ctx) {
+      widgetTheme = theme;
+      const details = result.details as DispatchDetails | undefined;
+
+      // No tracked tasks (validation failures) — plain text fallback.
+      if (!details?.tasks || details.tasks.length === 0) {
+        const text = result.content[0];
+        return makeText(ctx?.lastComponent, text?.type === 'text' ? text.text : '(no output)');
+      }
+
+      const frame = ctx?.state?.spinnerFrame ?? 0;
+
+      if (!options?.expanded) {
+        const tree = renderTaskTree(details.tasks, theme, frame);
+        tree[tree.length - 1] += expandHint(theme);
+        return makeText(ctx?.lastComponent, ['', ...tree].join('\n'));
+      }
+
+      return createExpandedDispatchView(details.tasks, theme);
     },
   });
 
@@ -296,13 +806,64 @@ export default function subagents(pi: ExtensionAPI) {
 
   pi.registerCommand('fleet', {
     description: 'Show recent subagent runs (live + persisted, across extensions using the shared runtime)',
-    handler: async (_args, ctx) => {
+    handler: async (args, ctx) => {
       const all = collectFleet(runtime.listRuns() as RunArtifact[]);
-      postText(
-        pi,
-        ctx,
-        all.length === 0 ? 'No subagent runs found.' : all.slice(0, MAX_FLEET_LIST).map(formatRunLine).join('\n'),
+
+      if (!ctx.hasUI) {
+        postText(
+          pi,
+          ctx,
+          all.length === 0 ? 'No subagent runs found.' : all.slice(0, MAX_FLEET_LIST).map(formatRunLine).join('\n'),
+        );
+        return;
+      }
+
+      if (all.length === 0) {
+        ctx.ui.notify('No subagent runs found.', 'info');
+        return;
+      }
+
+      // `/fleet <runId-prefix>` jumps straight to that run's detail view.
+      let initial: RunArtifact | undefined;
+      const query = args.trim();
+      if (query) {
+        const matches = all.filter((r) => r.runId.startsWith(query));
+        if (matches.length === 1) {
+          initial = matches[0];
+        } else if (matches.length > 1) {
+          ctx.ui.notify(`Ambiguous run id '${query}' (${matches.length} matches); showing the list`, 'warning');
+        } else {
+          ctx.ui.notify(`No run matches '${query}'; showing the list`, 'warning');
+        }
+      }
+
+      await ctx.ui.custom<void>(
+        (tui, theme, _kb, done) => {
+          widgetTheme = theme;
+          return new FleetOverlay(all, initial, tui, theme, () => done(undefined));
+        },
+        { overlay: true, overlayOptions: { width: '80%', maxHeight: '70%', anchor: 'center' } },
       );
     },
   });
+}
+
+// ── Spinner state (per tool-row renderer state) ──────────────────────────
+
+function ensureSpinner(ctx: any): number {
+  if (ctx?.state?.spinnerInterval) return ctx.state.spinnerFrame ?? 0;
+  if (!ctx?.state) ctx.state = {};
+  ctx.state.spinnerFrame = 0;
+  ctx.state.spinnerInterval = setInterval(() => {
+    ctx.state.spinnerFrame = (ctx.state.spinnerFrame + 1) % SPINNER_FRAMES.length;
+    ctx.invalidate?.();
+  }, SPINNER_INTERVAL);
+  return 0;
+}
+
+function clearSpinner(ctx: any) {
+  if (ctx?.state?.spinnerInterval) {
+    clearInterval(ctx.state.spinnerInterval);
+    ctx.state.spinnerInterval = undefined;
+  }
 }

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -30,7 +30,8 @@
     "typebox": "^1.1.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## What

TUI surfaces for the whole platform — the deferred UI half of phase 2b. Three parallel workflow lanes, visually verified in a live TUI (tmux-driven), not just typechecked:

- **dispatch live progress** — `renderCall`/`renderResult` with an `onUpdate` bridge: per-task status tree (spinner → ✓/✗, model, elapsed, tokens), council's visual vocabulary and expand hints
- **background-runs widget** — one quiet line above the editor (`◦ N background runs: labels`), set on launch, cleared on completion
- **`/fleet` interactive overlay** — filterable run list (status icon, namespace, agent, relative time, preview) with drill-down detail views (scrollable output, Esc hierarchy); `/fleet <id-prefix>` jumps straight to a run; plain-text fallback when headless
- **intercom delivery cards** — 📨 sender (cwd) [kind], body collapsed at 6 lines with expand hint, dim id/timestamp footer, reply hint on asks. Lane caught that `registerMessageRenderer` (not entry renderer) is what `sendMessage` custom messages render through — verified against pi's interactive-mode. Peer-supplied text is ANSI-stripped before rendering. `/intercom` listing is now an aligned entry (and no longer pollutes context)
- **codemode renderers** — `renderCall` with label + code preview; `renderResult` collapsed-by-default with log tree and error states

Also fixes a bug the visual pass caught: `collectFleet` let live records (no output) overwrite persisted artifacts (with output), so background results showed "(no output recorded)" — live now wins for status/timing while the artifact's output survives.

## Verification

34/34 tests, typecheck/lint/format/build green, plus a **real TUI session** driven via tmux: dispatch tree rendered live, widget set/cleared, overlay listed 32 runs and drilled into a detail view, an intercom delivery from a second session rendered as a card mid-conversation, codemode result tree with expand hint.