### PR TITLE
feat(relay): add hardened Pi-free core export

### DIFF
--- a/.changeset/quiet-mails-connect.md
+++ b/.changeset/quiet-mails-connect.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-relay': minor
+---
+
+Add a narrow, traversal-safe `@nicknisi/pi-relay/core` export for registry, mailbox, and policy operations and types, usable from plain Node without installing Pi or TUI packages.

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -9,6 +9,16 @@ Architecture follows [shift-labs/pi-peer](https://github.com/shift-labs-ai/pi-pe
 - **`relay` tool** — actions: `list`, `list-cwd`, `send`, `ask`, `reply`, `pending`, `cancel`, `status`, `claim`, `watch`
 - **`/relay` command** — prints the session listing; `/relay log [N]` prints the last N audit entries (default 50)
 
+## Pi-free core API
+
+Node applications can use the registry, mailbox, and transport-policy primitives without loading the pi extension or its TUI dependencies:
+
+```ts
+import { OutboundPolicy, deposit, deriveAddr, type Letter } from '@nicknisi/pi-relay/core';
+```
+
+The `@nicknisi/pi-relay/core` subpath exports a narrow record and alias registry, mailbox and ask/audit operations, presence and sweep utilities, policy guards and constants, and their public types. Filesystem-facing operations validate canonical relay addresses, aliases, and ask/message IDs before accessing the relay root; path constructors and raw persistence helpers remain internal. It depends only on Node built-ins. Pi and TUI are optional peers, so core-only installations do not fetch them. The package root remains the pi extension entry point; import `/core` from plain Node services and CLIs.
+
 ## Audit log
 
 Every deposit and every delivery appends one line-delimited JSON record to `<PI_RELAY_DIR>/audit.log` — written from the transport choke points so draining a letter as a receipt no longer destroys the evidence that it existed. Each line records the timestamp, the event (`deposit`/`deliver`), the letter kind, the from/to addresses, and the message id. **The full body is never logged** — only a short (≤80 char) whitespace-collapsed preview. The file is `0600`, append-only, and survives corrupt lines (skipped on parse). Read it with `/relay log [N]`.

--- a/packages/relay/core.test.ts
+++ b/packages/relay/core.test.ts
@@ -1,0 +1,180 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import * as core from './core.js';
+
+interface RelayPackage {
+  name: string;
+  exports: Record<string, { types: string; default: string }>;
+  peerDependenciesMeta: Record<string, { optional: boolean }>;
+}
+
+const relayDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(relayDir, '../..');
+const packageJson = JSON.parse(fs.readFileSync(path.join(relayDir, 'package.json'), 'utf8')) as RelayPackage;
+const fixtures: string[] = [];
+
+function fixture(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-relay-core-'));
+  fixtures.push(dir);
+  return dir;
+}
+
+function letter(over: Partial<core.Letter> = {}): core.Letter {
+  return {
+    id: '019fd000-0000-0000-0000-000000000001',
+    from: { addr: core.deriveAddr('/sender', 'session'), name: 'sender', cwd: '/sender' },
+    kind: 'ask',
+    body: 'question',
+    ts: Date.now(),
+    ...over,
+  };
+}
+
+afterEach(() => {
+  while (fixtures.length > 0) fs.rmSync(fixtures.pop()!, { recursive: true, force: true });
+});
+
+describe('/core filesystem boundary', () => {
+  it('rejects traversal in every address-bearing operation', async () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const badAddr = '../../../escaped';
+    const validAddr = core.deriveAddr('/receiver', 'session');
+    const validLetter = letter();
+    const badRecord: core.SessionRecord = {
+      addr: badAddr,
+      sessionId: 'session',
+      name: 'bad',
+      cwd: '/tmp',
+      pid: process.pid,
+      startedAt: Date.now(),
+      lastSeenAt: Date.now(),
+      status: 'idle',
+    };
+
+    const calls = [
+      () => core.readRecord(root, badAddr),
+      () => core.presenceOf(badRecord),
+      () => core.claimAlias(root, 'safe', badAddr, 'session'),
+      () => core.deposit(root, badAddr, validLetter),
+      () => core.deposit(root, validAddr, letter({ from: { ...validLetter.from, addr: badAddr } })),
+      () => core.drain(root, badAddr),
+      () => core.unreadCount(root, badAddr),
+      () => core.watchInbox(root, badAddr, () => {}),
+      () => core.trackIncomingAsk(root, badAddr, validLetter),
+      () =>
+        core.trackOutgoingAsk(root, badAddr, {
+          askId: validLetter.id,
+          toAddr: validAddr,
+          body: 'question',
+          ts: Date.now(),
+        }),
+      () =>
+        core.trackOutgoingAsk(root, validAddr, {
+          askId: validLetter.id,
+          toAddr: badAddr,
+          body: 'question',
+          ts: Date.now(),
+        }),
+      () => core.readIncomingAsk(root, badAddr, validLetter.id),
+      () => core.readOutgoingAsk(root, badAddr, validLetter.id),
+      () => core.clearAsk(root, badAddr, validLetter.id),
+      () => core.resolveAskByRef(root, badAddr, validLetter.id),
+      () => core.pendingAsks(root, badAddr),
+    ];
+
+    for (const call of calls) expect(call).toThrow(TypeError);
+    await expect(core.awaitReceipt(root, badAddr, validLetter, 1)).rejects.toThrow(TypeError);
+    expect(fs.readdirSync(base)).toEqual([]);
+  });
+
+  it('rejects traversal in aliases and ask/message identifiers', async () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const badId = '../../../escaped';
+    const badAlias = '../../../escaped';
+
+    const calls = [
+      () => core.readAlias(root, badAlias),
+      () => core.claimAlias(root, badAlias, addr, 'session'),
+      () => core.clearAlias(root, badAlias),
+      () => core.deposit(root, addr, letter({ id: badId })),
+      () => core.deposit(root, addr, letter({ replyTo: badId })),
+      () => core.trackIncomingAsk(root, addr, letter({ id: badId })),
+      () =>
+        core.trackOutgoingAsk(root, addr, {
+          askId: badId,
+          toAddr: addr,
+          body: 'question',
+          ts: Date.now(),
+        }),
+      () => core.readIncomingAsk(root, addr, badId),
+      () => core.readOutgoingAsk(root, addr, badId),
+      () => core.clearAsk(root, addr, badId),
+      () => core.resolveAskByRef(root, addr, badId),
+    ];
+
+    for (const call of calls) expect(call).toThrow(TypeError);
+    await expect(core.awaitReceipt(root, addr, letter({ id: badId }), 1)).rejects.toThrow(TypeError);
+    expect(fs.readdirSync(base)).toEqual([]);
+
+    fs.mkdirSync(root);
+    fs.writeFileSync(path.join(root, `${addr}.json`), JSON.stringify({ addr: badId, pid: 2_000_000_000 }));
+    expect(() => core.sweep(root, Date.now(), () => false)).toThrow(TypeError);
+    expect(fs.readdirSync(base)).toEqual(['relay']);
+  });
+});
+
+it('builds, packs, installs, and imports the real core package without Pi or TUI', () => {
+  const base = fixture();
+  const tarball = path.join(base, 'relay.tgz');
+  const appDir = path.join(base, 'app');
+  fs.mkdirSync(appDir);
+
+  execFileSync('pnpm', ['--filter', packageJson.name, 'build'], { cwd: repoRoot, stdio: 'pipe' });
+  execFileSync('pnpm', ['pack', '--out', tarball], { cwd: relayDir, stdio: 'pipe' });
+  fs.writeFileSync(
+    path.join(appDir, 'package.json'),
+    JSON.stringify({
+      private: true,
+      type: 'module',
+      dependencies: { [packageJson.name]: 'file:../relay.tgz' },
+    }),
+  );
+  execFileSync('pnpm', ['install', '--offline', '--ignore-scripts'], { cwd: appDir, stdio: 'pipe' });
+
+  const installedDir = path.join(appDir, 'node_modules', '@nicknisi', 'pi-relay');
+  const installedPackage = JSON.parse(fs.readFileSync(path.join(installedDir, 'package.json'), 'utf8')) as RelayPackage;
+  const coreExport = installedPackage.exports['./core'];
+  expect(coreExport).toBeDefined();
+  for (const target of Object.values(coreExport!)) {
+    expect(fs.existsSync(path.join(installedDir, target))).toBe(true);
+  }
+  expect(packageJson.peerDependenciesMeta['@earendil-works/pi-coding-agent']?.optional).toBe(true);
+  expect(packageJson.peerDependenciesMeta['@earendil-works/pi-tui']?.optional).toBe(true);
+  expect(fs.existsSync(path.join(appDir, 'node_modules', '@earendil-works', 'pi-coding-agent'))).toBe(false);
+  expect(fs.existsSync(path.join(appDir, 'node_modules', '@earendil-works', 'pi-tui'))).toBe(false);
+
+  const output = execFileSync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '--eval',
+      `const core = await import('@nicknisi/pi-relay/core');
+for (const name of ['deriveAddr', 'deposit', 'drain', 'claimAlias', 'pendingAsks', 'OutboundPolicy']) {
+  if (typeof core[name] !== 'function') throw new Error(\`Missing core export: \${name}\`);
+}
+for (const name of ['recordPath', 'inboxDir', 'asksDir', 'aliasPath', 'auditLogPath', 'writeRecord', 'writeAlias', 'appendAudit']) {
+  if (name in core) throw new Error(\`Internal helper escaped through /core: \${name}\`);
+}
+console.log('core-ok');`,
+    ],
+    { cwd: appDir, encoding: 'utf8' },
+  );
+  expect(output.trim()).toBe('core-ok');
+}, 120_000);

--- a/packages/relay/core.ts
+++ b/packages/relay/core.ts
@@ -1,0 +1,250 @@
+/** Pi-free relay registry, mailbox, and policy API for non-extension consumers. */
+import {
+  awaitReceipt as awaitReceiptInternal,
+  clearAsk as clearAskInternal,
+  deposit as depositInternal,
+  drain as drainInternal,
+  pendingAsks as pendingAsksInternal,
+  readAudit as readAuditInternal,
+  readIncomingAsk as readIncomingAskInternal,
+  readOutgoingAsk as readOutgoingAskInternal,
+  resolveAskByRef as resolveAskByRefInternal,
+  trackIncomingAsk as trackIncomingAskInternal,
+  trackOutgoingAsk as trackOutgoingAskInternal,
+  unreadCount as unreadCountInternal,
+  watchInbox as watchInboxInternal,
+  type AuditRecord,
+  type Letter,
+  type OutAsk,
+} from './mailbox.js';
+import {
+  claimAlias as claimAliasInternal,
+  clearAlias as clearAliasInternal,
+  isValidAliasName as isValidAliasNameInternal,
+  listAliases as listAliasesInternal,
+  listRecords as listRecordsInternal,
+  presenceOf as presenceOfInternal,
+  readAlias as readAliasInternal,
+  readRecord as readRecordInternal,
+  sweep as sweepInternal,
+  type AliasRecord,
+  type Presence,
+  type SessionRecord,
+} from './registry.js';
+
+export { MAX_BODY_CHARS, previewBody, type AuditRecord, type Letter, type LetterKind, type OutAsk } from './mailbox.js';
+export {
+  BACKLOG_CAP,
+  DEDUPE_WINDOW_MS,
+  OutboundPolicy,
+  RATE_LIMIT_MAX,
+  RATE_LIMIT_WINDOW_MS,
+  inboundAccepts,
+  type OutboundVerdict,
+} from './policy.js';
+export {
+  HEARTBEAT_STALE_MS,
+  SWEEP_MAIL_KEEP_MS,
+  deriveAddr,
+  isValidAliasName,
+  type AliasRecord,
+  type Presence,
+  type SessionRecord,
+} from './registry.js';
+
+const ADDRESS_PATTERN = /^[a-f0-9]{12}$/;
+const ASK_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/;
+
+function assertAddress(addr: string): void {
+  if (!ADDRESS_PATTERN.test(addr)) throw new TypeError(`Invalid relay address: ${addr}`);
+}
+
+function assertAliasName(name: string): void {
+  if (!isValidAliasNameInternal(name)) throw new TypeError(`Invalid relay alias: ${name}`);
+}
+
+function assertAskId(id: string): void {
+  if (!ASK_ID_PATTERN.test(id)) throw new TypeError(`Invalid relay ask/message id: ${id}`);
+}
+
+function assertLetter(letter: Letter): void {
+  if (typeof letter !== 'object' || letter === null) throw new TypeError('Invalid relay letter');
+  assertAskId(letter.id);
+  if (typeof letter.from !== 'object' || letter.from === null) throw new TypeError('Invalid relay letter sender');
+  assertAddress(letter.from.addr);
+  if (letter.replyTo !== undefined) assertAskId(letter.replyTo);
+  if (!Number.isFinite(letter.ts)) throw new TypeError(`Invalid relay letter timestamp: ${letter.ts}`);
+}
+
+function isSafeLetter(letter: Letter): boolean {
+  try {
+    assertLetter(letter);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeRecord(record: SessionRecord): boolean {
+  try {
+    assertAddress(record.addr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeAlias(alias: AliasRecord): boolean {
+  try {
+    assertAliasName(alias.name);
+    assertAddress(alias.addr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeOutAsk(out: OutAsk): boolean {
+  try {
+    assertAskId(out.askId);
+    assertAddress(out.toAddr);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSafeAuditRecord(record: AuditRecord): boolean {
+  try {
+    assertAddress(record.from);
+    assertAddress(record.to);
+    assertAskId(record.messageId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readRecord(root: string, addr: string): SessionRecord | null {
+  assertAddress(addr);
+  const record = readRecordInternal(root, addr);
+  return record && isSafeRecord(record) ? record : null;
+}
+
+export function listRecords(root: string): SessionRecord[] {
+  return listRecordsInternal(root).filter(isSafeRecord);
+}
+
+export function presenceOf(record: SessionRecord, now: number = Date.now()): Presence {
+  assertAddress(record.addr);
+  return presenceOfInternal(record, now);
+}
+
+export function readAlias(root: string, name: string): AliasRecord | null {
+  assertAliasName(name);
+  const alias = readAliasInternal(root, name);
+  return alias && isSafeAlias(alias) ? alias : null;
+}
+
+export function listAliases(root: string): AliasRecord[] {
+  return listAliasesInternal(root).filter(isSafeAlias);
+}
+
+export function claimAlias(root: string, name: string, addr: string, sessionId: string): AliasRecord {
+  assertAliasName(name);
+  assertAddress(addr);
+  return claimAliasInternal(root, name, addr, sessionId);
+}
+
+export function clearAlias(root: string, name: string): void {
+  assertAliasName(name);
+  clearAliasInternal(root, name);
+}
+
+export function sweep(root: string, now: number = Date.now(), sessionExists?: (sessionId: string) => boolean): void {
+  if (!listRecordsInternal(root).every(isSafeRecord) || !listAliasesInternal(root).every(isSafeAlias)) {
+    throw new TypeError('Relay root contains an invalid address or alias');
+  }
+  sweepInternal(root, now, sessionExists);
+}
+
+export function deposit(root: string, toAddr: string, letter: Letter): void {
+  assertAddress(toAddr);
+  assertLetter(letter);
+  depositInternal(root, toAddr, letter);
+}
+
+export function drain(root: string, addr: string): Letter[] {
+  assertAddress(addr);
+  return drainInternal(root, addr).filter(isSafeLetter);
+}
+
+export function unreadCount(root: string, addr: string): number {
+  assertAddress(addr);
+  return unreadCountInternal(root, addr);
+}
+
+export function watchInbox(root: string, addr: string, onMail: () => void): () => void {
+  assertAddress(addr);
+  return watchInboxInternal(root, addr, onMail);
+}
+
+export async function awaitReceipt(
+  root: string,
+  toAddr: string,
+  letter: Letter,
+  timeoutMs = 1500,
+): Promise<'delivered' | 'queued'> {
+  assertAddress(toAddr);
+  assertLetter(letter);
+  return awaitReceiptInternal(root, toAddr, letter, timeoutMs);
+}
+
+export function trackIncomingAsk(root: string, addr: string, letter: Letter): void {
+  assertAddress(addr);
+  assertLetter(letter);
+  trackIncomingAskInternal(root, addr, letter);
+}
+
+export function trackOutgoingAsk(root: string, addr: string, out: OutAsk): void {
+  assertAddress(addr);
+  assertAskId(out.askId);
+  assertAddress(out.toAddr);
+  trackOutgoingAskInternal(root, addr, out);
+}
+
+export function readIncomingAsk(root: string, addr: string, askId: string): Letter | null {
+  assertAddress(addr);
+  assertAskId(askId);
+  const letter = readIncomingAskInternal(root, addr, askId);
+  return letter && isSafeLetter(letter) ? letter : null;
+}
+
+export function readOutgoingAsk(root: string, addr: string, askId: string): OutAsk | null {
+  assertAddress(addr);
+  assertAskId(askId);
+  const out = readOutgoingAskInternal(root, addr, askId);
+  return out && isSafeOutAsk(out) ? out : null;
+}
+
+export function clearAsk(root: string, addr: string, askId: string): void {
+  assertAddress(addr);
+  assertAskId(askId);
+  clearAskInternal(root, addr, askId);
+}
+
+export function resolveAskByRef(root: string, addr: string, replyTo: string): Letter | null {
+  assertAddress(addr);
+  assertAskId(replyTo);
+  const letter = resolveAskByRefInternal(root, addr, replyTo);
+  return letter && isSafeLetter(letter) ? letter : null;
+}
+
+export function pendingAsks(root: string, addr: string): Letter[] {
+  assertAddress(addr);
+  return pendingAsksInternal(root, addr).filter(isSafeLetter);
+}
+
+export function readAudit(root: string, limit = 50): AuditRecord[] {
+  return readAuditInternal(root, limit).filter(isSafeAuditRecord);
+}

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -17,6 +17,7 @@
   "files": [
     "dist",
     "index.ts",
+    "core.ts",
     "registry.ts",
     "mailbox.ts",
     "policy.ts",
@@ -27,7 +28,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "default": "./dist/core.js"
     }
+  },
+  "scripts": {
+    "build": "node ../../scripts/build.ts"
   },
   "dependencies": {
     "typebox": "^1.1.0"
@@ -35,6 +43,14 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "@earendil-works/pi-tui": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    }
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

- add a narrow `@nicknisi/pi-relay/core` export that works without installing or loading Pi/TUI packages
- expose registry, mailbox, policy operations, and their public types for plain Node consumers
- publish the core entry through the Relay package exports/build
- add package-boundary tests that build, pack, install, and import the real core package in a Pi-free fixture
- document the new integration surface and include a Relay minor changeset

## Stack

- **This PR** — Pi-free core export
- #76 — filesystem and durable inbox hardening

## Testing

Validated at the top of the stack:

- `pnpm test` (219 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
