### PR TITLE
fix(statusline): swallow claude-notify spawn ENOENT instead of crashing pi

### DIFF
--- a/.changeset/statusline-claude-notify-enoent.md
+++ b/.changeset/statusline-claude-notify-enoent.md
@@ -1,0 +1,9 @@
+---
+'@nicknisi/pi-statusline': patch
+---
+
+Guard the optional `claude-notify` spawn so a missing binary no longer kills pi with an uncaught `ENOENT`.
+
+The `agent_end` handler spawned `claude-notify waiting <session> <pane>` with `detached: true` and `stdio: 'ignore'`, then immediately `.unref()`'d the returned `ChildProcess` without attaching an `error` listener. When `claude-notify` is not on `PATH`, Node emits `ENOENT` asynchronously on the child's `error` event; with no listener that escalates to an uncaught exception and takes the whole pi process down. `stdio: 'ignore'` does not suppress spawn `error` events.
+
+Attach an empty `error` listener so the failure is swallowed: behavior is unchanged when `claude-notify` exists, and a missing optional notifier can no longer crash pi.

--- a/packages/statusline/index.ts
+++ b/packages/statusline/index.ts
@@ -322,10 +322,16 @@ export default function (pi: ExtensionAPI) {
     const session = getTmuxSession();
     const paneId = process.env.TMUX_PANE;
     if (session && paneId) {
-      spawn('claude-notify', ['waiting', session, paneId], {
+      // claude-notify is an optional personal notifier. If it's missing
+      // (ENOENT) or fails to spawn for any reason, that must never take
+      // pi down as an uncaught exception — attach an error listener so
+      // the spawn error is swallowed.
+      const child = spawn('claude-notify', ['waiting', session, paneId], {
         detached: true,
         stdio: 'ignore',
-      }).unref();
+      });
+      child.on('error', () => {});
+      child.unref();
     }
   });
 


### PR DESCRIPTION
## Problem

The `statusline` extension's `agent_end` handler spawns an external `claude-notify` binary to signal that the agent is waiting:

```ts
spawn('claude-notify', ['waiting', session, paneId], {
  detached: true,
  stdio: 'ignore',
}).unref();
```

`claude-notify` is documented as a **personal script expected on `PATH`** (see `packages/statusline/README.md`). When it isn't installed, `spawn` emits `ENOENT` **asynchronously on the child's `error` event**. Because the code immediately `.unref()`'s the returned `ChildProcess` and never attaches an `error` listener, Node escalates that emitted error to an **uncaught exception** and tears the whole pi process down:

```
pi exiting due to uncaughtException:
Error: spawn claude-notify ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    ...
    spawnargs: [ 'waiting', 'shepherdshift', '%21' ]
```

`stdio: 'ignore'` does **not** suppress spawn `error` events — it only silences stdio streams — so a missing optional notifier reliably kills pi at the end of every turn. I hit this concretely when a PR review finished: the review itself completed fine, but pi crashed on the `agent_end` notification step.

## Fix

Attach an empty `error` listener to the spawned child so the failure is swallowed:

```ts
const child = spawn('claude-notify', ['waiting', session, paneId], {
  detached: true,
  stdio: 'ignore',
});
child.on('error', () => {});
child.unref();
```

- No behavior change when `claude-notify` is present — still fire-and-forget, detached, silent.
- A missing or failing-to-spawn notifier is now a no-op instead of a process-killing uncaught exception.

## Why this is the right layer to fix it

An optional, user-specific notifier should never be able to take the host agent down. Catching at the spawn site is the minimal, correct guard; users who *do* have `claude-notify` on PATH are unaffected, and users who don't are no longer penalized for the extension's own missing-error-listener bug.

## Changeset

`@nicknisi/pi-statusline`: patch