### PR TITLE
fix: stop dispatch rendering the task tree twice while running

### DIFF
--- a/.changeset/tidy-dispatch-tree.md
+++ b/.changeset/tidy-dispatch-tree.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-subagents': patch
+---
+
+Fix dispatch progress rendering each task twice while running. pi keeps the renderCall component on screen next to renderResult once the first onUpdate fires, and both rendered the same task tree — renderCall now renders only the header, renderResult owns the tree.

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -1551,12 +1551,11 @@ export default function subagents(pi: ExtensionAPI) {
           ? `${count} task${count === 1 ? '' : 's'}`
           : '...';
       const spinner = `${theme.fg('muted', SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!)} `;
-      const lines = [dispatchHeader(summary, theme, spinner)];
-      if (details && details.tasks.length > 0) {
-        lines.push('');
-        lines.push(...renderTaskTree(details.tasks, theme, frame));
-      }
-      return makeText(ctx.lastComponent, lines.join('\n'));
+      // Header only — the tree is rendered solely by renderResult. pi keeps
+      // the renderCall component on screen alongside renderResult once the
+      // first onUpdate fires, and emit() populates liveDispatches and fires
+      // onUpdate together — so rendering the tree here too shows it twice.
+      return makeText(ctx.lastComponent, dispatchHeader(summary, theme, spinner));
     },
 
     renderResult(result, options, theme, ctx) {


### PR DESCRIPTION
## Problem

While a `dispatch` call is running, every task row appeared twice in the TUI:

```
* Dispatch 0/1 done
  * pi-artifact-integration
  └ working…
  * pi-artifact-integration
  └ working… • ctrl+o to expand
```

Only one agent was actually running — the rows were two views of the same `TaskProgress` object. pi's `ToolExecutionComponent.updateDisplay()` renders **both** the `renderCall` component and the `renderResult` component once a result exists, including partial results from `onUpdate`. `dispatch` calls `emit()` (→ `onUpdate`) at the start of `execute`, so from the first second both renderers were drawing the same tree — `renderCall` without the expand hint, `renderResult` with it.

## Fix

`renderCall` now renders only the header line (spinner + `N/M done` summary). The task tree — live or settled — is rendered solely by `renderResult`. No behavior change otherwise: the spinner still animates via `ctx.invalidate()`, which re-renders both components each tick.

## Verification

- `pnpm typecheck && pnpm lint && pnpm format` clean
- Logic: `emit()` populates `liveDispatches` and fires `onUpdate` together in `execute`, so whenever `renderCall` previously had a tree to draw, a `renderResult` component was guaranteed on screen to draw it.