### PR TITLE
feat(codemode): schema-or-nothing output contracts and runscope ledger

### DIFF
--- a/.changeset/codemode-output-contracts.md
+++ b/.changeset/codemode-output-contracts.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-codemode': minor
+---
+
+codemode spawn() now requires an explicit output contract. A spawn with neither `outputSchema` nor `text: true` throws immediately instead of returning unparsed text. This prevents the silent failure mode where reading a field off unparsed text yields `undefined` while the run reports success. A schema-validating spawn that fails validation after its bounded repair attempt still returns `{ ok: false, kind: 'schema_invalid' }` — never a silently-empty string. Migration: add `text: true` to existing text-mode spawns, or define an `outputSchema`.

--- a/.changeset/codemode-runscope-ledger.md
+++ b/.changeset/codemode-runscope-ledger.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-codemode': minor
+---
+
+codemode now writes a runscope orchestration ledger into the parent session. Every `spawn` and `runWorkflow` lifecycle event — `spawn_start`, `spawn_end`, `stage_start`, `stage_end`, `gate_result` — is appended as a typed custom entry (`customType: 'codemode-runscope'`) via `pi.appendEntry`, each carrying `{ runId, spanId, parentSpanId, kind, ts }`. Custom entries persist to the session JSONL without entering LLM context. Stage `parentSpanId` is derived from `needs` edges so the trace tree mirrors the workflow DAG; spawns inside a workflow are parented to their stage via `AsyncLocalStorage`. Dependency-free — no OpenTelemetry.

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -16,8 +16,9 @@ log(...args: unknown[]): void;
 
 - `spawn` launches a hermetic in-process child agent through the shared runtime (namespace `codemode`). Children are version-matched to the host, cannot themselves spawn, and honor the ecosystem recursion guard. Run artifacts persist to `~/.pi/agent/subagent-runs/codemode/`, so codemode children appear in the `fleet` tool / `/fleet` command from `@nicknisi/pi-subagents`.
 - `spawn` **never rejects**. Check `result.ok`; failures carry `kind: 'crashed' | 'empty' | 'schema_invalid' | 'aborted'` plus `error`.
+- **Output contracts (breaking).** Every `spawn()` must declare its contract explicitly: either `outputSchema` (validated; parsed JSON lands in `result.data`) **or** `text: true` (raw text opt-in). A `spawn()` with **neither** throws immediately with an error naming the missing contract — it does _not_ return unparsed text. This prevents the silent failure mode where a schema-less spawn returns text, a caller reads a field off it (`result.someField`), gets `undefined`, and a whole parallel fleet reports success while every result is unusable. A schema-validating spawn that fails validation after one bounded repair attempt (a normalize-and-recheck pass) returns a loud recoverable failure: `{ ok: false, kind: 'schema_invalid', error, text }` — never a silently-empty string. **Migration:** add `text: true` to existing text-mode spawns, or define an `outputSchema`.
 - `runWorkflow` runs a declarative multi-stage DAG over `spawn` (from `@nicknisi/pi-shared`'s engine): per-stage `needs` deps (default linear), `foreach` fan-out, `gate` revise-feedback loops, `retries`, `tokenBudget`, and `sharesTree` stages that never overlap other work and hand their bounded `git diff HEAD` to dependents. Control artifacts land in `~/.pi/agent/workflow-runs/`; `opts.resumeFrom` skips previously-ok stages. Also never rejects — per-stage outcomes carry `ok`/`kind`. Prefer it over hand-rolled `Promise.all` when stages depend on each other, need gates/retries, or edit the working tree.
-- `SpawnOptions` highlights: `prompt` (required), `agent` (label), `model` (`'provider/id'`), `tools` (allowlist — `undefined` defaults to read-only `['read','grep','find','ls']`; pass `['read','bash','edit','write']` explicitly for builders), `systemPrompt`, `outputSchema` (validated; parsed JSON lands in `result.data`), `cwd`, `timeoutMs`, `maxTurns`, `maxToolCalls`, `thinkingLevel`.
+- `SpawnOptions` highlights: `prompt` (required), `agent` (label), `model` (`'provider/id'`), `tools` (allowlist — `undefined` defaults to read-only `['read','grep','find','ls']`; pass `['read','bash','edit','write']` explicitly for builders), `systemPrompt`, `outputSchema` (validated; parsed JSON lands in `result.data`), `text` (boolean — opt into raw text mode; required when `outputSchema` is omitted), `cwd`, `timeoutMs`, `maxTurns`, `maxToolCalls`, `thinkingLevel`.
 - `log` output comes back in the tool result's `details.logs`.
 
 The snippet executes **in the host process with full Node access** — `process`, `require`, and `fs` are all reachable, the same trust boundary as the `bash` tool (see Security model). `spawn`, `runWorkflow`, and `log` are the injected codemode API. Composition is plain code: that's the point.
@@ -32,7 +33,9 @@ const questions = [
   'Where are sessions persisted?',
   'What breaks if the token endpoint 500s?',
 ];
-const results = await Promise.all(questions.map((q) => spawn({ prompt: q, tools: ['read', 'grep', 'find', 'ls'] })));
+const results = await Promise.all(
+  questions.map((q) => spawn({ prompt: q, tools: ['read', 'grep', 'find', 'ls'], text: true })),
+);
 export default results.map((r, i) => ({
   question: questions[i],
   answer: r.ok ? r.text.slice(0, 500) : `FAILED (${r.kind}): ${r.error}`,
@@ -45,12 +48,13 @@ Map/reduce over files with a pipeline:
 const files = ['src/a.ts', 'src/b.ts', 'src/c.ts'];
 const summaries = [];
 for (const f of files) {
-  const r = await spawn({ prompt: `Summarize the public API of ${f} in 3 bullets.`, tools: ['read'] });
+  const r = await spawn({ prompt: `Summarize the public API of ${f} in 3 bullets.`, tools: ['read'], text: true });
   summaries.push({ file: f, summary: r.ok ? r.text : `failed: ${r.error}` });
 }
 const rollup = await spawn({
   prompt: `Combine these module summaries into one architecture paragraph:\n${JSON.stringify(summaries)}`,
   tools: [],
+  text: true,
 });
 export default { rollup: rollup.ok ? rollup.text : 'rollup failed', summaries };
 ```

--- a/packages/codemode/README.md
+++ b/packages/codemode/README.md
@@ -5,6 +5,7 @@ Codemode for the first-party subagent platform: the model writes TypeScript that
 ## What it adds
 
 - **`codemode` tool** (model-facing) — params: `{ code: string; label?: string; timeoutMs?: number }` (default 10 min, capped at 30 min). The snippet gets two injected bindings and must `export default` its result.
+- **Runscope orchestration ledger** (parent-session side effect) — every `spawn`/`runWorkflow` lifecycle event is appended to the _parent_ session as a typed custom entry (`customType: 'codemode-runscope'`). See [Runscope ledger](#runscope-ledger).
 
 ## The snippet API
 
@@ -59,6 +60,33 @@ const rollup = await spawn({
 export default { rollup: rollup.ok ? rollup.text : 'rollup failed', summaries };
 ```
 
+## Runscope ledger
+
+Every `spawn` and `runWorkflow` lifecycle event is appended to the **parent** session as a custom entry via `pi.appendEntry('codemode-runscope', entry)`. Custom entries persist to the session JSONL but **do not enter LLM context**, so the ledger is durable and free of context-window cost. Dependency-free — no OpenTelemetry.
+
+Entry shape (all fields except extras are guaranteed):
+
+```ts
+{
+  runId: string; // workflow run id, or the spawn's own runId for a standalone spawn
+  spanId: string; // this span (spawn runId, or stage id)
+  parentSpanId: string | null; // containing stage span, or the first `needs` dep for a stage, or null
+  kind: 'spawn_start' | 'spawn_end' | 'stage_start' | 'stage_end' | 'gate_result';
+  ts: number; // epoch ms
+  // extras (kind-dependent): ok, failureKind, error, passed, feedback
+}
+```
+
+Events:
+
+- **`spawn_start` / `spawn_end`** — around every `spawn`, standalone or inside a workflow stage. `spawn_end` carries `ok` and, on failure, `failureKind` + `error`.
+- **`stage_start` / `stage_end`** — around every workflow stage (including skipped / budget-exceeded ones). `stage_end` carries `ok` and, on failure, `failureKind` + `error`.
+- **`gate_result`** — emitted when a stage `gate` verdict is reached. Carries `passed: boolean` and, on revise, `feedback`.
+
+**Trace tree.** Stage `parentSpanId` is derived from `needs` edges (default: the previous stage), so the stage span tree mirrors the workflow DAG. A trace span has one parent, so a multi-need stage attaches to its **first** need — a spanning tree of the DAG. Spawns inside a workflow are parented to their stage via `AsyncLocalStorage`, so concurrent stages attribute their spawns correctly. Standalone spawns (no workflow) have `parentSpanId: null`.
+
+Read the ledger back by scanning `ctx.sessionManager.getEntries()` for `entry.type === 'custom' && entry.customType === 'codemode-runscope'` (e.g. on `session_start` to reconstruct a run view). Entries are not rendered in the transcript unless you register a renderer via `pi.registerEntryRenderer('codemode-runscope', ...)`.
+
 ## Security model
 
 The snippet executes **in-process with the host's full privileges**. This is the same trust boundary as any `bash` tool call and as the original pi-codemode: it's your model, writing code for your session, on your machine. There is no sandbox. Do not point it at untrusted prompt sources.
@@ -75,3 +103,4 @@ None.
 - **`export default` is required.** A missing/undefined default export returns a notice, not an error.
 - **Results are bounded** (16 KB), logs are bounded (200 entries × 2 KB), stacks are bounded (4 KB).
 - **bundle-require/ESM interop quirks:** the snippet is esbuild-bundled as ESM with target es2022 (top-level await works); bare package imports fail by design (no `node_modules` near the temp dir), but Node builtins and globals remain reachable — there is no sandbox.
+- **Runscope volume:** every spawn emits two ledger entries, and a `foreach` fan-out of N items emits 2N. Entries persist to the session JSONL (never LLM context), so a large fan-out grows the session file — the trade-off for a durable trace. Emission is best-effort and never fails a run.

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -48,6 +48,9 @@ const MAX_STACK_CHARS = 4000;
 const MAX_LOG_ENTRIES = 200;
 const MAX_LOG_CHARS = 2000;
 
+/** Spawn options as exposed to the codemode snippet: the shared runtime's set, plus `text` — an explicit raw-text opt-in. */
+type CodemodeSpawnOptions = SpawnOptions & { text?: boolean };
+
 const BINDINGS_PRELUDE = 'const { spawn, log, runWorkflow } = (globalThis as any).__piCodemode;\n';
 const GLOBAL_KEY = '__piCodemode';
 
@@ -195,7 +198,11 @@ export default function codemode(pi: ExtensionAPI) {
       '[read, grep, find, ls]; pass [read, bash, edit, write] explicitly for builders); systemPrompt?:',
       'string; replaceSystemPrompt?: boolean; extensionPaths?: string[]; skillPaths?: string[];',
       'includeContextFiles?: boolean; outputSchema?: TypeBox-like JSON schema object (validated;',
-      'parsed JSON lands in result.data); cwd?: string; timeoutMs?: number (default 15 min);',
+      'parsed JSON lands in result.data; a schema-validating spawn that fails validation after one',
+      "bounded repair attempt returns ok:false kind:'schema_invalid' — never a silently-empty string);",
+      'text?: boolean (opt into raw text mode; REQUIRED when outputSchema is omitted — a spawn with',
+      'neither outputSchema nor text:true is rejected immediately); cwd?: string; timeoutMs?: number',
+      '(default 15 min);',
       'maxTurns?: number; maxToolCalls?: number; thinkingLevel?: string }. Composition — Promise.all',
       'Composition — Promise.all',
       'fan-out, sequential pipelines, map/reduce over files — is your code. For dependent multi-stage',
@@ -215,6 +222,7 @@ export default function codemode(pi: ExtensionAPI) {
       'spawn never rejects: check result.ok and read result.error/result.kind on failure instead of try/catch around spawn.',
       'Fan out independent work with Promise.all([...]) and pass read-only tool allowlists (read, grep, find, ls) to research children.',
       'Wrap risky non-spawn steps (parsing, arithmetic on untrusted shapes) in try/catch — a thrown error fails the whole run.',
+      'Every spawn() must declare its output contract: pass outputSchema for structured data (validated; lands in result.data) or text:true for raw text. A spawn with NEITHER throws immediately — it does not return unparsed text.',
       'Prefer runWorkflow over hand-rolled Promise.all when stages depend on each other, need gates/retries, or edit the working tree.',
       'Use log(...) for progress notes; they come back in the result details.',
       'Do not attempt imports — the snippet is bundled standalone and only spawn/runWorkflow/log are available.',
@@ -247,9 +255,24 @@ export default function codemode(pi: ExtensionAPI) {
         logs.push(truncate(line, MAX_LOG_CHARS));
       };
 
-      const spawn = (options: SpawnOptions): Promise<SpawnResult> => {
+      const spawn = (options: CodemodeSpawnOptions): Promise<SpawnResult> => {
+        // Output contract: a schema-less spawn returns raw text, and reading a
+        // field off unparsed text fails silently (undefined, not an error) — a
+        // whole fan-out can look successful while every result is unusable.
+        // Require EITHER an outputSchema OR an explicit `text: true` opt-in.
+        // This throws synchronously and loudly rather than returning ok:false,
+        // so the run cannot be mistaken for a success.
+        if (!options.outputSchema && !options.text) {
+          throw new Error(
+            'spawn() requires an explicit output contract: pass `outputSchema` ' +
+              'for validated structured output (parsed JSON lands in result.data) ' +
+              'or `text: true` to opt into raw text mode. A schema-less spawn ' +
+              'without `text: true` is rejected to prevent silently-unusable ' +
+              'results (reading a field off unparsed text yields undefined, not an error).',
+          );
+        }
         const merged = mergeSignals(options.signal, signal ?? undefined, controller.signal);
-        const { signal: _userSignal, ...rest } = options;
+        const { signal: _userSignal, text: _text, ...rest } = options;
         const opts: SpawnOptions = { ...rest, cwd: options.cwd ?? ctx.cwd };
         // Default children to read-only, matching dispatch; pi's own default
         // (read/bash/edit/write) would apply otherwise.

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -22,6 +22,8 @@
  * the same trust boundary as pi-codemode and any bash tool call.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -34,8 +36,12 @@ import {
   type RunWorkflowOptions,
   type SpawnOptions,
   type SpawnResult,
+  type StageContext,
+  type SubagentRuntime,
+  type WorkflowEvent,
   type WorkflowResult,
   type WorkflowSpec,
+  type WorkflowStage,
 } from '@nicknisi/pi-shared';
 import { bundleRequire } from 'bundle-require';
 import { Type } from 'typebox';
@@ -50,6 +56,33 @@ const MAX_LOG_CHARS = 2000;
 
 /** Spawn options as exposed to the codemode snippet: the shared runtime's set, plus `text` — an explicit raw-text opt-in. */
 type CodemodeSpawnOptions = SpawnOptions & { text?: boolean };
+
+// ── Runscope orchestration ledger ─────────────────────────────────────────
+// Every spawn/runWorkflow lifecycle event is appended to the PARENT session
+// as a typed custom entry (customType 'codemode-runscope') via pi.appendEntry.
+// Custom entries persist to the session JSONL but never enter LLM context, so
+// the ledger is durable and free of context-window cost. No OpenTelemetry —
+// just structured spans written through the session.
+const RUNSCOPE_TYPE = 'codemode-runscope';
+
+type RunscopeKind = 'spawn_start' | 'spawn_end' | 'stage_start' | 'stage_end' | 'gate_result';
+
+interface RunscopeEntry {
+  runId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  kind: RunscopeKind;
+  ts: number;
+  [extra: string]: unknown;
+}
+
+// Async context carrying the active workflow run + stage span, so a spawn
+// fired inside a workflow stage can be parented to its stage even when stages
+// run concurrently. `enterWith` is used (not `run`) because the spawn call
+// lives inside the shared engine's runJob frame, which we cannot wrap — the
+// stage's prompt wrapper is our only interception point in that frame. Each
+// runJob is its own async frame, so the context does not leak across stages.
+const runscopeCtx = new AsyncLocalStorage<{ runId: string; stageSpan: string }>();
 
 const BINDINGS_PRELUDE = 'const { spawn, log, runWorkflow } = (globalThis as any).__piCodemode;\n';
 const GLOBAL_KEY = '__piCodemode';
@@ -178,6 +211,49 @@ function spinnerDot(theme: Theme, frame: number): string {
 
 export default function codemode(pi: ExtensionAPI) {
   const runtime = createSubagentRuntime({ namespace: 'codemode', artifactsDir: ARTIFACTS_ROOT });
+
+  // Append a runscope span to the parent session JSONL. Best-effort: a ledger
+  // write must never fail a codemode run.
+  const emitRunscope = (entry: RunscopeEntry): void => {
+    try {
+      pi.appendEntry(RUNSCOPE_TYPE, entry);
+    } catch {
+      // best-effort
+    }
+  };
+
+  // Traced runtime: wraps every spawn with spawn_start/spawn_end ledger
+  // entries. Used both by the snippet's `spawn` binding and by runWorkflow, so
+  // every child — standalone or inside a stage — is traced. The runId/parent
+  // come from the async context set by runWorkflow's stage-prompt wrapper; for
+  // a standalone spawn there is no context, so runId = the spawn's own runId
+  // and parentSpanId = null.
+  const tracedRuntime: SubagentRuntime = {
+    namespace: runtime.namespace,
+    spawn: (opts) => tracedRuntime.spawnDetached(opts).done,
+    spawnDetached: (opts) => {
+      const { runId, done } = runtime.spawnDetached(opts);
+      const span = runscopeCtx.getStore();
+      const entryRunId = span?.runId ?? runId;
+      const parentSpanId = span?.stageSpan ?? null;
+      emitRunscope({ runId: entryRunId, spanId: runId, parentSpanId, kind: 'spawn_start', ts: Date.now() });
+      void done.then((res) => {
+        emitRunscope({
+          runId: entryRunId,
+          spanId: runId,
+          parentSpanId,
+          kind: 'spawn_end',
+          ts: Date.now(),
+          ok: res.ok,
+          ...(res.ok ? {} : { failureKind: res.kind, error: res.error }),
+        });
+      });
+      return { runId, done };
+    },
+    listRuns: () => runtime.listRuns(),
+    activeCount: () => runtime.activeCount(),
+  };
+
   // Snippet bindings are handed over via a single global (globalThis.__piCodemode),
   // so two concurrent executions would clobber each other's spawn/log/runWorkflow —
   // serialize runs with a promise-chain mutex.
@@ -278,7 +354,7 @@ export default function codemode(pi: ExtensionAPI) {
         // (read/bash/edit/write) would apply otherwise.
         if (opts.tools === undefined) opts.tools = ['read', 'grep', 'find', 'ls'];
         if (merged) opts.signal = merged;
-        return runtime.spawn(opts);
+        return tracedRuntime.spawn(opts);
       };
 
       const boundRunWorkflow = (
@@ -286,9 +362,96 @@ export default function codemode(pi: ExtensionAPI) {
         wfOpts: Partial<RunWorkflowOptions> = {},
       ): Promise<WorkflowResult> => {
         const merged = mergeSignals(wfOpts.signal, signal ?? undefined, controller.signal);
+        const userOnProgress = wfOpts.onProgress;
         const full: RunWorkflowOptions = { cwd: ctx.cwd, ...wfOpts };
         if (merged) full.signal = merged;
-        return runWorkflow(spec, runtime, full);
+
+        // One runId for the whole workflow; every stage/gate entry carries it.
+        const wfRunId = randomUUID();
+        // Derive a stage's parent span from its needs edges so the trace tree
+        // mirrors the workflow DAG. A trace span has one parent, so multi-need
+        // stages attach to the first need (a spanning tree of the DAG); the
+        // full needs list is included in the entry for completeness.
+        const parentOf = (stageId: string): string | null => {
+          const idx = spec.stages.findIndex((s) => s.id === stageId);
+          if (idx === -1) return null;
+          const stage = spec.stages[idx]!;
+          const needs = stage.needs ?? (idx === 0 ? [] : [spec.stages[idx - 1]!.id]);
+          return needs[0] ?? null;
+        };
+
+        // Wrap each stage's prompt so the stage's async frame (runJob) carries
+        // the runId + stage span via AsyncLocalStorage.enterWith. The shared
+        // engine calls buildPrompt (and thus this wrapper) at the start of each
+        // attempt inside runJob; the subsequent `await runtime.spawn(...)` in
+        // the same frame inherits the context, so tracedRuntime can parent the
+        // spawn's span to its stage even under concurrent stages. String
+        // prompts are wrapped in a function returning the original string.
+        const wrappedStages: WorkflowStage[] = spec.stages.map((stage) => {
+          const origPrompt = stage.prompt;
+          const promptFn = typeof origPrompt === 'function' ? origPrompt : () => origPrompt;
+          const wrappedPrompt = (gctx: StageContext, item?: unknown, index?: number): string => {
+            runscopeCtx.enterWith({ runId: wfRunId, stageSpan: stage.id });
+            return promptFn(gctx, item, index);
+          };
+          const wrapped: WorkflowStage = { ...stage, prompt: wrappedPrompt };
+          if (stage.gate) {
+            const origGate = stage.gate;
+            wrapped.gate = (outcome, gctx) => {
+              const verdict = origGate(outcome, gctx);
+              emitRunscope({
+                runId: wfRunId,
+                spanId: stage.id,
+                parentSpanId: parentOf(stage.id),
+                kind: 'gate_result',
+                ts: Date.now(),
+                passed: verdict === true,
+                ...(verdict === true ? {} : { feedback: verdict.revise }),
+              });
+              return verdict;
+            };
+          }
+          return wrapped;
+        });
+
+        full.onProgress = (event: WorkflowEvent) => {
+          try {
+            if (event.type === 'stage_start') {
+              emitRunscope({
+                runId: wfRunId,
+                spanId: event.stageId!,
+                parentSpanId: parentOf(event.stageId!),
+                kind: 'stage_start',
+                ts: Date.now(),
+              });
+            } else if (
+              event.type === 'stage_complete' ||
+              event.type === 'stage_failed' ||
+              event.type === 'stage_skipped'
+            ) {
+              emitRunscope({
+                runId: wfRunId,
+                spanId: event.stageId!,
+                parentSpanId: parentOf(event.stageId!),
+                kind: 'stage_end',
+                ts: Date.now(),
+                ok: event.outcome?.ok,
+                ...(event.outcome && !event.outcome.ok
+                  ? { failureKind: event.outcome.kind, error: event.outcome.error }
+                  : {}),
+              });
+            }
+          } catch {
+            // ledger emission is best-effort
+          }
+          try {
+            userOnProgress?.(event);
+          } catch {
+            // a caller's progress callback must never break the workflow
+          }
+        };
+
+        return runWorkflow({ ...spec, stages: wrappedStages }, tracedRuntime, full);
       };
 
       const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-codemode-'));


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>