### PR TITLE
feat(answer): make extraction models configurable

### DIFF
--- a/.changeset/answer-configurable-models.md
+++ b/.changeset/answer-configurable-models.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-answer': minor
+---
+
+Make `/answer` extraction models configurable as an ordered `provider/model-id` fallback list in `~/.pi/agent/configs/answer.json`, preserving the existing Anthropic defaults.

--- a/packages/answer/README.md
+++ b/packages/answer/README.md
@@ -54,20 +54,17 @@ The extraction loader can be aborted with Esc, which cancels the whole flow.
 
 ## Configuration
 
-No config files are read. No environment variables are read directly.
+Optional global config: `~/.pi/agent/configs/answer.json`. Changes take effect on the next session or after `/reload`.
 
-### Extraction model selection
-
-Hardcoded preference list (`EXTRACTION_MODEL_PREFERENCES` in `index.ts`):
-
-```ts
-[
-  { provider: 'anthropic', modelId: 'claude-fable-5' },
-  { provider: 'anthropic', modelId: 'claude-opus-5' },
-];
+```json
+{
+  "extractionModels": ["anthropic/claude-fable-5", "anthropic/claude-opus-5"]
+}
 ```
 
-The first model that both exists in `ctx.modelRegistry` and passes `getApiKeyAndHeaders()` is used. The current session model (`ctx.model`) is **not** used for extraction — only checked for presence as a guard. To change the extraction model you must edit the source. API keys come from pi's normal model auth (env vars / models.json per pi's rules).
+`extractionModels` is a non-empty ordered list of `provider/model-id` strings. The first model that both exists in `ctx.modelRegistry` and passes `getApiKeyAndHeaders()` is used. Model IDs may contain additional slashes; only the first slash separates the provider. Missing or invalid config falls back to the list above and invalid config emits a warning. See [`answer.example.json`](./answer.example.json).
+
+The current session model (`ctx.model`) is **not** used for extraction—only checked for presence as a guard. API keys come from Pi's normal model authentication.
 
 ## Dependencies
 
@@ -80,7 +77,7 @@ No third-party npm dependencies.
 
 ## Caveats
 
-- **Hardcoded extraction models.** Both preferences are Anthropic models. With no Anthropic key configured, the command errors out listing what it checked. The code comment notes there is no provider-specific reasoning override because both candidates are Anthropic.
+- **Extraction-model availability.** If none of the configured candidates exist with working authentication, the command errors out listing every model it checked.
 - **Pi internals:** depends on `ctx.sessionManager.getBranch()` entry shapes (`entry.type === "message"`, `message.role`, `message.stopReason === "stop"`, content part `{ type: "text", text }`), `ctx.modelRegistry.find/getApiKeyAndHeaders/getProvider`, `ctx.ui.custom` component contract, and `pi.sendUserMessage(..., { deliverAs: "followUp" })`. Any of these changing across pi versions will break it.
 - **Editor render slicing.** `AnswerComponent.render` strips the first and last lines of the embedded `Editor.render()` output (`editorLines[1..len-2]`) assuming the Editor wraps its content in a border frame. If pi-tui's `Editor` render shape changes, answers will render wrong.
 - **Extraction is heuristic at the edges.** The LLM prompt tries to keep questions self-contained, but the regex fallback (`fallbackExtractQuestions`) is naive — it splits on sentence boundaries ending in `?` and can produce context-free or false-positive questions when extraction JSON parsing fails.

--- a/packages/answer/answer.example.json
+++ b/packages/answer/answer.example.json
@@ -1,0 +1,3 @@
+{
+  "extractionModels": ["anthropic/claude-fable-5", "anthropic/claude-opus-5"]
+}

--- a/packages/answer/config.test.ts
+++ b/packages/answer/config.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_ANSWER_CONFIG, loadAnswerConfig, parseModelPreference } from './config.js';
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pi-answer-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeConfig(agentDir: string, value: unknown): void {
+  const dir = join(agentDir, 'configs');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'answer.json'), JSON.stringify(value));
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('parseModelPreference', () => {
+  it('keeps slashes inside the model id', () => {
+    expect(parseModelPreference('fireworks/accounts/fireworks/models/glm-5p2')).toEqual({
+      provider: 'fireworks',
+      modelId: 'accounts/fireworks/models/glm-5p2',
+    });
+  });
+
+  it('rejects incomplete model specs', () => {
+    expect(parseModelPreference('claude-fable-5')).toBeUndefined();
+    expect(parseModelPreference('/claude-fable-5')).toBeUndefined();
+    expect(parseModelPreference('anthropic/')).toBeUndefined();
+  });
+});
+
+describe('loadAnswerConfig', () => {
+  it('uses the current preference list when no config exists', () => {
+    expect(loadAnswerConfig(tempDir())).toEqual({ config: DEFAULT_ANSWER_CONFIG, warnings: [] });
+  });
+
+  it('loads and deduplicates an ordered model preference list', () => {
+    const agentDir = tempDir();
+    writeConfig(agentDir, {
+      extractionModels: ['fireworks/glm-latest', 'anthropic/claude-fable-5', 'fireworks/glm-latest'],
+    });
+
+    expect(loadAnswerConfig(agentDir)).toEqual({
+      config: { extractionModels: ['fireworks/glm-latest', 'anthropic/claude-fable-5'] },
+      warnings: [],
+    });
+  });
+
+  it('warns and falls back for invalid JSON', () => {
+    const agentDir = tempDir();
+    const dir = join(agentDir, 'configs');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'answer.json'), '{ nope');
+
+    const result = loadAnswerConfig(agentDir);
+    expect(result.config).toEqual(DEFAULT_ANSWER_CONFIG);
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('warns and falls back for an empty preference list', () => {
+    const agentDir = tempDir();
+    writeConfig(agentDir, { extractionModels: [] });
+
+    const result = loadAnswerConfig(agentDir);
+    expect(result.config).toEqual(DEFAULT_ANSWER_CONFIG);
+    expect(result.warnings[0]).toContain('non-empty array');
+  });
+
+  it('warns and falls back for an invalid model spec', () => {
+    const agentDir = tempDir();
+    writeConfig(agentDir, { extractionModels: ['claude-fable-5'] });
+
+    const result = loadAnswerConfig(agentDir);
+    expect(result.config).toEqual(DEFAULT_ANSWER_CONFIG);
+    expect(result.warnings[0]).toContain('provider/model-id');
+  });
+});

--- a/packages/answer/config.ts
+++ b/packages/answer/config.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getAgentDir } from '@earendil-works/pi-coding-agent';
+
+export interface AnswerConfig {
+  /** Ordered provider/model-id candidates; the first available authenticated model wins. */
+  extractionModels: string[];
+}
+
+export interface LoadedAnswerConfig {
+  config: AnswerConfig;
+  warnings: string[];
+}
+
+export interface ModelPreference {
+  provider: string;
+  modelId: string;
+}
+
+export const DEFAULT_ANSWER_CONFIG: AnswerConfig = {
+  extractionModels: ['anthropic/claude-fable-5', 'anthropic/claude-opus-5'],
+};
+
+export function answerConfigPath(agentDir = getAgentDir()): string {
+  return join(agentDir, 'configs', 'answer.json');
+}
+
+export function parseModelPreference(value: string): ModelPreference | undefined {
+  const spec = value.trim();
+  const slash = spec.indexOf('/');
+  if (slash <= 0 || slash === spec.length - 1) return undefined;
+  return { provider: spec.slice(0, slash), modelId: spec.slice(slash + 1) };
+}
+
+export function loadAnswerConfig(agentDir = getAgentDir()): LoadedAnswerConfig {
+  const path = answerConfigPath(agentDir);
+  if (!existsSync(path)) return { config: { ...DEFAULT_ANSWER_CONFIG }, warnings: [] };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    return {
+      config: { ...DEFAULT_ANSWER_CONFIG },
+      warnings: [`Invalid answer config at ${path}: ${error instanceof Error ? error.message : String(error)}`],
+    };
+  }
+
+  const extractionModels =
+    parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>).extractionModels
+      : undefined;
+  if (
+    !Array.isArray(extractionModels) ||
+    extractionModels.length === 0 ||
+    extractionModels.some((model) => typeof model !== 'string' || !parseModelPreference(model))
+  ) {
+    return {
+      config: { ...DEFAULT_ANSWER_CONFIG },
+      warnings: [
+        `Invalid answer config at ${path}: extractionModels must be a non-empty array of provider/model-id strings`,
+      ],
+    };
+  }
+
+  return {
+    config: { extractionModels: [...new Set(extractionModels.map((model) => model.trim()))] },
+    warnings: [],
+  };
+}

--- a/packages/answer/index.ts
+++ b/packages/answer/index.ts
@@ -1,6 +1,7 @@
 import type { Api, Model, UserMessage } from '@earendil-works/pi-ai';
 import { getModelProvider } from '@nicknisi/pi-shared';
 import { BorderedLoader, Theme, type ExtensionAPI, type ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { loadAnswerConfig, parseModelPreference, type ModelPreference } from './config.js';
 import {
   type Component,
   type Focusable,
@@ -55,17 +56,7 @@ Rules:
 - Do not add commentary outside the JSON object.
 - If there are no user-answerable questions, return {"questions": []}.`;
 
-interface ExtractionModelPreference {
-  provider: string;
-  modelId: string;
-}
-
-const EXTRACTION_MODEL_PREFERENCES: readonly ExtractionModelPreference[] = [
-  { provider: 'anthropic', modelId: 'claude-fable-5' },
-  { provider: 'anthropic', modelId: 'claude-opus-5' },
-];
-
-function formatExtractionModelPreferences(preferences: readonly ExtractionModelPreference[]): string {
+function formatExtractionModelPreferences(preferences: readonly ModelPreference[]): string {
   return preferences.map((candidate) => `${candidate.provider}/${candidate.modelId}`).join(', ');
 }
 
@@ -187,7 +178,7 @@ async function selectExtractionModel(
       model: Model<Api>,
     ) => Promise<{ ok: true; apiKey?: string; headers?: Record<string, string | null> } | { ok: false; error: string }>;
   },
-  preferences: readonly ExtractionModelPreference[],
+  preferences: readonly ModelPreference[],
 ): Promise<Model<Api> | undefined> {
   for (const candidate of preferences) {
     const model = modelRegistry.find(candidate.provider, candidate.modelId);
@@ -464,6 +455,13 @@ class AnswerComponent implements Component, Focusable {
 }
 
 export default function (pi: ExtensionAPI) {
+  const { config, warnings } = loadAnswerConfig();
+  const extractionModelPreferences = config.extractionModels.map((model) => parseModelPreference(model)!);
+
+  pi.on('session_start', async (_event, ctx) => {
+    for (const warning of warnings) ctx.ui.notify(warning, 'warning');
+  });
+
   const answerHandler = async (ctx: ExtensionContext) => {
     if (!ctx.hasUI) {
       ctx.ui.notify('answer requires interactive mode', 'error');
@@ -488,7 +486,6 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.notify('Using the last completed assistant message', 'warning');
     }
 
-    const extractionModelPreferences = EXTRACTION_MODEL_PREFERENCES;
     const extractionModel = await selectExtractionModel(ctx.modelRegistry, extractionModelPreferences);
     if (!extractionModel) {
       ctx.ui.notify(
@@ -530,7 +527,6 @@ export default function (pi: ExtensionAPI) {
               ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
               ...(auth.headers !== undefined && { headers: auth.headers }),
               signal: loader.signal,
-              // (no provider-specific reasoning override; both fallback models are Anthropic)
             },
           )
           .result();

--- a/packages/answer/package.json
+++ b/packages/answer/package.json
@@ -16,7 +16,9 @@
   },
   "files": [
     "dist",
-    "index.ts"
+    "index.ts",
+    "config.ts",
+    "answer.example.json"
   ],
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- replace `/answer`'s hard-coded extraction model preference list with `~/.pi/agent/configs/answer.json`
- preserve the existing Anthropic defaults as an ordered fallback list
- accept registered `provider/model-id` values, including model IDs containing additional slashes
- select the first configured candidate that exists and has working authentication
- warn and fall back safely when configuration is invalid
- add an example config, tests, documentation, and a changeset

## Testing

- `pnpm test` (195 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
