### PR TITLE
fix(composer): put the cursor at the end of a recalled message

### DIFF
--- a/.changeset/eleven-lions-cheer.md
+++ b/.changeset/eleven-lions-cheer.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-composer': patch
+---
+
+Put the cursor at the end of a message recalled from history. pi-tui places the cursor at the start of an entry recalled with Up, so typing prepends to your own sentence; composer now overrides `navigateHistory` to move the cursor to the end after a successful Up recall. Down navigation, draft restoration, and boundary no-ops (Up at the oldest entry) keep their original cursor behavior.

--- a/packages/composer/README.md
+++ b/packages/composer/README.md
@@ -25,6 +25,11 @@ standalone `paste-expand.ts` so the two features don't fight over
   when an incoming paste matches an already-collapsed paste's stored content;
   if the marker `[paste #N ...]` is still in the buffer, the marker is replaced
   with the real content and the paste registry is renumbered to stay dense.
+- **History recall puts the cursor at the end**: pi-tui places the cursor at
+  the _start_ of a message recalled with Up, so typing prepends to your own
+  sentence. Composer overrides `navigateHistory` to move the cursor to the end
+  after a successful Up recall. Down, draft restoration, and boundary no-ops
+  (Up at the oldest entry) are untouched.
 
 ## Features
 
@@ -188,10 +193,12 @@ No npm runtime dependencies; `node:fs` / `node:os` / `node:path` only.
 
 ## Caveats
 
-- **pi-tui internals**: the paste-expand feature reaches into `Editor` privates
-  at runtime (`state`, `pastes`, `pasteCounter`, `pushUndoSnapshot`,
-  `cancelAutocomplete`, `exitHistoryBrowsing`, `setCursorCol`) and overrides
-  the TS-private `handlePaste` (compile-time private, runtime-accessible). It
+- **pi-tui internals**: the paste-expand and history-cursor features reach into
+  `Editor` privates at runtime (`state`, `pastes`, `pasteCounter`,
+  `historyIndex`, `pushUndoSnapshot`, `cancelAutocomplete`,
+  `exitHistoryBrowsing`, `setCursorCol`, `moveToLineEnd`) and override the
+  TS-private `handlePaste` and `navigateHistory` (compile-time private,
+  runtime-accessible). It
   also hard-codes pi's paste-marker format (`[paste #N +X lines]` /
   `[paste #N X chars]`) and replicates pi-tui's paste cleanup and registry
   renumbering. Any change to pi-tui's paste handling or marker format can

--- a/packages/composer/index.ts
+++ b/packages/composer/index.ts
@@ -62,10 +62,12 @@ interface EditorInternals {
   pastes: Map<number, string>;
   pasteCounter: number;
   lastAction: unknown;
+  historyIndex: number;
   pushUndoSnapshot(): void;
   cancelAutocomplete(): void;
   exitHistoryBrowsing(): void;
   setCursorCol(col: number): void;
+  moveToLineEnd(): void;
 }
 
 import { CustomEditor, type ExtensionAPI, type ExtensionContext } from '@earendil-works/pi-coding-agent';
@@ -248,6 +250,28 @@ class Composer extends CustomEditor {
     }
     // @ts-expect-error TS2855 — see class-level note: parent method is typed private.
     super.handlePaste(pastedText);
+  }
+
+  // ── History recall: cursor at the end ─────────────────────────────────
+  // pi-tui's navigateHistory places the cursor at the *start* of an entry
+  // recalled with Up (so a second Up keeps browsing history in multi-line
+  // entries). The cost is the overwhelmingly common case — recall the
+  // message you just sent and keep typing — which then prepends to your own
+  // sentence. Prefer the common case; Down is untouched. Ported from
+  // workos/arc's editor-history-cursor extension.
+  navigateHistory(direction: number): void {
+    const self = this as unknown as EditorInternals;
+    const previousHistoryIndex = self.historyIndex;
+    // @ts-expect-error TS2855 — see class-level note: parent method is typed private.
+    super.navigateHistory(direction);
+    // Only the Up case, and only when an entry was actually recalled:
+    // historyIndex -1 means the user's in-progress draft was restored, whose
+    // cursor position should be preserved exactly as it was, and an unchanged
+    // index means the original was a boundary no-op (already at the oldest
+    // entry), where moving the cursor would disrupt in-place editing.
+    if (direction !== -1 || self.historyIndex < 0 || self.historyIndex === previousHistoryIndex) return;
+    self.state.cursorLine = Math.max(0, self.state.lines.length - 1);
+    self.moveToLineEnd();
   }
 
   /** Replace the collapsed marker for paste `id` with its real content,


### PR DESCRIPTION
## What

Ports workos/arc#19 to composer — with the review feedback from that PR already addressed.

Press Up to bring back the message you just sent, and the cursor lands *in front of it*. Typing then prepends to your own sentence:

```
XXHELLO-HISTORY     <- before
HELLO-HISTORYXX     <- after
```

## Cause

pi-tui's `navigateHistory` chooses the cursor end deliberately:

```js
this.setTextInternal(this.history[i] || "", direction === -1 ? "start" : "end")
```

The rationale is multi-line entries: with the cursor parked on line 1, a second Up keeps browsing history instead of walking up inside the recalled text. The cost is the overwhelmingly common case — recall the message you just queued, keep typing.

## Implementation

Unlike arc (which patches the prototype so it works with any editor), composer *is* the editor here — so this is an honest subclass override of `navigateHistory`, following the exact pattern of the existing `handlePaste` override (class-level TS2415 pragma, TS2855 on the `super` call, `EditorInternals` cast for privates).

The cursor only moves when an entry was **actually recalled** on Up:

- Down is untouched (pi already puts the cursor at the end).
- `historyIndex === -1` after the call means the in-progress draft was restored — its cursor position is preserved.
- An unchanged `historyIndex` means the original call was a boundary no-op (Up at the oldest entry) — moving the cursor there would disrupt in-place editing. *(This is the greptile finding from arc#19, fixed here and upstream.)*

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean.
- Same logic verified upstream in arc#19 against a real TUI driven through a pty: send a message, press Up, type a marker, assert the marker lands after the recalled text.
- Changeset included (patch).
