### PR TITLE
fix(statusline): render extension statuses, and cap the context bar

### DIFF
--- a/.changeset/tidy-poets-shake.md
+++ b/.changeset/tidy-poets-shake.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-statusline': patch
+---
+
+Render extension statuses (`ctx.ui.setStatus()`) in the footer and cap the context bar at 20 columns. Replacing pi's footer meant every extension's status indicator was silently dropped; each status now renders as its own segment with whitespace folded and SGR colors left intact.

--- a/packages/statusline/index.ts
+++ b/packages/statusline/index.ts
@@ -204,6 +204,15 @@ function formatTimeUntil(resetsAt: string): string {
   }
 }
 
+// ── Context bar ──────────────────────────────────────────────────────────────
+
+/**
+ * Widest the context bar may grow. It is elastic filler — it takes whatever
+ * columns the real segments leave behind — so this cap is really a limit on
+ * how much of the line pure decoration may claim.
+ */
+const CONTEXT_BAR_MAX = 20;
+
 // ── Helper: build a progress bar ─────────────────────────────────────────────
 
 function buildBar(percent: number, width: number, theme: Pick<Theme, 'fg'>): string {
@@ -214,6 +223,20 @@ function buildBar(percent: number, width: number, theme: Pick<Theme, 'fg'>): str
   for (let i = 0; i < filled; i++) bar += '━';
   for (let i = 0; i < empty; i++) bar += '╌';
   return theme.fg(color, bar);
+}
+
+// ── Helper: keep an extension status on one line ─────────────────────────────
+
+/**
+ * Statuses are arbitrary extension text: fold whitespace so a stray newline
+ * cannot break the footer. Matches pi's own footer sanitiser — notably it
+ * leaves SGR escapes intact, because extensions colour their own indicators.
+ */
+function sanitizeStatusText(text: string): string {
+  return text
+    .replace(/[\r\n\t]/g, ' ')
+    .replace(/ +/g, ' ')
+    .trim();
 }
 
 // ── Helper: format token count ───────────────────────────────────────────────
@@ -448,9 +471,21 @@ export default function (pi: ExtensionAPI) {
             segments.push(`${ICON_USAGE} ${fiveStr} ${theme.fg('dim', '╱')} ${sevenStr}`);
           }
 
+          // Extension statuses (ctx.ui.setStatus). Replacing pi's footer means
+          // this line is the only place they can appear — without this, every
+          // extension's status indicator is silently dropped.
+          const extensionStatuses = Array.from(footerData.getExtensionStatuses().entries())
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([, text]) => sanitizeStatusText(text))
+            .filter((text) => text.length > 0);
+          // Each status is its own segment, so multiple extensions read as
+          // distinct items rather than one run-on string.
+          for (const status of extensionStatuses) segments.push(status);
+
           // Context bar — stretch to fill whatever width remains on the line.
           // Build a placeholder context segment, measure all segments + the right
-          // side, then give the bar the leftover columns (clamped 5..40).
+          // side, then give the bar the leftover columns (clamped 5..CONTEXT_BAR_MAX).
+          // The bar is elastic filler, so it yields to real information first.
           const tokenStr = tokensUsed > 0 ? theme.fg('dim', ` (${formatTokens(tokensUsed)})`) : '';
           const ctxLabel = `${ICON_CONTEXT} `;
           const ctxTail = ` ${remaining}% ctx${tokenStr}`;
@@ -471,7 +506,7 @@ export default function (pi: ExtensionAPI) {
             visibleWidth(ctxTail) +
             visibleWidth(right) +
             1; // min 1 gap between left and right
-          const barWidth = Math.max(5, Math.min(40, innerWidth - otherWidth));
+          const barWidth = Math.max(5, Math.min(CONTEXT_BAR_MAX, innerWidth - otherWidth));
           const contextBar = buildBar(remaining, barWidth, theme);
           segments.push(`${ctxLabel}${contextBar}${ctxTail}`);
 


### PR DESCRIPTION
## What

Replace pi's footer via `ctx.ui.setFooter(...)` and never reads `footerData.getExtensionStatuses()`. Pi's own footer is what renders `ctx.ui.setStatus()` indicators, so with this statusline active **every extension's status indicator was silently dropped** — including `pi-mcp-adapter`'s.

## Changes

1. **Render extension statuses.** Each status becomes its own segment (sorted by extension key), so several extensions read as distinct items rather than one run-on string. Inserted before the context-bar measurement, so `otherWidth` accounts for them automatically.
2. **Fold whitespace like pi does** (`\r\n\t` → space, collapse, trim) and deliberately **leave SGR escapes intact** — extensions colour their own indicators.
3. **Cap the context bar at 20 columns** (`CONTEXT_BAR_MAX`, was 40). The bar is elastic filler that claims whatever the real segments leave behind; this footer already carries cost, lines changed, 5h/7d usage bars, and branch + PR link, so the cap matters even more here than in arc.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all clean.
- Changeset included (patch).

Shoutout to @grinich for implementing this upstream.
