### PR TITLE
feat: add machine-local model switching with fuzzy section-aware picker

### DIFF
--- a/.changeset/model-switch.md
+++ b/.changeset/model-switch.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-model-switch': minor
+---
+
+Add machine-local preferred model switching and a fuzzy section-aware picker with configurable shortcuts.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Local paths are added to pi's settings without copying — edits in the repo are
 | [auto-theme](packages/auto-theme/)       | Sync pi theme with macOS system appearance (dark↔light pairs)                                                                | —                                                   |
 | [claude-compat](packages/claude-compat/) | Claude Code compatibility: `CLAUDE_PLUGIN_ROOT` path shimming + `` !`command` `` dynamic SKILL.md placeholders (allowlisted) | two extension entry points                          |
 | [cloak](packages/cloak/)                 | Redact secrets from `read` tool results before they reach model context, via glob-scoped regex rules                         | `/cloak-status`, `cloak.json`                       |
+| [model-switch](packages/model-switch/)   | Cycle or fuzzy-pick from a machine-local, sectioned model list, skipping missing or unauthenticated entries                  | `/model-cycle`, configurable shortcuts              |
 | [session-name](packages/session-name/)   | Auto-name sessions (heuristic or LLM), mirror to terminal title, name-focused session picker                                 | `/sn`, `/sessions`                                  |
 | [stash](packages/stash/)                 | `ctrl+s` parks the prompt draft on a LIFO stack; pop or auto-restore                                                         | `ctrl+s`, stash widget                              |
 

--- a/packages/model-switch/README.md
+++ b/packages/model-switch/README.md
@@ -1,0 +1,148 @@
+# @nicknisi/pi-model-switch
+
+Cycle or fuzzy-pick from a machine-local, sectioned list of preferred Pi models.
+
+This package is useful when the same Pi configuration is shared across machines but each machine has different providers, credentials, or model preferences. The extension reads an untracked local config instead of using `enabledModels`, skips unavailable entries, and leaves Pi's normal `/model` and Ctrl+L picker unchanged.
+
+## Install
+
+From npm after the package is published:
+
+```bash
+pi install npm:@nicknisi/pi-model-switch
+```
+
+From a local checkout:
+
+```bash
+pi install ~/Developer/pi-extensions/packages/model-switch
+```
+
+## Configure shortcuts
+
+The defaults are Ctrl+Shift+M forward, Ctrl+Shift+Alt+M backward, and Ctrl+Shift+L for the fuzzy picker. Override any of them in Pi's existing `~/.pi/agent/keybindings.json`:
+
+```json
+{
+  "model-switch.cycleForward": "ctrl+shift+m",
+  "model-switch.cycleBackward": "ctrl+shift+alt+m",
+  "model-switch.select": "ctrl+shift+l"
+}
+```
+
+These extension-owned action IDs are ignored by Pi's built-in keybinding manager and read by model-switch during extension load. Run `/reload` or restart Pi after changing them. Each value must be one non-empty Pi key string; a missing or invalid value falls back to its default.
+
+## Configure models
+
+Copy the example config:
+
+```bash
+mkdir -p ~/.pi/agent/configs
+cp model-switch.example.json ~/.pi/agent/configs/model-switch.json
+```
+
+Or create `~/.pi/agent/configs/model-switch.json` directly with named sections:
+
+```json
+{
+  "sections": {
+    "work": ["cloudflare-ai-gateway/gpt-5.6-sol", "cloudflare-ai-gateway/claude-opus-5"],
+    "personal": ["fireworks/accounts/fireworks/models/kimi-k3"]
+  }
+}
+```
+
+Section names are arbitrary — define as many as you want. The legacy flat format also works:
+
+```json
+{
+  "models": ["cloudflare-ai-gateway/gpt-5.6-sol"]
+}
+```
+
+The file is read on every interaction, so edits take effect without reloading Pi.
+
+### Config schema
+
+| Field      | Type                       | Default | Description                                                                        |
+| ---------- | -------------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `sections` | `Record<string, string[]>` | —       | Named sections of ordered `provider/model-id` references. Preferred over `models`. |
+| `models`   | `string[]`                 | —       | Legacy flat list. Treated as a single unnamed section when `sections` is absent.   |
+
+The first `/` separates the provider from the model ID. Additional slashes belong to the model ID, so references such as `fireworks/accounts/fireworks/models/kimi-k3` work as expected.
+
+Keep this config machine-local and untracked. A personal machine and work machine can each provide their own sections while sharing the installed extension and the rest of your Pi dotfiles.
+
+## Behavior
+
+### Cycling
+
+- **Ctrl+Shift+M** moves forward through usable models in the active section.
+- **Ctrl+Shift+Alt+M** moves backward.
+- The active section is the one containing the current model. If the current model is not in any section, the first section is used.
+- Cycling wraps at both ends within the active section.
+
+### Fuzzy picker
+
+- **Ctrl+Shift+L** or `/model-switch` opens a fuzzy-searchable TUI picker.
+- **Tab** cycles between sections within the picker.
+- Type to fuzzy-filter models within the active section.
+- The picker preserves config order, marks the current model with `●`, switches the chosen entry, and treats cancellation as a no-op.
+- Sections with no usable models are hidden from the picker.
+
+### General
+
+- Missing models and models without working provider authentication are skipped while preserving config order.
+- If no configured model is usable, Pi keeps the current model and shows a warning.
+- Invalid JSON or invalid config values produce a warning containing the config path.
+- The extension never changes the model at startup.
+
+`enabledModels` is not read or modified. Pi's `/model` command and Ctrl+L picker continue to expose the normal available catalog.
+
+## Troubleshooting
+
+### The custom shortcuts do not respond
+
+Check the `model-switch.cycleForward`, `model-switch.cycleBackward`, and `model-switch.select` values in `~/.pi/agent/keybindings.json`, then run `/reload`. Check Pi's startup diagnostics for another extension using the same physical keys, and verify that your terminal reports the configured combinations as distinct modified key events. No built-in Pi keybinding changes are required.
+
+### A configured model is skipped
+
+Check that Pi knows the exact reference and that its provider is authenticated:
+
+```bash
+pi --list-models
+```
+
+Model entries must use the full `provider/model-id` shown by Pi. Authentication is machine-specific and can be managed with `/login` and `/logout`.
+
+### No configured models are available
+
+The config may be missing, empty, malformed, or contain only missing/unauthenticated entries. Pi's warning includes the active config path. `PI_CODING_AGENT_DIR` changes that path along with the rest of the agent configuration.
+
+## Caveats
+
+- This extension owns only its custom cycle and fuzzy picker; it cannot and does not mutate Pi's read-only scoped model list.
+- The picker uses a custom search + list component with `ctx.ui.custom()`; native `/model` and Ctrl+L remain available for the full catalog.
+- Terminal support for multi-modifier keys varies; configure simpler non-conflicting keys or use a terminal with the Kitty keyboard protocol when modified keys are not distinguishable.
+- Availability is checked on each interaction, which may resolve provider credentials before switching.
+- Duplicate references within a section are preserved as written; avoid them unless repeated cycle positions are intentional.
+
+## Development
+
+From the repository root:
+
+```bash
+pnpm vitest run packages/model-switch
+pnpm typecheck
+pnpm lint
+pnpm format:check
+pnpm build
+```
+
+Smoke-test extension loading with a scratch agent directory:
+
+```bash
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+PI_CODING_AGENT_DIR="$tmp" pi --no-extensions -e packages/model-switch/index.ts --list-models
+```

--- a/packages/model-switch/config.test.ts
+++ b/packages/model-switch/config.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_MODEL_CYCLE_KEYBINDINGS, loadModelSwitchConfig, loadModelSwitchKeybindings } from './config.js';
+
+const tempDirs: string[] = [];
+
+function tempConfig(content?: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-model-switch-'));
+  tempDirs.push(dir);
+  const path = join(dir, 'model-switch.json');
+  if (content !== undefined) writeFileSync(path, content);
+  return path;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('loadModelSwitchKeybindings', () => {
+  it('uses defaults when keybindings.json is missing or malformed', () => {
+    expect(loadModelSwitchKeybindings(tempConfig())).toEqual(DEFAULT_MODEL_CYCLE_KEYBINDINGS);
+    expect(loadModelSwitchKeybindings(tempConfig('{ nope'))).toEqual(DEFAULT_MODEL_CYCLE_KEYBINDINGS);
+  });
+
+  it('loads extension-owned bindings from keybindings.json', () => {
+    const result = loadModelSwitchKeybindings(
+      tempConfig(
+        JSON.stringify({
+          'model-switch.cycleForward': 'ctrl+alt+n',
+          'model-switch.cycleBackward': 'ctrl+alt+b',
+          'model-switch.select': 'ctrl+alt+l',
+          'app.model.select': 'ctrl+l',
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      forward: 'ctrl+alt+n',
+      backward: 'ctrl+alt+b',
+      select: 'ctrl+alt+l',
+    });
+  });
+
+  it('falls back per binding when extension-owned values are absent or invalid', () => {
+    const result = loadModelSwitchKeybindings(
+      tempConfig(
+        JSON.stringify({
+          'model-switch.cycleForward': [],
+          'model-switch.cycleBackward': ' ctrl+alt+b ',
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      forward: DEFAULT_MODEL_CYCLE_KEYBINDINGS.forward,
+      backward: 'ctrl+alt+b',
+      select: DEFAULT_MODEL_CYCLE_KEYBINDINGS.select,
+    });
+  });
+});
+
+describe('loadModelSwitchConfig', () => {
+  it('returns empty sections when the config is missing', () => {
+    const result = loadModelSwitchConfig(tempConfig());
+
+    expect(result).toEqual({ ok: true, config: { sections: [] } });
+  });
+
+  it('loads named sections in order', () => {
+    const result = loadModelSwitchConfig(
+      tempConfig(
+        JSON.stringify({
+          sections: {
+            work: ['cloudflare-ai-gateway/grok-4.5', '  fireworks/.../kimi-k3  '],
+            personal: ['fireworks/.../kimi-k3'],
+          },
+        }),
+      ),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      config: {
+        sections: [
+          { name: 'work', models: ['cloudflare-ai-gateway/grok-4.5', 'fireworks/.../kimi-k3'] },
+          { name: 'personal', models: ['fireworks/.../kimi-k3'] },
+        ],
+      },
+    });
+  });
+
+  it('falls back to legacy flat models as a single section', () => {
+    const result = loadModelSwitchConfig(tempConfig(JSON.stringify({ models: ['cloudflare-ai-gateway/grok-4.5'] })));
+
+    expect(result).toEqual({
+      ok: true,
+      config: { sections: [{ name: 'models', models: ['cloudflare-ai-gateway/grok-4.5'] }] },
+    });
+  });
+
+  it('prefers sections when both sections and models are present', () => {
+    const result = loadModelSwitchConfig(
+      tempConfig(
+        JSON.stringify({
+          sections: { work: ['provider/model-a'] },
+          models: ['provider/model-b'],
+        }),
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.config.sections).toEqual([{ name: 'work', models: ['provider/model-a'] }]);
+  });
+
+  it('reports malformed JSON with the config path', () => {
+    const path = tempConfig('{ nope');
+    const result = loadModelSwitchConfig(path);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain(path);
+      expect(result.error).toContain('Invalid model-switch config');
+    }
+  });
+
+  it.each([
+    ['non-object input', '[]'],
+    ['missing sections and models', '{}'],
+    ['non-object sections', JSON.stringify({ sections: 'nope' })],
+    ['empty sections object', JSON.stringify({ sections: {} })],
+    ['non-array section models', JSON.stringify({ sections: { work: 'nope' } })],
+    ['non-string model in section', JSON.stringify({ sections: { work: [42] } })],
+    ['empty model in section', JSON.stringify({ sections: { work: ['  '] } })],
+    ['non-array legacy models', JSON.stringify({ models: 'grok-4.5' })],
+  ])('rejects %s', (_label, content) => {
+    const path = tempConfig(content);
+    const result = loadModelSwitchConfig(path);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain(path);
+  });
+});

--- a/packages/model-switch/config.ts
+++ b/packages/model-switch/config.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
+
+export interface ModelSwitchSection {
+  name: string;
+  models: string[];
+}
+
+export interface ModelSwitchConfig {
+  sections: ModelSwitchSection[];
+}
+
+export interface ModelSwitchKeybindings {
+  forward: string;
+  backward: string;
+  select: string;
+}
+
+export const DEFAULT_MODEL_CYCLE_KEYBINDINGS: ModelSwitchKeybindings = {
+  forward: 'ctrl+shift+m',
+  backward: 'ctrl+shift+alt+m',
+  select: 'ctrl+shift+l',
+};
+
+const FORWARD_KEYBINDING = 'model-switch.cycleForward';
+const BACKWARD_KEYBINDING = 'model-switch.cycleBackward';
+const SELECT_KEYBINDING = 'model-switch.select';
+
+export type ConfigLoadResult = { ok: true; config: ModelSwitchConfig } | { ok: false; error: string };
+
+export function modelCycleConfigPath(): string {
+  return join(getAgentDir(), 'configs', 'model-switch.json');
+}
+
+export function modelCycleKeybindingsPath(): string {
+  return join(getAgentDir(), 'keybindings.json');
+}
+
+export function loadModelSwitchKeybindings(path = modelCycleKeybindingsPath()): ModelSwitchKeybindings {
+  if (!existsSync(path)) return { ...DEFAULT_MODEL_CYCLE_KEYBINDINGS };
+
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { ...DEFAULT_MODEL_CYCLE_KEYBINDINGS };
+  }
+
+  if (!value || typeof value !== 'object') return { ...DEFAULT_MODEL_CYCLE_KEYBINDINGS };
+
+  const bindings = value as Record<string, unknown>;
+  const forward = bindings[FORWARD_KEYBINDING];
+  const backward = bindings[BACKWARD_KEYBINDING];
+  const select = bindings[SELECT_KEYBINDING];
+
+  return {
+    forward:
+      typeof forward === 'string' && forward.trim().length > 0
+        ? forward.trim()
+        : DEFAULT_MODEL_CYCLE_KEYBINDINGS.forward,
+    backward:
+      typeof backward === 'string' && backward.trim().length > 0
+        ? backward.trim()
+        : DEFAULT_MODEL_CYCLE_KEYBINDINGS.backward,
+    select:
+      typeof select === 'string' && select.trim().length > 0 ? select.trim() : DEFAULT_MODEL_CYCLE_KEYBINDINGS.select,
+  };
+}
+
+function validateModelStrings(raw: unknown, path: string, context: string): string[] | { error: string } {
+  if (!Array.isArray(raw)) {
+    return { error: `Invalid model-switch config at ${path}: expected "${context}" to be a string[]` };
+  }
+  if (raw.some((model) => typeof model !== 'string' || model.trim().length === 0)) {
+    return { error: `Invalid model-switch config at ${path}: every model in "${context}" must be a non-empty string` };
+  }
+  return raw.map((model) => model.trim());
+}
+
+export function loadModelSwitchConfig(path = modelCycleConfigPath()): ConfigLoadResult {
+  if (!existsSync(path)) {
+    return { ok: true, config: { sections: [] } };
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Invalid model-switch config at ${path}: ${message}` };
+  }
+
+  if (!value || typeof value !== 'object') {
+    return { ok: false, error: `Invalid model-switch config at ${path}: expected an object` };
+  }
+
+  const obj = value as Record<string, unknown>;
+
+  // Prefer "sections" if present; fall back to legacy "models" as a single section.
+  if ('sections' in obj && obj.sections && typeof obj.sections === 'object') {
+    const sectionsRaw = obj.sections as Record<string, unknown>;
+    const sections: ModelSwitchSection[] = [];
+
+    for (const [name, modelsRaw] of Object.entries(sectionsRaw)) {
+      const result = validateModelStrings(modelsRaw, path, `sections.${name}`);
+      if (!Array.isArray(result)) return { ok: false, error: result.error };
+      sections.push({ name, models: result });
+    }
+
+    if (sections.length === 0) {
+      return {
+        ok: false,
+        error: `Invalid model-switch config at ${path}: "sections" must define at least one section`,
+      };
+    }
+
+    return { ok: true, config: { sections } };
+  }
+
+  if ('models' in obj) {
+    const result = validateModelStrings(obj.models, path, 'models');
+    if (!Array.isArray(result)) return { ok: false, error: result.error };
+    return { ok: true, config: { sections: [{ name: 'models', models: result }] } };
+  }
+
+  return {
+    ok: false,
+    error: `Invalid model-switch config at ${path}: expected { "sections": { ... } } or { "models": [...] }`,
+  };
+}

--- a/packages/model-switch/cycle.test.ts
+++ b/packages/model-switch/cycle.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import type { Api, Model } from '@earendil-works/pi-ai';
+import {
+  findActiveSection,
+  parseModelReference,
+  resolveAvailableModels,
+  selectCycleTarget,
+  type ModelRegistryLike,
+} from './cycle.js';
+import type { ModelSwitchSection } from './config.js';
+
+function model(provider: string, id: string): Model<Api> {
+  return { provider, id } as Model<Api>;
+}
+
+function registry(models: Model<Api>[], unauthenticated: string[] = []): ModelRegistryLike {
+  const byReference = new Map(models.map((item) => [`${item.provider}/${item.id}`, item]));
+  const unavailable = new Set(unauthenticated);
+
+  return {
+    find(provider, modelId) {
+      return byReference.get(`${provider}/${modelId}`);
+    },
+    async getApiKeyAndHeaders(item) {
+      const reference = `${item.provider}/${item.id}`;
+      return unavailable.has(reference)
+        ? { ok: false as const, error: 'not authenticated' }
+        : { ok: true as const, apiKey: 'test' };
+    },
+  };
+}
+
+describe('parseModelReference', () => {
+  it('keeps slashes inside the model id', () => {
+    expect(parseModelReference('fireworks/accounts/fireworks/models/kimi-k3')).toEqual({
+      provider: 'fireworks',
+      modelId: 'accounts/fireworks/models/kimi-k3',
+    });
+  });
+
+  it.each(['missing-provider', '/missing-provider', 'missing-model/'])('rejects %s', (value) => {
+    expect(parseModelReference(value)).toBeUndefined();
+  });
+});
+
+describe('resolveAvailableModels', () => {
+  it('preserves configured order while skipping invalid, missing, and unauthenticated models', async () => {
+    const grok = model('cloudflare-ai-gateway', 'grok-4.5');
+    const kimi = model('fireworks', 'accounts/fireworks/models/kimi-k3');
+    const deepseek = model('fireworks', 'accounts/fireworks/models/deepseek-v4-pro');
+
+    const result = await resolveAvailableModels(
+      [
+        'fireworks/accounts/fireworks/models/kimi-k3',
+        'invalid',
+        'missing/nope',
+        'cloudflare-ai-gateway/grok-4.5',
+        'fireworks/accounts/fireworks/models/deepseek-v4-pro',
+      ],
+      registry([grok, kimi, deepseek], ['fireworks/accounts/fireworks/models/deepseek-v4-pro']),
+    );
+
+    expect(result).toEqual([kimi, grok]);
+  });
+});
+
+describe('findActiveSection', () => {
+  const workSection: ModelSwitchSection = {
+    name: 'work',
+    models: ['provider/work-a', 'provider/work-b'],
+  };
+  const personalSection: ModelSwitchSection = {
+    name: 'personal',
+    models: ['provider/personal-a'],
+  };
+  const sections = [workSection, personalSection];
+
+  it('returns undefined for empty sections', () => {
+    expect(findActiveSection([], model('provider', 'x'))).toBeUndefined();
+  });
+
+  it('returns the first section when there is no current model', () => {
+    expect(findActiveSection(sections, undefined)).toBe(workSection);
+  });
+
+  it('returns the section containing the current model', () => {
+    expect(findActiveSection(sections, model('provider', 'work-b'))).toBe(workSection);
+    expect(findActiveSection(sections, model('provider', 'personal-a'))).toBe(personalSection);
+  });
+
+  it('falls back to the first section when the current model is not in any section', () => {
+    expect(findActiveSection(sections, model('other', 'outside'))).toBe(workSection);
+  });
+});
+
+describe('selectCycleTarget', () => {
+  const first = model('provider', 'first');
+  const second = model('provider', 'second');
+  const third = model('provider', 'third');
+  const available = [first, second, third];
+
+  it('returns undefined for an empty list', () => {
+    expect(selectCycleTarget(first, [], 'forward')).toBeUndefined();
+  });
+
+  it('returns the only model in either direction', () => {
+    expect(selectCycleTarget(first, [first], 'forward')).toBe(first);
+    expect(selectCycleTarget(first, [first], 'backward')).toBe(first);
+  });
+
+  it('enters at the directional boundary when current is outside the list', () => {
+    const outside = model('other', 'outside');
+
+    expect(selectCycleTarget(outside, available, 'forward')).toBe(first);
+    expect(selectCycleTarget(outside, available, 'backward')).toBe(third);
+    expect(selectCycleTarget(undefined, available, 'forward')).toBe(first);
+    expect(selectCycleTarget(undefined, available, 'backward')).toBe(third);
+  });
+
+  it('moves in both directions and wraps at each boundary', () => {
+    expect(selectCycleTarget(first, available, 'forward')).toBe(second);
+    expect(selectCycleTarget(second, available, 'backward')).toBe(first);
+    expect(selectCycleTarget(third, available, 'forward')).toBe(first);
+    expect(selectCycleTarget(first, available, 'backward')).toBe(third);
+  });
+});

--- a/packages/model-switch/cycle.ts
+++ b/packages/model-switch/cycle.ts
@@ -1,0 +1,83 @@
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { ModelSwitchSection } from './config.js';
+
+export type CycleDirection = 'forward' | 'backward';
+
+export interface ModelReference {
+  provider: string;
+  modelId: string;
+}
+
+export interface ModelRegistryLike {
+  find(provider: string, modelId: string): Model<Api> | undefined;
+  getApiKeyAndHeaders(
+    model: Model<Api>,
+  ): Promise<{ ok: true; apiKey?: string; headers?: Record<string, string | null> } | { ok: false; error: string }>;
+}
+
+export function parseModelReference(value: string): ModelReference | undefined {
+  const separator = value.indexOf('/');
+  if (separator <= 0 || separator === value.length - 1) return undefined;
+
+  return {
+    provider: value.slice(0, separator),
+    modelId: value.slice(separator + 1),
+  };
+}
+
+export async function resolveAvailableModels(
+  references: readonly string[],
+  registry: ModelRegistryLike,
+): Promise<Model<Api>[]> {
+  const available: Model<Api>[] = [];
+
+  for (const value of references) {
+    const reference = parseModelReference(value);
+    if (!reference) continue;
+
+    const model = registry.find(reference.provider, reference.modelId);
+    if (!model) continue;
+
+    const auth = await registry.getApiKeyAndHeaders(model);
+    if (auth.ok) available.push(model);
+  }
+
+  return available;
+}
+
+export function findActiveSection(
+  sections: readonly ModelSwitchSection[],
+  current: Model<Api> | undefined,
+): ModelSwitchSection | undefined {
+  if (sections.length === 0) return undefined;
+  if (!current) return sections[0];
+
+  const found = sections.find((section) =>
+    section.models.some((value) => {
+      const ref = parseModelReference(value);
+      return ref?.provider === current.provider && ref?.modelId === current.id;
+    }),
+  );
+
+  return found ?? sections[0];
+}
+
+export function selectCycleTarget(
+  current: Model<Api> | undefined,
+  available: readonly Model<Api>[],
+  direction: CycleDirection,
+): Model<Api> | undefined {
+  if (available.length === 0) return undefined;
+
+  const currentIndex = current
+    ? available.findIndex((model) => model.provider === current.provider && model.id === current.id)
+    : -1;
+
+  if (currentIndex === -1) {
+    return direction === 'forward' ? available[0] : available[available.length - 1];
+  }
+
+  const offset = direction === 'forward' ? 1 : -1;
+  const nextIndex = (currentIndex + offset + available.length) % available.length;
+  return available[nextIndex];
+}

--- a/packages/model-switch/index.test.ts
+++ b/packages/model-switch/index.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import modelCycle from './index.js';
+
+const tempDirs: string[] = [];
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+
+type ShortcutHandler = (ctx: ExtensionContext) => Promise<void> | void;
+type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void> | void;
+
+function model(provider: string, id: string): Model<Api> {
+  return { provider, id } as Model<Api>;
+}
+
+function tempAgentDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-model-switch-handler-'));
+  tempDirs.push(dir);
+  process.env.PI_CODING_AGENT_DIR = dir;
+  return dir;
+}
+
+function writeConfig(sections: Record<string, string[]>): string {
+  const dir = tempAgentDir();
+  const configDir = join(dir, 'configs');
+  mkdirSync(configDir);
+  writeFileSync(join(configDir, 'model-switch.json'), JSON.stringify({ sections }));
+  return dir;
+}
+
+function writeKeybindings(value: unknown): string {
+  const dir = tempAgentDir();
+  writeFileSync(join(dir, 'keybindings.json'), JSON.stringify(value));
+  return dir;
+}
+
+function harness(
+  options: {
+    current?: Model<Api>;
+    models?: Model<Api>[];
+    unauthenticated?: string[];
+    switchResult?: boolean;
+    customResult?: string | null;
+    hasUI?: boolean;
+  } = {},
+) {
+  if (!process.env.PI_CODING_AGENT_DIR) tempAgentDir();
+
+  const shortcuts = new Map<string, ShortcutHandler>();
+  const commands = new Map<string, CommandHandler>();
+  const setModel = vi.fn(async () => options.switchResult ?? true);
+  const notify = vi.fn();
+  const custom = vi.fn(async () => options.customResult ?? null);
+  const models = options.models ?? [];
+  const byReference = new Map(models.map((item) => [`${item.provider}/${item.id}`, item]));
+  const unauthenticated = new Set(options.unauthenticated ?? []);
+
+  const pi = {
+    registerShortcut(key: string, shortcut: { handler: ShortcutHandler }) {
+      shortcuts.set(key, shortcut.handler);
+    },
+    registerCommand(name: string, command: { handler: CommandHandler }) {
+      commands.set(name, command.handler);
+    },
+    setModel,
+  } as unknown as ExtensionAPI;
+
+  const ctx = {
+    model: options.current,
+    hasUI: options.hasUI ?? true,
+    modelRegistry: {
+      find(provider: string, modelId: string) {
+        return byReference.get(`${provider}/${modelId}`);
+      },
+      async getApiKeyAndHeaders(item: Model<Api>) {
+        const reference = `${item.provider}/${item.id}`;
+        return unauthenticated.has(reference)
+          ? { ok: false as const, error: 'not authenticated' }
+          : { ok: true as const, apiKey: 'test' };
+      },
+    },
+    ui: { notify, custom },
+  } as unknown as ExtensionContext;
+
+  modelCycle(pi);
+  return { shortcuts, commands, setModel, notify, custom, ctx };
+}
+
+beforeEach(() => {
+  delete process.env.PI_CODING_AGENT_DIR;
+});
+
+afterEach(() => {
+  if (originalAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('model-switch extension', () => {
+  it('registers default cycle and picker shortcuts plus the picker command', () => {
+    const { shortcuts, commands } = harness();
+
+    expect([...shortcuts.keys()]).toEqual(['ctrl+shift+m', 'ctrl+shift+alt+m', 'ctrl+shift+l']);
+    expect([...commands.keys()]).toEqual(['model-switch']);
+  });
+
+  it('registers extension-owned shortcuts from keybindings.json', () => {
+    writeKeybindings({
+      'model-switch.cycleForward': 'ctrl+alt+n',
+      'model-switch.cycleBackward': 'ctrl+alt+b',
+      'model-switch.select': 'ctrl+alt+l',
+    });
+    const { shortcuts } = harness();
+
+    expect([...shortcuts.keys()]).toEqual(['ctrl+alt+n', 'ctrl+alt+b', 'ctrl+alt+l']);
+  });
+
+  it('cycles within the section containing the current model', async () => {
+    const current = model('provider', 'work-a');
+    const next = model('provider', 'work-b');
+    const personalModel = model('provider', 'personal-a');
+    writeConfig({
+      work: ['provider/work-a', 'provider/work-b'],
+      personal: ['provider/personal-a'],
+    });
+    const { shortcuts, setModel, ctx } = harness({ current, models: [current, next, personalModel] });
+
+    await shortcuts.get('ctrl+shift+m')!(ctx);
+
+    expect(setModel).toHaveBeenCalledWith(next);
+    expect(setModel).not.toHaveBeenCalledWith(personalModel);
+  });
+
+  it('enters the first section at the boundary when current is outside all sections', async () => {
+    const outside = model('other', 'outside');
+    const first = model('provider', 'work-a');
+    const last = model('provider', 'work-b');
+    writeConfig({ work: ['provider/work-a', 'provider/work-b'] });
+    const { shortcuts, setModel, ctx } = harness({ current: outside, models: [first, last] });
+
+    await shortcuts.get('ctrl+shift+m')!(ctx);
+    expect(setModel).toHaveBeenLastCalledWith(first);
+
+    await shortcuts.get('ctrl+shift+alt+m')!(ctx);
+    expect(setModel).toHaveBeenLastCalledWith(last);
+  });
+
+  it('skips unavailable models before switching', async () => {
+    const first = model('provider', 'first');
+    const second = model('provider', 'second');
+    writeConfig({ work: ['provider/first', 'provider/second'] });
+    const { shortcuts, setModel, ctx } = harness({
+      models: [first, second],
+      unauthenticated: ['provider/first'],
+    });
+
+    await shortcuts.get('ctrl+shift+m')!(ctx);
+
+    expect(setModel).toHaveBeenCalledWith(second);
+  });
+
+  it('warns when cycling through a section with no usable models', async () => {
+    writeConfig({ work: ['missing/model'] });
+    const { shortcuts, setModel, notify, ctx } = harness();
+
+    await shortcuts.get('ctrl+shift+m')!(ctx);
+
+    expect(setModel).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('No usable models in section "work"'), 'warning');
+  });
+
+  it('warns for invalid config or empty sections', async () => {
+    const dir = tempAgentDir();
+    const configDir = join(dir, 'configs');
+    mkdirSync(configDir);
+    writeFileSync(join(configDir, 'model-switch.json'), '{ nope');
+    const invalid = harness();
+
+    await invalid.shortcuts.get('ctrl+shift+m')!(invalid.ctx);
+    expect(invalid.setModel).not.toHaveBeenCalled();
+    expect(invalid.notify).toHaveBeenCalledWith(
+      expect.stringContaining(join(dir, 'configs', 'model-switch.json')),
+      'warning',
+    );
+
+    writeConfig({});
+    const empty = harness();
+    await empty.shortcuts.get('ctrl+shift+m')!(empty.ctx);
+    expect(empty.setModel).not.toHaveBeenCalled();
+  });
+
+  it('opens the fuzzy picker via command and switches the selected model', async () => {
+    const target = model('provider', 'target');
+    writeConfig({ work: ['provider/target'] });
+    const { commands, setModel, custom, ctx } = harness({
+      models: [target],
+      customResult: 'provider/target',
+    });
+
+    await commands.get('model-switch')!('', ctx);
+
+    expect(custom).toHaveBeenCalledTimes(1);
+    expect(setModel).toHaveBeenCalledWith(target);
+  });
+
+  it('opens the fuzzy picker via the configured select shortcut', async () => {
+    const target = model('provider', 'target');
+    writeConfig({ work: ['provider/target'] });
+    const { shortcuts, custom, ctx } = harness({ models: [target], customResult: 'provider/target' });
+
+    await shortcuts.get('ctrl+shift+l')!(ctx);
+
+    expect(custom).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not switch when the picker is cancelled or UI is unavailable', async () => {
+    const target = model('provider', 'target');
+    writeConfig({ work: ['provider/target'] });
+    const cancelled = harness({ models: [target], customResult: null });
+
+    await cancelled.commands.get('model-switch')!('', cancelled.ctx);
+    expect(cancelled.setModel).not.toHaveBeenCalled();
+
+    const noUi = harness({ models: [target], hasUI: false, customResult: 'provider/target' });
+    await noUi.commands.get('model-switch')!('', noUi.ctx);
+    expect(noUi.custom).not.toHaveBeenCalled();
+    expect(noUi.setModel).not.toHaveBeenCalled();
+  });
+
+  it('warns when the picker has no usable models across all sections', async () => {
+    writeConfig({ work: ['missing/model'], personal: ['also/missing'] });
+    const { commands, setModel, notify, custom, ctx } = harness();
+
+    await commands.get('model-switch')!('', ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(setModel).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('No configured models are available'), 'warning');
+  });
+
+  it('warns when Pi rejects a picker selection', async () => {
+    const target = model('provider', 'target');
+    writeConfig({ work: ['provider/target'] });
+    const { commands, notify, ctx } = harness({
+      models: [target],
+      customResult: 'provider/target',
+      switchResult: false,
+    });
+
+    await commands.get('model-switch')!('', ctx);
+
+    expect(notify).toHaveBeenCalledWith('Could not switch to provider/target', 'warning');
+  });
+});

--- a/packages/model-switch/index.ts
+++ b/packages/model-switch/index.ts
@@ -1,0 +1,114 @@
+import type { Api, Model } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import type { SelectItem } from '@earendil-works/pi-tui';
+import { loadModelSwitchConfig, loadModelSwitchKeybindings, modelCycleConfigPath } from './config.js';
+import { findActiveSection, resolveAvailableModels, selectCycleTarget, type CycleDirection } from './cycle.js';
+import { SectionPicker, type PickerSection } from './section-picker.js';
+
+async function resolveSectionModels(references: readonly string[], ctx: ExtensionContext): Promise<Model<Api>[]> {
+  return resolveAvailableModels(references, ctx.modelRegistry);
+}
+
+async function switchModel(pi: ExtensionAPI, ctx: ExtensionContext, target: Model<Api>): Promise<void> {
+  if (!(await pi.setModel(target))) {
+    ctx.ui.notify(`Could not switch to ${target.provider}/${target.id}`, 'warning');
+  }
+}
+
+async function cycleConfiguredModel(pi: ExtensionAPI, ctx: ExtensionContext, direction: CycleDirection): Promise<void> {
+  const loaded = loadModelSwitchConfig();
+  if (!loaded.ok) {
+    ctx.ui.notify(loaded.error, 'warning');
+    return;
+  }
+
+  const activeSection = findActiveSection(loaded.config.sections, ctx.model);
+  if (!activeSection) {
+    ctx.ui.notify(`No configured models are available in ${modelCycleConfigPath()}`, 'warning');
+    return;
+  }
+
+  const available = await resolveSectionModels(activeSection.models, ctx);
+  if (available.length === 0) {
+    ctx.ui.notify(`No usable models in section "${activeSection.name}" (${modelCycleConfigPath()})`, 'warning');
+    return;
+  }
+
+  const target = selectCycleTarget(ctx.model, available, direction);
+  if (target) await switchModel(pi, ctx, target);
+}
+
+function buildSectionItems(models: Model<Api>[], current: Model<Api> | undefined): SelectItem[] {
+  return models.map((model) => {
+    const isCurrent = model.provider === current?.provider && model.id === current.id;
+    return {
+      value: `${model.provider}/${model.id}`,
+      label: `${isCurrent ? '●' : ' '} ${model.provider}/${model.id}`,
+    };
+  });
+}
+
+async function showModelPicker(pi: ExtensionAPI, ctx: ExtensionContext): Promise<void> {
+  if (!ctx.hasUI) return;
+
+  const loaded = loadModelSwitchConfig();
+  if (!loaded.ok) {
+    ctx.ui.notify(loaded.error, 'warning');
+    return;
+  }
+
+  const pickerSections: PickerSection[] = [];
+  const modelByReference = new Map<string, Model<Api>>();
+
+  for (const section of loaded.config.sections) {
+    const available = await resolveSectionModels(section.models, ctx);
+    if (available.length > 0) {
+      pickerSections.push({
+        name: section.name,
+        items: buildSectionItems(available, ctx.model),
+      });
+      for (const model of available) {
+        modelByReference.set(`${model.provider}/${model.id}`, model);
+      }
+    }
+  }
+
+  if (pickerSections.length === 0) {
+    ctx.ui.notify(`No configured models are available in ${modelCycleConfigPath()}`, 'warning');
+    return;
+  }
+
+  const selected = await ctx.ui.custom<string | null>((tui, theme, _keybindings, done) => {
+    return new SectionPicker(pickerSections, theme, done);
+  });
+
+  if (!selected) return;
+
+  const target = modelByReference.get(selected);
+  if (target) await switchModel(pi, ctx, target);
+}
+
+export default function modelCycle(pi: ExtensionAPI) {
+  const keybindings = loadModelSwitchKeybindings();
+  type ShortcutKey = Parameters<ExtensionAPI['registerShortcut']>[0];
+
+  pi.registerShortcut(keybindings.forward as ShortcutKey, {
+    description: 'Cycle configured models forward',
+    handler: async (ctx) => cycleConfiguredModel(pi, ctx, 'forward'),
+  });
+
+  pi.registerShortcut(keybindings.backward as ShortcutKey, {
+    description: 'Cycle configured models backward',
+    handler: async (ctx) => cycleConfiguredModel(pi, ctx, 'backward'),
+  });
+
+  pi.registerShortcut(keybindings.select as ShortcutKey, {
+    description: 'Select a configured model',
+    handler: async (ctx) => showModelPicker(pi, ctx),
+  });
+
+  pi.registerCommand('model-switch', {
+    description: 'Select from configured models',
+    handler: async (_args, ctx) => showModelPicker(pi, ctx),
+  });
+}

--- a/packages/model-switch/model-switch.example.json
+++ b/packages/model-switch/model-switch.example.json
@@ -1,0 +1,11 @@
+{
+  "sections": {
+    "work": [
+      "cloudflare-ai-gateway/gpt-5.6-sol",
+      "cloudflare-ai-gateway/claude-opus-5",
+      "cloudflare-ai-gateway/grok-4.5",
+      "fireworks/accounts/fireworks/models/kimi-k3"
+    ],
+    "personal": ["fireworks/accounts/fireworks/models/kimi-k3"]
+  }
+}

--- a/packages/model-switch/package.json
+++ b/packages/model-switch/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@nicknisi/pi-model-switch",
+  "version": "0.1.0",
+  "description": "Cycle or fuzzy-pick from a machine-local, sectioned list of preferred Pi models",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/model-switch#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/model-switch"
+  },
+  "files": [
+    "dist",
+    "index.ts",
+    "config.ts",
+    "cycle.ts",
+    "section-picker.ts",
+    "README.md",
+    "model-switch.example.json"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/packages/model-switch/section-picker.ts
+++ b/packages/model-switch/section-picker.ts
@@ -1,0 +1,100 @@
+import {
+  Container,
+  Input,
+  SelectList,
+  Text,
+  getKeybindings,
+  matchesKey,
+  type Component,
+  type SelectItem,
+  type SelectListTheme,
+} from '@earendil-works/pi-tui';
+import type { Theme } from '@earendil-works/pi-coding-agent';
+
+export interface PickerSection {
+  name: string;
+  items: SelectItem[];
+}
+
+export class SectionPicker implements Component {
+  private container = new Container();
+  private tabBar = new Text('', 0, 0);
+  private searchInput = new Input();
+  private selectList: SelectList;
+  private activeSectionIndex = 0;
+  private readonly selectTheme: SelectListTheme;
+
+  constructor(
+    private readonly sections: PickerSection[],
+    private readonly theme: Theme,
+    private readonly done: (value: string | null) => void,
+  ) {
+    this.selectTheme = {
+      selectedPrefix: (text) => theme.fg('accent', text),
+      selectedText: (text) => theme.fg('accent', text),
+      description: (text) => theme.fg('muted', text),
+      scrollInfo: (text) => theme.fg('dim', text),
+      noMatch: (text) => theme.fg('warning', text),
+    };
+
+    this.selectList = new SelectList(sections[0]?.items ?? [], 10, this.selectTheme);
+    this.selectList.onSelect = (item) => this.done(item.value);
+    this.selectList.onCancel = () => this.done(null);
+
+    this.container.addChild(this.tabBar);
+    this.container.addChild(this.searchInput);
+    this.container.addChild(this.selectList);
+    this.renderTabBar();
+  }
+
+  private renderTabBar(): void {
+    const parts = this.sections.map((section, index) => {
+      const label = section.name;
+      return index === this.activeSectionIndex
+        ? this.theme.fg('accent', this.theme.bold(`[${label}]`))
+        : this.theme.fg('dim', ` ${label} `);
+    });
+    this.tabBar.setText(parts.join(''));
+  }
+
+  private switchSection(direction: 1 | -1): void {
+    this.activeSectionIndex = (this.activeSectionIndex + direction + this.sections.length) % this.sections.length;
+    this.searchInput.setValue('');
+    this.selectList = new SelectList(this.sections[this.activeSectionIndex]?.items ?? [], 10, this.selectTheme);
+    this.selectList.onSelect = (item) => this.done(item.value);
+    this.selectList.onCancel = () => this.done(null);
+    this.container.clear();
+    this.container.addChild(this.tabBar);
+    this.container.addChild(this.searchInput);
+    this.container.addChild(this.selectList);
+    this.renderTabBar();
+  }
+
+  render(width: number): string[] {
+    return this.container.render(width);
+  }
+
+  invalidate(): void {
+    this.container.invalidate();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, 'tab')) {
+      this.switchSection(1);
+      return;
+    }
+
+    const kb = getKeybindings();
+    if (
+      kb.matches(data, 'tui.select.up') ||
+      kb.matches(data, 'tui.select.down') ||
+      kb.matches(data, 'tui.select.confirm') ||
+      kb.matches(data, 'tui.select.cancel')
+    ) {
+      this.selectList.handleInput(data);
+    } else {
+      this.searchInput.handleInput(data);
+      this.selectList.setFilter(this.searchInput.getValue());
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,8 @@ importers:
 
   packages/mg: {}
 
+  packages/model-switch: {}
+
   packages/orchestrate: {}
 
   packages/pin-last-prompt: {}


### PR DESCRIPTION
## Summary

Adds `@nicknisi/pi-model-switch` — a Pi extension for cycling and fuzzy-picking from a machine-local, sectioned list of preferred models.

### Why

`enabledModels` is global config shared across machines via dotfiles, but each machine has different authenticated providers. This extension reads an untracked local config (`~/.pi/agent/configs/model-switch.json`) instead, so work and personal machines can each have their own model list.

### Features

- **Cycle shortcuts** (configurable via `keybindings.json`):
  - `model-switch.cycleForward` — default `ctrl+shift+m`
  - `model-switch.cycleBackward` — default `ctrl+shift+alt+m`
  - Cycles within the section containing the current model

- **Fuzzy picker** (`/model-switch` command + `model-switch.select` shortcut — default `ctrl+shift+l`):
  - Custom TUI with search input and `SelectList`
  - **Tab** cycles between sections
  - Type to fuzzy-filter within the active section
  - Current model marked with `●`
  - Cancellation is a no-op

- **Config schema** (`~/.pi/agent/configs/model-switch.json`):
  ```json
  {
    "sections": {
      "work": ["cloudflare-ai-gateway/gpt-5.6-sol", "..."],
      "personal": ["openrouter/anthropic/claude-opus-5"]
    }
  }
  ```
  Legacy flat `{ "models": [...] }` still works as a single unnamed section.

- Skips missing and unauthenticated models
- Warns when no usable models exist
- Leaves native `/model`, `Ctrl+L`, and `Ctrl+P` unchanged

### Configurable shortcuts

All three shortcuts are extension-owned entries in Pi's existing `keybindings.json`:

```json
{
  "model-switch.cycleForward": "ctrl+shift+m",
  "model-switch.cycleBackward": "ctrl+shift+alt+m",
  "model-switch.select": "ctrl+shift+l"
}
```

Pi ignores these unknown action IDs; the extension reads them at load time.

### Validation

- 41 tests passing (config, cycle, picker)
- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build` all pass
- Real Pi extension-load smoke passes
- Ideation contract verification: 7/7