### PR TITLE
fix: time complete runs instead of individual turns in turn-timer

### DIFF
--- a/.changeset/turn-timer-full-run.md
+++ b/.changeset/turn-timer-full-run.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-turn-timer': patch
+---
+
+Time complete runs (agent_start → agent_settled) instead of individual turns (turn_start → turn_end). A turn is one LLM response plus its tool calls, so a run with multiple tool-call rounds emitted one timer row per round. Now one row is emitted per user message, covering the full wall-clock from message sent to agent idle.

--- a/packages/turn-timer/README.md
+++ b/packages/turn-timer/README.md
@@ -1,11 +1,11 @@
 # @nicknisi/pi-turn-timer
 
-Shows how long each full turn took — assistant response plus tool calls plus tool results — as a dim one-line row rendered below the response, similar to Claude Code's per-turn elapsed timer. It exists because pi has no built-in per-turn timing display. One row is emitted per turn (not per assistant message), so tool-call batches within a turn share a single timer.
+Shows how long a complete run took — from the moment you send a message until the agent settles and is awaiting your next message — as a dim one-line row rendered below the response, similar to Claude Code's per-turn elapsed timer. It exists because pi has no built-in per-run timing display. A run that spans multiple LLM responses and tool-call rounds still produces a single timer row.
 
 ## What it adds
 
 - **UI:** a custom transcript entry renderer that draws a dim text row of the form `· 12.3s` (or `· 1m 23s` for ≥ 60s) after each completed turn.
-- **Events hooked:** `turn_start` (records the start timestamp), `turn_end` (computes elapsed time and appends the entry).
+- **Events hooked:** `agent_start` (records the start timestamp), `agent_settled` (computes elapsed time and appends the entry). `agent_settled` fires only once the agent is idle and won't continue automatically (no retry/compaction/follow-up remaining), so the timer covers the whole run.
 - **Custom entry type:** `turn-duration`, with data shape `{ seconds: number }`.
 
 No slash commands, tools, keybindings, or overlays. No configuration.
@@ -14,8 +14,8 @@ No slash commands, tools, keybindings, or overlays. No configuration.
 
 - The entry is a custom transcript entry that does **not** participate in LLM context, so it never pollutes the conversation.
 - `/copy` reads only assistant message text, so it never picks up the timer rows.
-- Timing starts from `event.timestamp` on `turn_start` if present, falling back to `Date.now()`. Elapsed time is computed with `Date.now()` at `turn_end`.
-- If `turn_end` fires without a prior `turn_start` (e.g. extension loaded mid-turn), the event is ignored.
+- Timing starts from `Date.now()` on `agent_start`. Elapsed time is computed with `Date.now()` at `agent_settled`.
+- If `agent_settled` fires without a prior `agent_start` (e.g. extension loaded mid-run), the event is ignored.
 - Duration formatting: `< 60s` → `Ns.s` (one decimal, e.g. `0.8s`); `≥ 60s` → `Mm Ss` (e.g. `1m 23s`).
 
 ## Configuration
@@ -31,7 +31,7 @@ No npm runtime dependencies, no workspace deps.
 
 ## Caveats
 
-- Depends on pi extension internals: `registerEntryRenderer`, `appendEntry`, and the `turn_start` / `turn_end` event names (including `turn_start`'s `timestamp` field). A pi release that renames these APIs or events breaks the extension.
+- Depends on pi extension internals: `registerEntryRenderer`, `appendEntry`, and the `agent_start` / `agent_settled` event names. A pi release that renames these APIs or events breaks the extension.
 - Relies on the theme's `"dim"` foreground color existing; unusual themes could render the row differently.
 - Uses wall-clock time (`Date.now()`), so the measurement includes any time the session sat idle mid-turn (e.g. waiting on an interactive tool prompt or permission prompt).
 - No platform-specific behavior; works anywhere pi runs.

--- a/packages/turn-timer/index.ts
+++ b/packages/turn-timer/index.ts
@@ -1,15 +1,15 @@
 /**
  * Turn Timer Extension
  *
- * Shows how long each full turn took (assistant + tool calls + results),
- * as a dim one-line row below the response — similar to Claude Code's
- * per-turn elapsed timer. One row per turn, so tool-call batches don't
- * each get their own timer.
+ * Shows how long a complete run took — from the moment you send a message
+ * until the agent settles and is awaiting your next message. This spans
+ * every LLM response, tool call, and tool result in the run, so a turn
+ * with multiple tool-call rounds still produces a single timer row.
  *
- * Uses turn_start/turn_end and renders the result as a custom transcript
- * entry that does NOT participate in LLM context, so it never pollutes
- * the conversation and /copy (which reads only assistant message text)
- * never picks it up.
+ * Uses agent_start/agent_settled and renders the result as a custom
+ * transcript entry that does NOT participate in LLM context, so it never
+ * pollutes the conversation and /copy (which reads only assistant message
+ * text) never picks it up.
  */
 
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
@@ -33,16 +33,18 @@ export default function turnTimer(pi: ExtensionAPI) {
     return new Text(label, 0, 0);
   });
 
-  // ── Time each full turn (assistant + tool calls + results) ──────────
-  // One row per turn, not one per assistant message, so tool-call
-  // batches don't each get their own timer.
+  // ── Time each complete run (all turns until the agent settles) ──────
+  // agent_start fires when the run begins; agent_settled fires when the
+  // agent is idle and won't continue automatically (no retry/compaction/
+  // follow-up remaining). This yields one row per user message, not one
+  // per tool-call round.
   let start: number | undefined;
 
-  pi.on('turn_start', (event) => {
-    start = event.timestamp ?? Date.now();
+  pi.on('agent_start', () => {
+    start = Date.now();
   });
 
-  pi.on('turn_end', () => {
+  pi.on('agent_settled', () => {
     if (start === undefined) return;
     const seconds = (Date.now() - start) / 1000;
     start = undefined;


### PR DESCRIPTION
## What

`@nicknisi/pi-turn-timer` previously hooked `turn_start` / `turn_end`. In pi's event model a *turn* is one LLM response plus its tool calls, so a run with multiple tool-call rounds emitted a timer row per round — showing per-tool-call timing rather than the full run.

This switches to `agent_start` / `agent_settled`, so one dim `· Ns` row is emitted per user message, covering the full wall-clock from message sent to agent idle (awaiting the next message). `agent_settled` fires only once the agent won't continue automatically (no retry/compaction/follow-up remaining).

## Changes

- `packages/turn-timer/index.ts` — swap `turn_start`/`turn_end` → `agent_start`/`agent_settled`; update comments.
- `packages/turn-timer/README.md` — update docs to match.
- Changeset: patch.

## Verify

`pnpm typecheck && pnpm lint && pnpm format` pass. Smoke-tested live: one timer row per complete run, including runs with multiple tool-call rounds.