### PR TITLE
fix(codemode): inject CJS require so snippets can use require('node:...')

### DIFF
--- a/.changeset/codemode-fix-dynamic-require.md
+++ b/.changeset/codemode-fix-dynamic-require.md
@@ -1,0 +1,7 @@
+---
+'@nicknisi/pi-codemode': patch
+---
+
+Fix `Dynamic require of "node:fs" is not supported` errors in codemode snippets.
+
+Snippets that used CJS `require('node:...')` (which the tool description advertises as reachable) failed at runtime: esbuild bundles to ESM and rewrites those calls to a `__require` shim that throws when `require` is undefined in ESM scope. Inject a real CJS `require` (via `createRequire(import.meta.url)`) as an esbuild banner so the shim resolves to the genuine Node built-in instead of throwing.

--- a/packages/codemode/index.ts
+++ b/packages/codemode/index.ts
@@ -472,7 +472,18 @@ export default function codemode(pi: ExtensionAPI) {
       const { mod } = await bundleRequire({
         filepath: file,
         format: 'esm',
-        esbuildOptions: { target: 'es2022' },
+        esbuildOptions: {
+          target: 'es2022',
+          // Snippets may use CJS `require('node:fs')` (the tool description
+          // advertises `process/require/fs` as reachable). esbuild bundles to
+          // ESM and rewrites those to a `__require` shim that throws
+          // `Dynamic require of "node:fs" is not supported` when `require` is
+          // undefined in ESM scope. Inject a real CJS `require` via banner so
+          // the shim resolves to the genuine built-in instead of throwing.
+          banner: {
+            js: 'import { createRequire as __piCodemodeCreateRequire } from "node:module"; const require = __piCodemodeCreateRequire(import.meta.url);',
+          },
+        },
       });
       return mod.default;
     };


### PR DESCRIPTION
## Problem

Codemode snippets that used CJS `require('node:fs')` (which the tool description advertises as reachable) failed at runtime with:

```
Dynamic require of "node:fs" is not supported
```

esbuild bundles snippets to ESM and rewrites those `require` calls to a `__require` shim that throws when `require` is undefined in ESM scope.

## Fix

Inject a real CJS `require` via `createRequire(import.meta.url)` as an esbuild banner, so the shim resolves to the genuine Node built-in instead of throwing.

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm format:check` ✓
- Smoke test: reproduced the failure without the banner (`Dynamic require of "node:fs" is not supported`), then confirmed `require('node:fs')` resolves correctly with the banner applied.