### PR TITLE
fix(model-switch): match filter anywhere in provider/modelId across all sections

### DIFF
--- a/.changeset/tame-tables-shine.md
+++ b/.changeset/tame-tables-shine.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-model-switch': patch
+---
+
+Fix picker filtering: typing a model name (e.g. "claude" or "kimi") now matches anywhere in the provider/modelId string and searches across all sections, instead of prefix-matching only within the active section

--- a/packages/model-switch/section-picker.test.ts
+++ b/packages/model-switch/section-picker.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Theme } from '@earendil-works/pi-coding-agent';
+import { SectionPicker, type PickerSection } from './section-picker.js';
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+} as unknown as Theme;
+
+function sections(): PickerSection[] {
+  return [
+    {
+      name: 'work',
+      items: [
+        { value: 'cloudflare-ai-gateway/gpt-5.6-sol', label: '  cloudflare-ai-gateway/gpt-5.6-sol' },
+        { value: 'cloudflare-ai-gateway/claude-opus-5', label: '  cloudflare-ai-gateway/claude-opus-5' },
+        {
+          value: 'fireworks/accounts/fireworks/models/kimi-k3',
+          label: '  fireworks/accounts/fireworks/models/kimi-k3',
+        },
+      ],
+    },
+    {
+      name: 'personal',
+      items: [
+        {
+          value: 'fireworks/accounts/fireworks/models/kimi-k3',
+          label: '  fireworks/accounts/fireworks/models/kimi-k3',
+        },
+      ],
+    },
+  ];
+}
+
+function render(picker: SectionPicker): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
+  return picker
+    .render(240)
+    .join('\n')
+    .replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+function type(picker: SectionPicker, text: string): void {
+  for (const char of text) picker.handleInput(char);
+}
+
+describe('SectionPicker filtering', () => {
+  it('matches a model name substring inside provider/modelId', () => {
+    const picker = new SectionPicker(sections(), theme, vi.fn());
+
+    type(picker, 'claude');
+    const output = render(picker);
+
+    expect(output).toContain('cloudflare-ai-gateway/claude-opus-5');
+    expect(output).not.toContain('gpt-5.6-sol');
+    expect(output).not.toContain('kimi-k3');
+  });
+
+  it('searches across all sections and dedupes models present in multiple sections', () => {
+    const picker = new SectionPicker(sections(), theme, vi.fn());
+
+    type(picker, 'kimi');
+    const output = render(picker);
+
+    const occurrences = output.split('kimi-k3').length - 1;
+    expect(occurrences).toBe(1);
+  });
+
+  it('shows only the active section when the query is empty', () => {
+    const picker = new SectionPicker(sections(), theme, vi.fn());
+
+    type(picker, 'claude');
+    type(picker, '\x7f'.repeat(7)); // backspace away the query
+    const output = render(picker);
+
+    expect(output).toContain('cloudflare-ai-gateway/claude-opus-5');
+    expect(output).toContain('cloudflare-ai-gateway/gpt-5.6-sol');
+  });
+
+  it('confirms the highlighted filtered match on enter', () => {
+    const done = vi.fn();
+    const picker = new SectionPicker(sections(), theme, done);
+
+    type(picker, 'kimi');
+    picker.handleInput('\r');
+
+    expect(done).toHaveBeenCalledWith('fireworks/accounts/fireworks/models/kimi-k3');
+  });
+});

--- a/packages/model-switch/section-picker.ts
+++ b/packages/model-switch/section-picker.ts
@@ -38,8 +38,7 @@ export class SectionPicker implements Component {
     };
 
     this.selectList = new SelectList(sections[0]?.items ?? [], 10, this.selectTheme);
-    this.selectList.onSelect = (item) => this.done(item.value);
-    this.selectList.onCancel = () => this.done(null);
+    this.wireSelectList();
 
     this.container.addChild(this.tabBar);
     this.container.addChild(this.searchInput);
@@ -57,12 +56,44 @@ export class SectionPicker implements Component {
     this.tabBar.setText(parts.join(''));
   }
 
+  private wireSelectList(): void {
+    this.selectList.onSelect = (item) => this.done(item.value);
+    this.selectList.onCancel = () => this.done(null);
+  }
+
   private switchSection(direction: 1 | -1): void {
     this.activeSectionIndex = (this.activeSectionIndex + direction + this.sections.length) % this.sections.length;
     this.searchInput.setValue('');
-    this.selectList = new SelectList(this.sections[this.activeSectionIndex]?.items ?? [], 10, this.selectTheme);
-    this.selectList.onSelect = (item) => this.done(item.value);
-    this.selectList.onCancel = () => this.done(null);
+    this.rebuildList();
+  }
+
+  private filteredItems(): SelectItem[] {
+    const query = this.searchInput.getValue().trim().toLowerCase();
+    if (query.length === 0) return this.sections[this.activeSectionIndex]?.items ?? [];
+
+    // SelectList.setFilter only matches value.startsWith(query), which can never
+    // match a model name inside "provider/modelId" — filter here instead, with a
+    // substring match across every section.
+    const seen = new Set<string>();
+    const matches: SelectItem[] = [];
+    for (const section of this.sections) {
+      for (const item of section.items) {
+        if (seen.has(item.value) || !item.value.toLowerCase().includes(query)) continue;
+        seen.add(item.value);
+        matches.push({ ...item, description: section.name });
+      }
+    }
+    return matches;
+  }
+
+  private rebuildList(): void {
+    // Size the primary column to the content so section descriptions never
+    // truncate long provider/modelId labels (SelectList caps it at 32 otherwise).
+    this.selectList = new SelectList(this.filteredItems(), 10, this.selectTheme, {
+      minPrimaryColumnWidth: 1,
+      maxPrimaryColumnWidth: Number.MAX_SAFE_INTEGER,
+    });
+    this.wireSelectList();
     this.container.clear();
     this.container.addChild(this.tabBar);
     this.container.addChild(this.searchInput);
@@ -94,7 +125,7 @@ export class SectionPicker implements Component {
       this.selectList.handleInput(data);
     } else {
       this.searchInput.handleInput(data);
-      this.selectList.setFilter(this.searchInput.getValue());
+      this.rebuildList();
     }
   }
 }


### PR DESCRIPTION
## Problem

The model-switch picker filter was broken: typing a model name like `claude` or `kimi` showed no results.

Two compounding bugs in `section-picker.ts`:

1. **Prefix matching**: pi-tui's `SelectList.setFilter` matches `item.value.toLowerCase().startsWith(filter)`, and item values are `provider/modelId` strings (e.g. `cloudflare-ai-gateway/claude-opus-5`). A query like `claude` can never match because the value starts with the provider name.
2. **Section scoping**: the filter only applied to the active section tab, so a match in another section never appeared.

## Fix

- Filter in the extension instead: case-insensitive **substring** match on `provider/modelId`, searched **across all sections** when a query is present (empty query keeps the active-section view).
- Cross-section results are deduped (the example config has the same model in two sections) and tagged with their section name in the description column.
- Pass `minPrimaryColumnWidth: 1` / `maxPrimaryColumnWidth: MAX_SAFE_INTEGER` to `SelectList` — its default 32-char primary column cap would otherwise truncate long model ids once a description is present.

## Tests

New `section-picker.test.ts` covering: substring match, cross-section search + dedupe, empty query restoring the active section, and enter confirming a filtered match. Full suite: 163/163 pass; typecheck/lint/format clean.