### PR TITLE
feat(workflows): examples + patterns layer (lanes, gates, bake-off)

### DIFF
--- a/.changeset/pi-workflows-recipes.md
+++ b/.changeset/pi-workflows-recipes.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-workflows': minor
+---
+
+Examples + patterns layer: three standalone workflow scripts in `examples/` (copy-and-adapt — the registry is `ls`, no index re-exports them) plus a README Recipes section. `lanes.js` ports the parallel file-disjoint editing pattern under a hard-rules preamble. `gates.js` distills three judge/verify prompt builders from `@quintinshaw/pi-dynamic-workflows` (adversarial refutation, deep-research coverage, 3-way code-review verdict) as plain documented functions. `bake-off.js` races N models on one task in isolated worktrees and an advisory judge picks the winner. To support bake-off, `agent()` gained a `worktree: true` opt (forwarded to the subagent runtime's isolated-worktree spawn; the `.patch` path is surfaced via an opt-in `{ value, patchPath, runId }` return — non-worktree calls are unchanged) and `engine.ts` exports a `compileScript` for spawn-free compile + `meta` reads, used by the new `examples.test.ts` smoke test.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -36,7 +36,7 @@ return { answered: results.length, results };
 | `budget`                     | `{ total, spent, remaining }` over the run's token usage. `total` defaults to `Infinity`; `spent` accumulates across `agent()` calls. Read-only.                                                                                                                                                                                     |
 | `cwd`                        | The session working directory.                                                                                                                                                                                                                                                                                                       |
 
-`agent()` opts: `model` (`'provider/id'`), `tools` (allowlist — default read-only `['read','grep','find','ls']`; pass `['read','bash','edit','write']` for builders), `label` (child agent label), `systemPrompt`, `schema` (validated; parsed JSON lands in `result.data`), `effort` (thinking level), `timeoutMs`, `maxTurns`, `agentType` (accepted but ignored — no agent-type registry; resolve `systemPrompt` in the script itself).
+`agent()` opts: `model` (`'provider/id'`), `tools` (allowlist — default read-only `['read','grep','find','ls']`; pass `['read','bash','edit','write']` for builders), `label` (child agent label), `systemPrompt`, `schema` (validated; parsed JSON lands in `result.data`), `effort` (thinking level), `timeoutMs`, `maxTurns`, `worktree` (run the child in an isolated git worktree; on settle the change set is captured to a `.patch` and `agent()` returns `{ value, patchPath, runId }` instead of the bare value — opt-in, so non-worktree calls are unchanged), `agentType` (accepted but ignored — no agent-type registry; resolve `systemPrompt` in the script itself).
 
 The script executes **in the host process with full Node access** — `process`, `require`, and `fs` are all reachable, the same trust boundary as the `bash` tool. Keep the returned value small: summaries, counts, key findings — never raw file dumps.
 
@@ -63,6 +63,14 @@ Every `agent()` call spawns through `@nicknisi/pi-shared`'s subagent runtime wit
 | Trigger-word arming (the tool activates on keywords) | The model calls the `workflow` tool when intent warrants — no arming, no keyword matching.                                                                                                                     |
 | Phases with per-phase budgets                        | `phase(name)` is a logging marker only. Budget is a single run-level `{ total, spent, remaining }`; per-stage budgets are the `workflow.ts` engine's `tokenBudget` (use `runWorkflow` from codemode for that). |
 | The third-party engine's script globals              | Unchanged: `args`, `agent`, `parallel`, `pipeline`, `phase`, `log`, `budget`, `cwd`. Existing scripts run as-is.                                                                                               |
+
+## Recipes
+
+The `examples/` directory ships standalone, copy-and-adapt workflow scripts — the registry is `ls`, so these are code you read and copy, never APIs you import (no index re-exports them). Drop any of them into `~/.pi/agent/workflows/` and run via `/wf run <name>`.
+
+- **`lanes.js`** — N parallel agents editing FILE-DISJOINT lanes of one repo under a hard-rules preamble (each lane owns a fixed file set; no git, no installs; the parent integrates centrally). Use it when a task splits into independent edits that don't overlap on files. Adapt by setting `VERIFY` to your typecheck command and filling the `LANES` array with `{ name, files, brief }` per lane.
+- **`gates.js`** — three judge/verify prompt builders returning prompt strings: adversarial refutation (defeats confirmation bias), deep-research coverage (defeats silent source omission), and a 3-way code-review verdict (defeats verdict collapse). Use it when you need a reliable gate inside your own workflow. Adapt by copying the builder whose failure mode you need and calling it from an `agent()` with a JSON schema. Prompt patterns distilled from `@quintinshaw/pi-dynamic-workflows`.
+- **`bake-off.js`** — race N models on the SAME task in isolated worktrees (`worktree: true`), then an advisory judge reads each contender's `.patch` and picks a winner. Use it on hard build tasks where a single GLM-5.2-class builder produces decent-but-flawed code; the 2x token cost buys a measurably better hit rate. Adapt by setting `CONTENDERS` to the models to race and passing `task` in `args`; the workflow returns the winner's `patchPath` to apply via `/patches`.
 
 ## Dependencies
 

--- a/packages/workflows/engine.ts
+++ b/packages/workflows/engine.ts
@@ -33,6 +33,10 @@ export interface EngineSpawnOk {
   text: string;
   data?: unknown;
   usage: EngineSpawnUsage;
+  /** Run id of the child spawn, when the spawn fn attaches it. */
+  runId?: string;
+  /** Path to the worktree `.patch` file, for `worktree: true` runs that changed files. */
+  patchPath?: string;
 }
 
 export interface EngineSpawnFail {
@@ -55,6 +59,8 @@ export interface EngineSpawnOptions {
   timeoutMs?: number;
   maxTurns?: number;
   outputSchema?: unknown;
+  /** Run the child in an isolated git worktree; its change set is captured to a `.patch`. */
+  worktree?: boolean;
 }
 
 export type EngineSpawnFn = (opts: EngineSpawnOptions) => Promise<EngineSpawnResult>;
@@ -172,10 +178,16 @@ export async function runScript(opts: RunScriptOptions): Promise<RunScriptResult
       ...(typeof agentOpts.timeoutMs === 'number' ? { timeoutMs: agentOpts.timeoutMs } : {}),
       ...(typeof agentOpts.maxTurns === 'number' ? { maxTurns: agentOpts.maxTurns } : {}),
       ...(agentOpts.schema !== undefined ? { outputSchema: agentOpts.schema } : {}),
+      ...(agentOpts.worktree === true ? { worktree: true } : {}),
     };
     const res = await spawn(spawnOpts);
     addUsage(usage, res.usage);
     if (!res.ok) throw new Error(`${res.kind}: ${res.error}`);
+    // A worktree run that changed files produces a `.patch`; surface it
+    // alongside the value so the script can hand the path to a judge or
+    // return it for the `/patches` apply flow. Opt-in: only when patchPath is
+    // present, so non-worktree scripts see the unchanged `data ?? text` return.
+    if (res.patchPath) return { value: res.data ?? res.text ?? null, patchPath: res.patchPath, runId: res.runId };
     return res.data ?? res.text ?? null;
   };
 
@@ -191,16 +203,50 @@ export async function runScript(opts: RunScriptOptions): Promise<RunScriptResult
     return values as U[];
   };
 
-  // Compile: rewrite `export const meta =` so the vm compiles (a stranded
-  // `export` fails loudly) AND meta is captured into a holder passed as a
-  // function parameter — runInThisContext cannot see a closure variable, so
-  // the holder rides the call. The body keeps a local `meta` binding too, so
-  // scripts that reference `meta` later still work. The body is wrapped in an
-  // async function so a top-level `return` compiles.
+  // Compile + run. compileScript is extracted so callers (tests, future
+  // tooling) can compile + read `meta` without a real spawn.
+  const compiled = compileScript(script);
+  const value = await compiled.fn(args, agent, parallel, pipeline, phase, log, budget, cwd);
+  return { value, meta: compiled.meta, logs, usage, durationMs: Date.now() - startedAt };
+}
+
+// ── Compile-only entry ────────────────────────────────────────────────────
+
+/** The compiled async body; invoking it runs the script with injected globals. */
+export type CompiledFn = (
+  args: unknown,
+  agent: unknown,
+  parallel: unknown,
+  pipeline: unknown,
+  phase: unknown,
+  log: unknown,
+  budget: unknown,
+  cwd: string,
+) => Promise<unknown>;
+
+export interface CompiledScript {
+  /** The script's `meta` export, read via a stub dry-run (no real spawn). */
+  meta: ScriptMeta | undefined;
+  /** Invoke to run the script; spawn-backed globals must be supplied. */
+  fn: CompiledFn;
+}
+
+/**
+ * Compile a workflow script and read its `meta` export WITHOUT a real spawn.
+ *
+ * `export const meta =` is rewritten to an outer-binding assignment so the vm
+ * compiles (a stranded `export` fails loudly) and `meta` is captured into a
+ * holder. The body is wrapped in an async function so a top-level `return`
+ * compiles. `meta` is populated by a stub dry-run — `agent` returns `null`,
+ * `parallel`/`pipeline` are `Promise.all`-style folds over those stubs — so the
+ * script's `meta` declaration (which well-formed scripts place first) is read
+ * without spawning any child sessions. A syntax error throws here.
+ */
+export function compileScript(script: string): CompiledScript {
   const metaHolder: { value: ScriptMeta | undefined } = { value: undefined };
   const stripped = script.replace(STRIP_META, 'const meta = metaHolder.value =');
   const wrapped = `(async function(args, agent, parallel, pipeline, phase, log, budget, cwd, metaHolder){\n${stripped}\n})`;
-  const fn = new vm.Script(wrapped, { filename: 'workflow.js' }).runInThisContext() as (
+  const raw = new vm.Script(wrapped, { filename: 'workflow.js' }).runInThisContext() as (
     args: unknown,
     agent: unknown,
     parallel: unknown,
@@ -211,7 +257,39 @@ export async function runScript(opts: RunScriptOptions): Promise<RunScriptResult
     cwd: string,
     metaHolder: { value: ScriptMeta | undefined },
   ) => Promise<unknown>;
+  // Bind metaHolder so callers invoke an 8-arg fn; the holder rides the call
+  // (runInThisContext cannot see a closure variable, so it must be a parameter).
+  const fn: CompiledFn = (args, agent, parallel, pipeline, phase, log, budget, cwd) =>
+    raw(args, agent, parallel, pipeline, phase, log, budget, cwd, metaHolder);
 
-  const value = await fn(args, agent, parallel, pipeline, phase, log, budget, cwd, metaHolder);
-  return { value, meta: metaHolder.value, logs, usage, durationMs: Date.now() - startedAt };
+  // Stub dry-run to read `meta`. Well-formed scripts declare `meta` first, so
+  // it is assigned synchronously before the first `await`; we await the whole
+  // stubbed body anyway so a script that computes meta from `args` works too.
+  // Any throw is swallowed — we only care that it compiled + set meta.
+  const stubAgent = async (): Promise<null> => null;
+  const stubParallel = <T>(thunks: Array<() => Promise<T>>): Promise<T[]> => Promise.all(thunks.map((t) => t()));
+  const stubPipeline = async <T, U>(items: T[], ...stages: Array<(item: T) => Promise<U>>): Promise<U[]> => {
+    let values: unknown[] = [...items];
+    for (const stage of stages) values = await stubParallel((values as T[]).map((v) => () => stage(v)));
+    return values as U[];
+  };
+  const stubBudget = { total: Infinity, spent: 0, remaining: Infinity };
+  void fn(
+    undefined,
+    stubAgent,
+    stubParallel,
+    stubPipeline,
+    () => {},
+    () => {},
+    stubBudget,
+    '/tmp',
+  ).catch(() => {});
+
+  // `meta` is a getter so a caller that re-runs `fn` with real globals sees
+  // the post-run meta (the stub dry-run may have thrown on args-derived meta;
+  // the real run sets it). For static meta the stub already populated it.
+  return Object.defineProperty({ fn }, 'meta', {
+    get: () => metaHolder.value,
+    enumerable: true,
+  }) as CompiledScript;
 }

--- a/packages/workflows/examples.test.ts
+++ b/packages/workflows/examples.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Smoke test for the example workflow files: each example file COMPILES under
+ * the package's script compiler (`compileScript` — a stub dry-run, no real
+ * spawn) and its `meta` export has a non-empty `name` + `description`.
+ *
+ * No real spawns: compileScript reads `meta` via a stub dry-run where
+ * `agent`/`parallel`/`pipeline` are no-ops (see engine.ts).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { compileScript } from './engine.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const examplesDir = path.join(here, 'examples');
+
+const examples = fs
+  .readdirSync(examplesDir)
+  .filter((f) => f.endsWith('.js'))
+  .map((f) => path.join(examplesDir, f));
+
+describe('examples smoke: compile + meta', () => {
+  it('discovers exactly the three example files', () => {
+    expect(examples.map((e) => path.basename(e)).sort()).toEqual(['bake-off.js', 'gates.js', 'lanes.js']);
+  });
+
+  for (const file of examples) {
+    const name = path.basename(file);
+    it(`${name} compiles and exports meta.name + meta.description`, () => {
+      const src = fs.readFileSync(file, 'utf8');
+      const compiled = compileScript(src);
+      expect(typeof compiled.meta?.name).toBe('string');
+      expect((compiled.meta?.name ?? '').length).toBeGreaterThan(0);
+      expect(typeof compiled.meta?.description).toBe('string');
+      expect((compiled.meta?.description ?? '').length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/packages/workflows/examples/bake-off.js
+++ b/packages/workflows/examples/bake-off.js
@@ -73,7 +73,7 @@ const verdict = await agent(
     'task below, independently, in isolated worktrees. You are given each contender model, ' +
     'its self-reported summary, and the path to its patch. Read each patch (use bash: ' +
     '`cat <patchPath>`) and compare them on correctness, minimalism, and style. Pick the ' +
-    'winner. Do not just trust the summaries — read the actual diffs.\n\n' +
+    'winner. Do not just trust the summaries — read the actual diffs (the read tool takes a path; no bash needed).\n\n' +
     'TASK:\n' +
     TASK +
     '\n\nCONTENDERS JSON:\n' +
@@ -82,6 +82,7 @@ const verdict = await agent(
   {
     label: 'judge',
     model: JUDGE_MODEL,
+    tools: ['read'], // patches are files — read-only judging, no bash
     schema: {
       type: 'object',
       properties: {

--- a/packages/workflows/examples/bake-off.js
+++ b/packages/workflows/examples/bake-off.js
@@ -1,0 +1,106 @@
+// bake-off.js — Bake-Off mode: race N models on one task, an advisory judge picks.
+//
+// WHEN BAKE-OFF BEATS A SINGLE BUILDER: empirically, a single GLM-5.2-class
+// builder produces decent-but-flawed code — right shape, subtle bugs. Racing
+// two models on the SAME task in ISOLATED worktrees and letting an advisory
+// judge pick the winner is a quality lever: the judge sees two independent
+// attempts AND their patches, and the better one wins. It costs ~2x the
+// tokens of a single build for a measurably better hit rate on hard tasks.
+// Don't run it for trivial edits — the judge overhead isn't worth it there.
+//
+// HOW IT WORKS:
+//   1. Each contender runs as a builder agent with `worktree: true` — it
+//      writes into its own detached worktree, so contenders never stomp each
+//      other. On settle the subagent runtime captures the full change set
+//      (including untracked files) to a `.patch`.
+//   2. agent() returns `{ value, patchPath, runId }` for a worktree run that
+//      changed files — the wrapper is opt-in: non-worktree agent() calls keep
+//      returning the bare value, so existing scripts are unaffected.
+//   3. A single judge agent receives all contender summaries + their patch
+//      paths and returns `{ winner, why, confidence }`.
+//   4. The workflow returns the winner's patchPath — apply it via the
+//      subagents fleet apply flow (the `/patches` staging area: pre-flights
+//      each patch without applying, then `Enter` to `git apply --3way`).
+//
+// Adapt: set CONTENDERS to the models you want to race, pass `task` in args
+// (or edit DEFAULT_TASK). The judge can be a stronger/different model than the
+// builders — set JUDGE_MODEL.
+
+export const meta = {
+  name: 'bake_off',
+  description: 'Race N models on one task in isolated worktrees; an advisory judge picks the winner',
+};
+
+// Models to race, in 'provider/id' form. Add or remove contenders freely.
+const CONTENDERS = ['z-ai/glm-5.2', 'anthropic/claude-sonnet-4-5'];
+const JUDGE_MODEL = 'anthropic/claude-opus-4-1';
+
+const DEFAULT_TASK = 'Implement X in packages/foo/bar.ts such that Y holds. Keep the change minimal and correct.';
+const TASK = (args && args.task) || DEFAULT_TASK;
+
+const BUILDER_TOOLS = ['read', 'edit', 'write', 'bash', 'grep', 'find'];
+const BUILDER_PROMPT =
+  'You are a builder. Implement the following task in this repo. Make the change minimal ' +
+  'and correct; run the repo typecheck before finishing. Report a one-paragraph summary of ' +
+  'what you changed and why.\n\nTASK:\n' +
+  TASK;
+
+// A throw inside parallel() collapses the wave — wrap each contender so a
+// failure reports which model died instead of nuking the whole race.
+const safeRun = (model, i) => async () => {
+  try {
+    const r = await agent(BUILDER_PROMPT, {
+      label: 'contender-' + (i + 1),
+      model,
+      tools: BUILDER_TOOLS,
+      worktree: true,
+    });
+    if (r && typeof r === 'object' && 'patchPath' in r) {
+      return { model, ok: true, summary: r.value, patchPath: r.patchPath, runId: r.runId };
+    }
+    return { model, ok: true, summary: r, patchPath: null, runId: null };
+  } catch (e) {
+    return { model, ok: false, summary: 'contender crashed: ' + (e && e.message), patchPath: null, runId: null };
+  }
+};
+
+phase('race');
+const entries = await parallel(CONTENDERS.map(safeRun));
+
+phase('judge');
+const verdict = await agent(
+  'You are an advisory judge for a model bake-off. Two builders each attempted the SAME ' +
+    'task below, independently, in isolated worktrees. You are given each contender model, ' +
+    'its self-reported summary, and the path to its patch. Read each patch (use bash: ' +
+    '`cat <patchPath>`) and compare them on correctness, minimalism, and style. Pick the ' +
+    'winner. Do not just trust the summaries — read the actual diffs.\n\n' +
+    'TASK:\n' +
+    TASK +
+    '\n\nCONTENDERS JSON:\n' +
+    JSON.stringify(entries, null, 2) +
+    '\n\nReturn JSON { winner: <model id>, why: <one paragraph>, confidence: "low"|"medium"|"high" }.',
+  {
+    label: 'judge',
+    model: JUDGE_MODEL,
+    schema: {
+      type: 'object',
+      properties: {
+        winner: { type: 'string' },
+        why: { type: 'string' },
+        confidence: { type: 'string', enum: ['low', 'medium', 'high'] },
+      },
+      required: ['winner', 'why', 'confidence'],
+    },
+  },
+);
+
+const winner = entries.find((e) => e.model === verdict.winner) ?? entries[0];
+
+return {
+  winner: verdict.winner,
+  why: verdict.why,
+  confidence: verdict.confidence,
+  // Apply this via the subagents /patches staging area (git apply --3way).
+  patchPath: (winner && winner.patchPath) || null,
+  contenders: entries.map((e) => ({ model: e.model, ok: e.ok, patchPath: e.patchPath })),
+};

--- a/packages/workflows/examples/gates.js
+++ b/packages/workflows/examples/gates.js
@@ -1,0 +1,91 @@
+// gates.js — judge/verify PROMPT builders.
+//
+// WHAT IT'S FOR: the prompt engineering that turns a flaky judge into a
+// reliable gate. Each builder is a function returning a prompt STRING; copy
+// the one that matches your gate into your own workflow and hand it to an
+// agent() with a JSON schema. These are PATTERNS, not an API — read them,
+// adapt the framing to your task, do not import this file.
+//
+// The valuable knowledge here is WHAT failure mode each framing prevents:
+//   adversarialReview      → confirmation bias / sycophancy
+//   deepResearchCoverage   → silent source omission / single-source skew
+//   codeReviewVerdict      → verdict collapse + severity ordering
+//
+// prompt patterns distilled from @quintinshaw/pi-dynamic-workflows.
+
+export const meta = {
+  name: 'gates',
+  description: 'Judge/verify prompt builders: adversarial refutation, research coverage, code-review verdict',
+};
+
+// ── Adversarial refutation ─────────────────────────────────────────────────
+// Prevents: confirmation bias. A reviewer asked "is this finding real?" tends
+// to agree (sycophancy), and a wrong finding survives. Reframing the job as
+// "try to REFUTE this; default to real=false when uncertain" flips the prior:
+// a finding survives only when enough independent skeptics FAIL to refute it.
+// `reviewers` skeptics vote in parallel; the finding survives when the
+// real-vote share meets `threshold`. The "state the strongest reason it could
+// be WRONG first" line forces the skeptic to actually attack, not rubber-stamp.
+const adversarialReview = (task, finding, reviewers, threshold) =>
+  'You are a skeptical reviewer. Try to REFUTE this finding for the task below. ' +
+  'Default to real=false when uncertain; investigate with the available tools if needed. ' +
+  'State the strongest reason the finding could be WRONG before you decide.\n\n' +
+  'TASK: ' +
+  task +
+  '\nFINDING: ' +
+  finding +
+  '\n\nReturn JSON { real: boolean, reason: string }. This finding is counted real only ' +
+  'if it survives ' +
+  reviewers +
+  ' independent refuters at threshold ' +
+  threshold +
+  '.';
+
+// ── Deep-research coverage check ──────────────────────────────────────────
+// Prevents: silent source omission. A research fan-out gathers N sources and
+// lists claims; without a coverage check, a claim from a single weak source
+// (or one a model half-remembered and attributed to a plausible URL) survives
+// alongside well-sourced ones. This gate groups claims asserting the SAME
+// fact across DISTINCT source URLs and keeps a claim only when it has
+// `minSupport` distinct sources OR one clearly authoritative source. Conflicts
+// and single-source claims are discarded — the report says so explicitly.
+const deepResearchCoverage = (sources, minSupport) =>
+  'Cross-check these research sources. Group claims that assert the same fact across ' +
+  'different source URLs. Keep a claim only if it is supported by at least ' +
+  minSupport +
+  ' distinct source URLs OR by one clearly authoritative source. Discard claims found in ' +
+  'a single weak source or that conflict with others. Do not invent sources.\n\n' +
+  'SOURCES JSON:\n' +
+  JSON.stringify(sources) +
+  '\n\nReturn JSON { supported: [{ claim, sources: [url] }], discarded: [claim] }.';
+
+// ── Code-review verdict + severity ─────────────────────────────────────────
+// Prevents: verdict collapse. A boolean "is this issue real?" collapses
+// CONFIRMED (will break) and PLAUSIBLE (worth a look) into one bucket, losing
+// the hedge the report needs. A 3-way verdict — CONFIRMED / PLAUSIBLE /
+// REFUTED — with a per-finding failure scenario keeps the signal; only REFUTED
+// is filtered out. Severity framing: name the concrete failure scenario, not a
+// vague "this might be bad" — a finding with no traceable failure is PLAUSIBLE
+// at best, never CONFIRMED.
+const codeReviewVerdict = (finding, diffBlock) =>
+  'You are a verifier. Determine whether this code review finding is CONFIRMED, PLAUSIBLE, ' +
+  'or REFUTED.\n' +
+  'CONFIRMED = you can trace the exact failure in the diff.\n' +
+  'PLAUSIBLE = the concern is valid but not certain.\n' +
+  'REFUTED = the finding is wrong or already handled.\n\n' +
+  'FINDING:\n' +
+  finding +
+  diffBlock +
+  '\n\nReturn JSON { verdict: "CONFIRMED"|"PLAUSIBLE"|"REFUTED", reason: string }. ' +
+  'If you cannot trace a concrete failure scenario, return at most PLAUSIBLE.';
+
+// Demonstrate the shapes — copy whichever builder fits your gate.
+phase('gates');
+log('adversarialReview  →', adversarialReview('ship the release', 'auth refresh leaks', 3, 0.66).slice(0, 60) + '…');
+log('deepResearchCoverage →', deepResearchCoverage([{ url: 'https://example', claims: ['x'] }], 2).slice(0, 60) + '…');
+log('codeReviewVerdict  →', codeReviewVerdict('file.ts:42 null deref', '\n<diff>…</diff>').slice(0, 60) + '…');
+
+return {
+  builders: ['adversarialReview', 'deepResearchCoverage', 'codeReviewVerdict'],
+  note: 'Copy the builder that matches your gate; call it from agent() with a JSON schema.',
+};

--- a/packages/workflows/examples/gates.js
+++ b/packages/workflows/examples/gates.js
@@ -11,7 +11,22 @@
 //   deepResearchCoverage   → silent source omission / single-source skew
 //   codeReviewVerdict      → verdict collapse + severity ordering
 //
-// prompt patterns distilled from @quintinshaw/pi-dynamic-workflows.
+// Prompt patterns distilled from @quintinshaw/pi-dynamic-workflows (MIT).
+// Substantial portions of the prompt text below are adapted from that
+// package, whose LICENSE requires this notice:
+//
+//   Copyright (c) 2026 QuintinShaw
+//   Copyright (c) Michael Livs (original pi-dynamic-workflows)
+//
+//   Permission is hereby granted, free of charge, to any person obtaining a
+//   copy of this software and associated documentation files (the
+//   "Software"), to deal in the Software without restriction, including
+//   without limitation the rights to use, copy, modify, merge, publish,
+//   distribute, sublicense, and/or sell copies of the Software, and to
+//   permit persons to whom the Software is furnished to do so, subject to
+//   the following conditions: the above copyright notice and this
+//   permission notice shall be included in all copies or substantial
+//   portions of the Software.
 
 export const meta = {
   name: 'gates',

--- a/packages/workflows/examples/lanes.js
+++ b/packages/workflows/examples/lanes.js
@@ -1,0 +1,70 @@
+// lanes.js — N parallel agents editing FILE-DISJOINT lanes of one repo.
+//
+// WHAT IT'S FOR: when a task splits into independent, file-disjoint edits
+// across a single repo, lanes runs them concurrently under hard rules that
+// make the parallelism safe: each lane owns a fixed file set, no lane touches
+// git or installs, and the parent integrates centrally. This is the pattern
+// behind "hardening lanes" — a blocker list split by subsystem, each lane
+// owned by one agent.
+//
+// HOW TO ADAPT:
+//   1. Set VERIFY to the repo's typecheck/lint command (repo-wide is fine —
+//      errors in files a lane does NOT own are other lanes mid-edit; each
+//      lane ignores them; only its own files must be clean).
+//   2. Fill LANES with one entry per parallel edit: a `name`, the exact
+//      `files` that lane may touch (no others), and a one-paragraph `brief`.
+//   3. Run it: /wf run lanes
+//   4. You (the parent) integrate the lanes' edits centrally — review and
+//      stage them here.
+//
+// The hard-rules preamble is the pattern's soul — keep it. The fan-out is a
+// single parallel() over the lanes. Cap lanes at the subagent runtime's child
+// budget (4 by default); split into a second wave if you need more.
+
+export const meta = {
+  name: 'lanes',
+  description: 'Parallel file-disjoint editing lanes under a hard-rules preamble',
+};
+
+// Repo-wide verification command. Replace with your project's typecheck
+// (`npx tsgo --noEmit`, `tsc --noEmit`, `cargo check`, …).
+const VERIFY = 'npx tsgo --noEmit';
+
+const COMMON = `You are one of N parallel agents editing the same repo (cwd is the repo root).
+HARD RULES — read before anything else:
+1. Edit ONLY the files listed for your lane. Other agents own the rest concurrently; touching their files corrupts their work.
+2. NO git commands, NO installs, NO format/test runners. The parent integrates centrally.
+3. Verify ONLY with \`${VERIFY}\` run from the repo root. It is repo-wide, so errors in files you do NOT own are other lanes mid-edit — ignore those. YOUR files must be clean.
+4. Match the existing code style.
+5. No behavior changes beyond your lane's brief.
+Report: files changed + one line per change.`;
+
+// One entry per parallel edit. `files` is the lane's exclusive write set.
+const LANES = [
+  {
+    name: 'engine',
+    files: ['packages/shared/subagents.ts', 'packages/shared/workflow.ts'],
+    brief: 'Make the budget counter event handling typecheck-visible…',
+  },
+  {
+    name: 'dispatch',
+    files: ['packages/subagents/index.ts'],
+    brief: 'Add allowTreeMutation + serialize tree-mutating tasks…',
+  },
+  // Add lanes here (≤ ~4 per wave).
+];
+
+const lanes = LANES.map((l) => ({
+  label: l.name,
+  prompt: COMMON + '\n\nLANE ' + l.name + ' — ' + l.files.join(', ') + ' (no other files):\n\n' + l.brief,
+}));
+
+phase('lanes');
+const results = await parallel(
+  lanes.map((l) => () => agent(l.prompt, { label: l.label, tools: ['read', 'edit', 'write', 'bash', 'grep'] })),
+);
+
+return LANES.reduce((acc, l, i) => {
+  acc[l.name] = results[i] ?? 'LANE RETURNED NULL (missing coverage)';
+  return acc;
+}, {});

--- a/packages/workflows/index.ts
+++ b/packages/workflows/index.ts
@@ -39,7 +39,13 @@ import {
   type SubagentRuntime,
 } from '@nicknisi/pi-shared';
 import { Type } from 'typebox';
-import { runScript, type EngineSpawnFn, type EngineSpawnOptions, type RunScriptResult } from './engine.js';
+import {
+  runScript,
+  type EngineSpawnFn,
+  type EngineSpawnOptions,
+  type EngineSpawnResult,
+  type RunScriptResult,
+} from './engine.js';
 
 const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
 const NAMESPACE = 'workflows';
@@ -84,7 +90,7 @@ function makeSpawnFn(
   cwd: string,
   externalSignal: AbortSignal | undefined,
 ): EngineSpawnFn {
-  return async (opts: EngineSpawnOptions): Promise<SpawnResult> => {
+  return async (opts: EngineSpawnOptions): Promise<EngineSpawnResult> => {
     const spawnOpts: SpawnOptions = {
       prompt: opts.prompt,
       cwd,
@@ -95,12 +101,23 @@ function makeSpawnFn(
       ...(opts.timeoutMs !== undefined ? { timeoutMs: opts.timeoutMs } : {}),
       ...(opts.maxTurns !== undefined ? { maxTurns: opts.maxTurns } : {}),
       ...(opts.outputSchema !== undefined ? { outputSchema: opts.outputSchema as never } : {}),
+      ...(opts.worktree === true ? { worktree: true } : {}),
     };
     // Default children to read-only, matching codemode/dispatch; pi's own
     // default (read/bash/edit/write) would apply otherwise.
     if (opts.tools !== undefined) spawnOpts.tools = opts.tools;
     else spawnOpts.tools = ['read', 'grep', 'find', 'ls'];
-    return spawnCancellable(cancellables, runtime, spawnOpts, externalSignal);
+    const res = await spawnCancellable(cancellables, runtime, spawnOpts, externalSignal);
+    // Surface the worktree `.patch` path (recorded on the run record after
+    // settle) so workflow scripts can return it for the `/patches` apply flow.
+    if (res.ok) {
+      const record = runtime.listRuns().find((r) => r.runId === res.runId);
+      const patchPath = record?.worktree?.patchPath;
+      if (patchPath) {
+        return { ok: true, text: res.text, data: res.data, usage: res.usage, runId: res.runId, patchPath };
+      }
+    }
+    return res;
   };
 }
 


### PR DESCRIPTION
Three standalone example workflow scripts in packages/workflows/examples/
(copy-and-adapt — the registry is ls, no index re-exports them) plus a
README Recipes section.

- lanes.js: N parallel agents editing file-disjoint lanes of one repo under
  a hard-rules preamble (each lane owns a fixed file set; no git/installs;
  parent integrates centrally). Generalized from Nick's hardening_lanes.
- gates.js: three judge/verify prompt builders distilled from
  @quintinshaw/pi-dynamic-workflows — adversarial refutation (defeats
  confirmation bias), deep-research coverage (defeats silent source
  omission), 3-way code-review verdict (defeats verdict collapse). Each a
  function returning a prompt string with a header on the failure mode it
  prevents.
- bake-off.js: race N models on the same task in isolated worktrees; an
  advisory judge reads each .patch and picks a winner; returns the winner's
  patchPath for the /patches apply flow.

To support bake-off, agent() gained a worktree: true opt (forwarded to the
subagent runtime's isolated-worktree spawn; the .patch path surfaces via an
opt-in { value, patchPath, runId } return — non-worktree calls unchanged),
and engine.ts exports compileScript for spawn-free compile + meta reads,
used by examples.test.ts (4 smoke tests, no real spawns).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>