### PR TITLE
feat(composer): expose the border inlay over the pi.events bus

### DIFF
--- a/.changeset/composer-label-bus.md
+++ b/.changeset/composer-label-bus.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-composer': minor
+---
+
+Add an extension API for the border inlay over pi's shared event bus (`pi.events`). Other extensions can push label text with `pi.events.emit('composer:set-label', { text })` (absent/empty text clears it, falling back to the session name), and composer emits `composer:label-request` on every session start so producers can re-push regardless of extension load order. Pushed labels go through the same format/colour/position/truncation pipeline as the session name.

--- a/packages/composer/README.md
+++ b/packages/composer/README.md
@@ -31,6 +31,8 @@ standalone `paste-expand.ts` so the two features don't fight over
   sentence. Composer overrides `navigateHistory` to move the cursor to the end
   after a successful Up recall. Down, draft restoration, and boundary no-ops
   (Up at the oldest entry) are untouched.
+- **Extension API** over `pi.events`: other extensions can push their own text
+  into the border inlay — see [Extension API](#extension-api).
 
 ## Features
 
@@ -56,6 +58,34 @@ standalone `paste-expand.ts` so the two features don't fight over
 - **Focus indicator**: border switches colour when the tmux pane holding this session has terminal focus (requires tmux `focus-events on`)
 - **Spinner prefix**: while pi is working, the prefix glyph animates as a spinner — pick from built-in presets or define your own frames (configurable speed and colour, including `"rainbow"`)
 - **Border glow**: while pi is working, the border either _pulses_ (breathes between the border colour and a glow colour) or _shimmers_ (a highlight sweeps along the top/bottom rules)
+
+## Extension API
+
+Other extensions can replace the border-inlay text over pi's shared event bus
+(`pi.events`), without importing anything from this package:
+
+```ts
+// Push a label (any non-empty string):
+pi.events.emit('composer:set-label', { text: `⏱ ${elapsed}` });
+
+// Clear it (falls back to the session name):
+pi.events.emit('composer:set-label', {});
+```
+
+The pushed text takes precedence over the session name and goes through the
+same formatting pipeline — `sessionNameFormat`, `sessionNameColor`, position,
+border, and truncation all apply. The override is cleared on every session
+start so a stale label never leaks across sessions.
+
+Because extension load order is not guaranteed, composer emits
+`composer:label-request` on every `session_start`; producers should respond to
+it (and to whatever changes their own state) with `composer:set-label`:
+
+```ts
+pi.events.on('composer:label-request', () => {
+  pi.events.emit('composer:set-label', { text: currentLabel() });
+});
+```
 
 ## Install
 

--- a/packages/composer/index.ts
+++ b/packages/composer/index.ts
@@ -11,12 +11,13 @@
  * config-driven (~/.pi/agent/configs/composer.json) and supports a
  * prefix glyph, boxed/unboxed modes, configurable padding, menu gap,
  * rounded vs square corners, a configurable session-name inlay in the border
- * (shown only when the session has a name), and working-state animations
- * (spinner prefix and border glow while the agent works). The
- * rounded ╭╮│╰╯ corners remain the default to preserve the original look.
- * Paste-expand behavior was merged in from the former standalone
- * `paste-expand.ts` so the two features don't
- * fight over `setEditorComponent` (last-call-wins).
+ * (shown only when the session has a name — or another extension has pushed
+ * label text over the `pi.events` bus; see the README's Extension API), and
+ * working-state animations (spinner prefix and border glow while the agent
+ * works). The rounded ╭╮│╰╯ corners remain the default to preserve the
+ * original look. Paste-expand behavior was merged in from the former
+ * standalone `paste-expand.ts` so the two features don't fight over
+ * `setEditorComponent` (last-call-wins).
  *
  * Layout (boxed):
  *   ╭──────────────────────────╮
@@ -80,6 +81,7 @@ import { CONFIG, configLoadError, reloadConfig } from './config.js';
 import {
   applyColor,
   mixRgb,
+  parseLabelData,
   plainText,
   rainbowRgb,
   resolveRgb,
@@ -141,6 +143,11 @@ let busySince = 0;
  * auto-names sessions, so any value here was set deliberately — via /name,
  * --name, or an extension such as session-name. */
 let sessionName: string | undefined;
+
+/** Label text pushed by another extension via the `composer:set-label` bus
+ * event; takes precedence over the session name. Cleared and re-requested on
+ * every session start so a stale label never leaks across sessions. */
+let labelOverride: string | undefined;
 let animTimer: ReturnType<typeof setInterval> | undefined;
 let previewTimer: ReturnType<typeof setTimeout> | undefined;
 let animTui: TUI | undefined;
@@ -387,13 +394,14 @@ class Composer extends CustomEditor {
    * the session is unnamed or the rule is too narrow (keeps at least 8 cells
    * of plain rule). */
   private sessionNameLabel(width: number): { text: string; width: number } | null {
-    if (!CONFIG.SESSION_NAME || !sessionName) return null;
+    const label = labelOverride ?? sessionName;
+    if (!CONFIG.SESSION_NAME || !label) return null;
     const [pre, post] = splitFormat(CONFIG.SESSION_NAME_FORMAT);
     const surroundW = visibleWidth(pre) + visibleWidth(post);
     const fit = width - 8 - surroundW;
     const cap = CONFIG.SESSION_NAME_MAX_WIDTH > 0 ? Math.min(CONFIG.SESSION_NAME_MAX_WIDTH, fit) : fit;
     if (cap < 4) return null;
-    const name = truncateCells(sessionName, cap);
+    const name = truncateCells(label, cap);
     return {
       text: this.border(pre) + this.name(name) + this.border(post),
       width: surroundW + visibleWidth(name),
@@ -527,9 +535,20 @@ function disableFocusTracking(): void {
 }
 
 export default function composer(pi: ExtensionAPI) {
+  // Extension API over pi's shared event bus: another extension pushes label
+  // text with pi.events.emit('composer:set-label', { text }); an absent or
+  // empty text clears the override. Composer re-emits 'composer:label-request'
+  // on every session start so producers can re-push regardless of load order.
+  pi.events.on('composer:set-label', (data) => {
+    labelOverride = parseLabelData(data);
+    animTui?.requestRender();
+  });
+
   pi.on('session_start', (_event, ctx: ExtensionContext) => {
     if (ctx.mode !== 'tui') return;
     sessionName = pi.getSessionName() || undefined;
+    labelOverride = undefined;
+    pi.events.emit('composer:label-request', {});
     ctx.ui.setEditorComponent((tui, theme, kb) => {
       // All palette fns read CONFIG.* at call time so /composer reloads
       // take effect without rebuilding the editor component.
@@ -642,6 +661,7 @@ export default function composer(pi: ExtensionAPI) {
     stopAnimation();
     animTui = undefined;
     sessionName = undefined;
+    labelOverride = undefined;
     ctx.ui.setEditorComponent(undefined);
   });
 }

--- a/packages/composer/utils.test.ts
+++ b/packages/composer/utils.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { splitFormat, truncateCells } from './utils.js';
+import { parseLabelData, splitFormat, truncateCells } from './utils.js';
+
+describe('parseLabelData', () => {
+  it('returns the text when it is a non-empty string', () => {
+    expect(parseLabelData({ text: 'fix the tests' })).toBe('fix the tests');
+  });
+
+  it('clears on absent, empty, blank, or wrongly-typed text', () => {
+    expect(parseLabelData({})).toBeUndefined();
+    expect(parseLabelData({ text: '' })).toBeUndefined();
+    expect(parseLabelData({ text: '   ' })).toBeUndefined();
+    expect(parseLabelData({ text: 42 })).toBeUndefined();
+    expect(parseLabelData(null)).toBeUndefined();
+    expect(parseLabelData('just a string')).toBeUndefined();
+    expect(parseLabelData(undefined)).toBeUndefined();
+  });
+});
 
 describe('splitFormat', () => {
   it('splits the template around {name}', () => {

--- a/packages/composer/utils.ts
+++ b/packages/composer/utils.ts
@@ -17,6 +17,13 @@ export function splitFormat(format: string): [string, string] {
   return [format.slice(0, i), format.slice(i + '{name}'.length)];
 }
 
+/** Parse a `composer:set-label` bus payload: a non-empty string `text` sets
+ * the label; anything else (absent, empty, wrong type) clears the override. */
+export function parseLabelData(data: unknown): string | undefined {
+  const text = (data as { text?: unknown } | null | undefined)?.text;
+  return typeof text === 'string' && text.trim().length > 0 ? text : undefined;
+}
+
 /** Truncate to `max` visible cells, appending an ellipsis when truncated. */
 export function truncateCells(s: string, max: number): string {
   if (visibleWidth(s) <= max) return s;


### PR DESCRIPTION
Follow-up to #62.

## What

Composer's border inlay is no longer hard-coded to the session name. Any extension can push text into it over pi's shared event bus (`pi.events`) — no import of this package needed:

```ts
pi.events.emit('composer:set-label', { text: `⏱ ${elapsed}` });  // set
pi.events.emit('composer:set-label', {});                        // clear → session name
```

Semantics:
- A non-empty `text` overrides the session name; absent/empty/wrongly-typed clears the override.
- The override is cleared on every `session_start` (and `session_shutdown`) so labels never leak across sessions.
- Composer emits `composer:label-request` on every `session_start`; producers respond with `composer:set-label`, which makes the handshake independent of extension load order.
- Pushed labels go through the same pipeline as the session name: `sessionNameFormat`, `sessionNameColor`, position, border, truncation.

## Changes

- `index.ts`: bus listener, handshake emit, override state (cleared on session start/shutdown)
- `utils.ts`: `parseLabelData` payload parser + tests
- README gains an Extension API section; changeset included (minor)

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- 118 tests pass (2 new for `parseLabelData`)
- Smoke-tested extension load