### PR TITLE
fix(relay): harden filesystem and inbox operations

### DIFF
--- a/.changeset/quiet-mails-connect.md
+++ b/.changeset/quiet-mails-connect.md
@@ -2,4 +2,4 @@
 '@nicknisi/pi-relay': minor
 ---
 
-Add a narrow, traversal-safe `@nicknisi/pi-relay/core` export for registry, mailbox, and policy operations and types, usable from plain Node without installing Pi or TUI packages.
+Add a narrow, traversal- and symlink-safe `@nicknisi/pi-relay/core` export for registry, mailbox, and policy operations and types, usable from plain Node without installing Pi or TUI packages. Harden Relay storage with canonical directories, no-follow file access, and random exclusive temporary files.

--- a/.changeset/tough-apples-listen.md
+++ b/.changeset/tough-apples-listen.md
@@ -2,4 +2,4 @@
 '@nicknisi/pi-relay': patch
 ---
 
-Close Relay filesystem TOCTOU gaps by rejecting symlinked root ancestors and pinning root and child directory descriptors across record, alias, audit, mailbox, ask, receipt, and watch operations. Use descriptor-relative Unix syscalls while preserving atomic deposits and clean descriptor shutdown.
+Close Relay filesystem TOCTOU gaps by rejecting user-controlled symlinked root ancestors, safely canonicalizing protected system aliases such as macOS `/var`, and pinning root and child directory descriptors across record, alias, audit, mailbox, ask, receipt, and watch operations. Use descriptor-relative Unix syscalls while preserving atomic deposits and clean descriptor shutdown.

--- a/.changeset/tough-apples-listen.md
+++ b/.changeset/tough-apples-listen.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-relay': patch
+---
+
+Close Relay filesystem TOCTOU gaps by rejecting symlinked root ancestors and pinning root and child directory descriptors across record, alias, audit, mailbox, ask, receipt, and watch operations. Use descriptor-relative Unix syscalls while preserving atomic deposits and clean descriptor shutdown.

--- a/.changeset/tough-apples-listen.md
+++ b/.changeset/tough-apples-listen.md
@@ -2,4 +2,4 @@
 '@nicknisi/pi-relay': patch
 ---
 
-Close Relay filesystem TOCTOU gaps by rejecting user-controlled symlinked root ancestors, safely canonicalizing protected system aliases such as macOS `/var`, and pinning root and child directory descriptors across record, alias, audit, mailbox, ask, receipt, and watch operations. Use descriptor-relative Unix syscalls while preserving atomic deposits and clean descriptor shutdown.
+Close Relay filesystem TOCTOU gaps by rejecting user-controlled symlinked root ancestors, safely canonicalizing protected system aliases such as macOS `/var`, and pinning root and child directory descriptors across record, alias, audit, mailbox, ask, receipt, watch, and durable inbox-claim operations. Mailbox filenames now contain the complete validated message id, preventing same-millisecond prefix collisions and allowing receipts to track the exact letter. Core consumers can atomically claim an inbox, recover stable claim/file tokens after a crash, safely read letters without following symlinks, and acknowledge or requeue them after fsyncing their own journal.

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -96,7 +96,7 @@ The directory is created `0700` and every file `0600` — other users on the mac
 
 ## Caveats
 
-- **Mailbox semantics support Linux and macOS only.** Relay rejects symlinks in every configured-root component, pins root and mailbox descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic rename-over-existing, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
+- **Mailbox semantics support Linux and macOS only.** Relay rejects user-controlled symlinks in configured-root components, permits protected root-owned system aliases such as macOS `/var`, pins root and mailbox descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic rename-over-existing, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
 - **One machine.** Delivery is a file landing in a directory; two sessions reach each other exactly when they share a filesystem. A container and its host cannot.
 - **Presence is heartbeat-accurate**, not instantaneous (within ~45s).
 - Delivery injects with `deliverAs: "steer"` (lands between tool calls) and `triggerTurn: true` (wakes an idle session).

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -14,10 +14,14 @@ Architecture follows [shift-labs/pi-peer](https://github.com/shift-labs-ai/pi-pe
 Node applications can use the registry, mailbox, and transport-policy primitives without loading the pi extension or its TUI dependencies:
 
 ```ts
-import { OutboundPolicy, deposit, deriveAddr, type Letter } from '@nicknisi/pi-relay/core';
+import { OutboundPolicy, claimInbox, deposit, deriveAddr, type Letter } from '@nicknisi/pi-relay/core';
 ```
 
-The `@nicknisi/pi-relay/core` subpath exports a narrow record and alias registry, mailbox and ask/audit operations, presence and sweep utilities, policy guards and constants, and their public types. Filesystem-facing operations validate canonical relay addresses, aliases, and ask/message IDs before accessing the relay root; path constructors and raw persistence helpers remain internal. Core uses Node built-ins plus Koffi's prebuilt native bridge for descriptor-relative Unix syscalls; Pi and TUI remain optional peers, so core-only installations do not fetch them. The package root remains the pi extension entry point; import `/core` from plain Node services and CLIs.
+The `@nicknisi/pi-relay/core` subpath exports a narrow record and alias registry, mailbox and ask/audit operations, presence and sweep utilities, policy guards and constants, and their public types. Filesystem-facing operations validate canonical relay addresses, aliases, claim tokens, and ask/message IDs before accessing the relay root; path constructors and raw persistence helpers remain internal. Core uses Node built-ins plus Koffi's prebuilt native bridge for descriptor-relative Unix syscalls; Pi and TUI remain optional peers, so core-only installations do not fetch them. The package root remains the pi extension entry point; import `/core` from plain Node services and CLIs.
+
+### Durable core inbox claims
+
+A non-Pi consumer can atomically detach the current inbox with `claimInbox(root, addr)`. It receives only a stable `claimToken` and stable `fileTokens`, never filesystem paths. New deposits immediately land in a fresh inbox. `readClaimedLetter` reopens and validates a claimed letter without following links; after the consumer durably writes and `fsync`s its own journal, `ackClaimedLetter` deletes that exact file or `requeueClaimedLetter` atomically returns it to the current inbox. `recoverInboxClaims` enumerates the same tokens after a process crash. All claim, read, ack, and requeue work is relative to pinned root/inbox/claim descriptors, and empty completed claims are removed automatically.
 
 ## Audit log
 
@@ -47,7 +51,7 @@ main moved; rebase before you push.
 
 - **A mailbox outlives the process.** The address is a hash of the working directory and pi's session id, so a session resumed with `pi -c` answers to the same address. Mail sent to a closed session waits on disk and is read when it resumes — the common case when you're opening and closing terminals all day.
 - **The queue is inspectable.** Diagnosing delivery is `ls`, not instrumenting a transport.
-- **Consumption is the receipt.** The receiver deletes the letter as it reads it, so the sender learns _delivered_ vs _queued_ — "the letter vanished" means the agent has it, which no socket ack can tell you.
+- **Consumption is the receipt.** The receiver deletes the exact full-message-id letter as it reads it, so the sender learns _delivered_ vs _queued_. A durable core claim remains queued until it is acknowledged; moving it into a claim does not produce a false receipt.
 
 ## Semantics
 
@@ -55,7 +59,7 @@ main moved; rebase before you push.
 - **Authority boundary on every delivery.** Each message arrives with a repeated statement that it came from a peer and carries no authority — it cannot approve anything, cannot change configuration, slash commands in it are inert text. The sending side's tool guidelines carry the reciprocal rule: never ask a peer to do something your own permissions would refuse.
 - **Loops break structurally**, independent of what either model decides: identical text from one sender inside 10s is dropped; >8 messages per 30s per sender is refused; an unread backlog of 50 refuses new mail until the peer drains.
 - **Plain text only, ≤32KB.** Send a summary and a path, not a payload.
-- **Sweeping is narrow:** a running session is never touched; a mailbox holding undelivered mail is kept 30 days; an offline-but-resumable session keeps its record (its address — new mail must remain deliverable while it's down); only an empty mailbox of a session that can no longer be resumed is discarded promptly. Listing never has side effects.
+- **Sweeping is narrow:** a running session is never touched; an inbox or durable claim holding undelivered mail is kept 30 days; an offline-but-resumable session keeps its record (its address — new mail must remain deliverable while it's down); only an empty mailbox of a session that can no longer be resumed is discarded promptly. Listing never has side effects.
 
 ### ask / reply / pending / cancel
 
@@ -96,7 +100,7 @@ The directory is created `0700` and every file `0600` — other users on the mac
 
 ## Caveats
 
-- **Mailbox semantics support Linux and macOS only.** Relay rejects user-controlled symlinks in configured-root components, permits protected root-owned system aliases such as macOS `/var`, pins root and mailbox descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic rename-over-existing, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
+- **Mailbox semantics support Linux and macOS only.** Relay rejects user-controlled symlinks in configured-root components, permits protected root-owned system aliases such as macOS `/var`, pins root, mailbox, and durable-claim descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic renames, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
 - **One machine.** Delivery is a file landing in a directory; two sessions reach each other exactly when they share a filesystem. A container and its host cannot.
 - **Presence is heartbeat-accurate**, not instantaneous (within ~45s).
 - Delivery injects with `deliverAs: "steer"` (lands between tool calls) and `triggerTurn: true` (wakes an idle session).

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -17,7 +17,7 @@ Node applications can use the registry, mailbox, and transport-policy primitives
 import { OutboundPolicy, deposit, deriveAddr, type Letter } from '@nicknisi/pi-relay/core';
 ```
 
-The `@nicknisi/pi-relay/core` subpath exports a narrow record and alias registry, mailbox and ask/audit operations, presence and sweep utilities, policy guards and constants, and their public types. Filesystem-facing operations validate canonical relay addresses, aliases, and ask/message IDs before accessing the relay root; path constructors and raw persistence helpers remain internal. It depends only on Node built-ins. Pi and TUI are optional peers, so core-only installations do not fetch them. The package root remains the pi extension entry point; import `/core` from plain Node services and CLIs.
+The `@nicknisi/pi-relay/core` subpath exports a narrow record and alias registry, mailbox and ask/audit operations, presence and sweep utilities, policy guards and constants, and their public types. Filesystem-facing operations validate canonical relay addresses, aliases, and ask/message IDs before accessing the relay root; path constructors and raw persistence helpers remain internal. Core uses Node built-ins plus Koffi's prebuilt native bridge for descriptor-relative Unix syscalls; Pi and TUI remain optional peers, so core-only installations do not fetch them. The package root remains the pi extension entry point; import `/core` from plain Node services and CLIs.
 
 ## Audit log
 
@@ -96,7 +96,7 @@ The directory is created `0700` and every file `0600` — other users on the mac
 
 ## Caveats
 
-- **Mailbox semantics are unix-only.** Delivery relies on atomic `renameSync`-over-existing, `fs.watch`, and `0600`/`0700` permission bits; Windows is untested and unsupported.
+- **Mailbox semantics support Linux and macOS only.** Relay rejects symlinks in every configured-root component, pins root and mailbox descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic rename-over-existing, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
 - **One machine.** Delivery is a file landing in a directory; two sessions reach each other exactly when they share a filesystem. A container and its host cannot.
 - **Presence is heartbeat-accurate**, not instantaneous (within ~45s).
 - Delivery injects with `deliverAs: "steer"` (lands between tool calls) and `triggerTurn: true` (wakes an idle session).

--- a/packages/relay/core.test.ts
+++ b/packages/relay/core.test.ts
@@ -92,7 +92,20 @@ describe('/core filesystem boundary', () => {
     expect(fs.readdirSync(base)).toEqual([]);
   });
 
-  it('rejects symlinked roots and every symlinked ancestor component', () => {
+  it.runIf(process.platform === 'darwin')('creates an exact /var temp root through the protected system link', () => {
+    const canonicalBase = fixture();
+    expect(canonicalBase.startsWith('/private/var/')).toBe(true);
+    const root = path.join('/var', path.relative('/private/var', canonicalBase), 'relay');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const validLetter = letter();
+
+    core.deposit(root, addr, validLetter);
+
+    expect(fs.realpathSync.native(root)).toBe(path.join(canonicalBase, 'relay'));
+    expect(core.drain(root, addr)).toEqual([validLetter]);
+  });
+
+  it('rejects symlinked roots and user-controlled symlinked ancestor components', () => {
     const base = fixture();
     const outside = path.join(base, 'outside');
     const root = path.join(base, 'relay');

--- a/packages/relay/core.test.ts
+++ b/packages/relay/core.test.ts
@@ -18,7 +18,7 @@ const packageJson = JSON.parse(fs.readFileSync(path.join(relayDir, 'package.json
 const fixtures: string[] = [];
 
 function fixture(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-relay-core-'));
+  const dir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'pi-relay-core-')));
   fixtures.push(dir);
   return dir;
 }
@@ -92,6 +92,116 @@ describe('/core filesystem boundary', () => {
     expect(fs.readdirSync(base)).toEqual([]);
   });
 
+  it('rejects symlinked roots and every symlinked ancestor component', () => {
+    const base = fixture();
+    const outside = path.join(base, 'outside');
+    const root = path.join(base, 'relay');
+    const addr = core.deriveAddr('/receiver', 'session');
+    fs.mkdirSync(outside);
+    fs.symlinkSync(outside, root, 'dir');
+
+    expect(() => core.listRecords(root)).toThrow(/symlink/i);
+    expect(() => core.deposit(root, addr, letter())).toThrow(/symlink/i);
+    expect(fs.readdirSync(outside)).toEqual([]);
+
+    fs.unlinkSync(root);
+    const ancestor = path.join(base, 'ancestor');
+    fs.symlinkSync(outside, ancestor, 'dir');
+    const nestedRoot = path.join(ancestor, 'nested', 'relay');
+    expect(() => core.listRecords(nestedRoot)).toThrow(/symlink/i);
+    expect(() => core.deposit(nestedRoot, addr, letter())).toThrow(/symlink/i);
+    expect(fs.readdirSync(outside)).toEqual([]);
+  });
+
+  it('rejects symlinked inbox and ask directories in every access mode', async () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const outside = path.join(base, 'outside');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const validLetter = letter();
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.symlinkSync(outside, path.join(root, `${addr}.inbox`), 'dir');
+
+    for (const call of [
+      () => core.deposit(root, addr, validLetter),
+      () => core.drain(root, addr),
+      () => core.unreadCount(root, addr),
+      () => core.watchInbox(root, addr, () => {}),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    await expect(core.awaitReceipt(root, addr, validLetter, 1)).rejects.toThrow(/symlink/i);
+
+    fs.unlinkSync(path.join(root, `${addr}.inbox`));
+    fs.symlinkSync(outside, path.join(root, `${addr}.asks`), 'dir');
+    const out: core.OutAsk = {
+      askId: validLetter.id,
+      toAddr: core.deriveAddr('/peer', 'session'),
+      body: 'question',
+      ts: Date.now(),
+    };
+    for (const call of [
+      () => core.trackIncomingAsk(root, addr, validLetter),
+      () => core.trackOutgoingAsk(root, addr, out),
+      () => core.readIncomingAsk(root, addr, validLetter.id),
+      () => core.readOutgoingAsk(root, addr, validLetter.id),
+      () => core.clearAsk(root, addr, validLetter.id),
+      () => core.pendingAsks(root, addr),
+      () => core.resolveAskByRef(root, addr, validLetter.id),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    expect(fs.readdirSync(outside)).toEqual([]);
+  });
+
+  it('rejects symlinked aliases, records, letters, asks, and audit files without following them', () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const outside = path.join(base, 'outside');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const validLetter = letter();
+    const sentinel = path.join(outside, 'sentinel.json');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.writeFileSync(sentinel, '{"sentinel":true}');
+
+    fs.symlinkSync(outside, path.join(root, 'aliases'), 'dir');
+    for (const call of [
+      () => core.claimAlias(root, 'ci', addr, 'session'),
+      () => core.readAlias(root, 'ci'),
+      () => core.listAliases(root),
+      () => core.clearAlias(root, 'ci'),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    fs.unlinkSync(path.join(root, 'aliases'));
+
+    fs.symlinkSync(sentinel, path.join(root, `${addr}.json`), 'file');
+    expect(() => core.readRecord(root, addr)).toThrow(/symlink/i);
+    expect(() => core.listRecords(root)).toThrow(/symlink/i);
+    fs.unlinkSync(path.join(root, `${addr}.json`));
+
+    const inbox = path.join(root, `${addr}.inbox`);
+    fs.mkdirSync(inbox);
+    fs.symlinkSync(sentinel, path.join(inbox, `${validLetter.ts}-${validLetter.id.slice(0, 6)}.json`), 'file');
+    expect(() => core.drain(root, addr)).toThrow(/symlink/i);
+    fs.rmSync(inbox, { recursive: true, force: true });
+
+    const asks = path.join(root, `${addr}.asks`);
+    fs.mkdirSync(asks);
+    fs.symlinkSync(sentinel, path.join(asks, `${validLetter.id}.json`), 'file');
+    expect(() => core.readIncomingAsk(root, addr, validLetter.id)).toThrow(/symlink/i);
+    expect(() => core.clearAsk(root, addr, validLetter.id)).toThrow(/symlink/i);
+    fs.rmSync(asks, { recursive: true, force: true });
+
+    fs.symlinkSync(sentinel, path.join(root, 'audit.log'), 'file');
+    expect(() => core.readAudit(root)).toThrow(/symlink/i);
+    expect(() => core.deposit(root, addr, validLetter)).toThrow(/symlink/i);
+    expect(fs.readFileSync(sentinel, 'utf8')).toBe('{"sentinel":true}');
+    expect(fs.existsSync(path.join(root, `${addr}.inbox`))).toBe(false);
+  });
+
   it('rejects traversal in aliases and ask/message identifiers', async () => {
     const base = fixture();
     const root = path.join(base, 'relay');
@@ -130,6 +240,11 @@ describe('/core filesystem boundary', () => {
   });
 });
 
+it('keeps the Pi extension entry importable', async () => {
+  const entry = await import('./index.js');
+  expect(typeof entry.default).toBe('function');
+});
+
 it('builds, packs, installs, and imports the real core package without Pi or TUI', () => {
   const base = fixture();
   const tarball = path.join(base, 'relay.tgz');
@@ -155,6 +270,7 @@ it('builds, packs, installs, and imports the real core package without Pi or TUI
   for (const target of Object.values(coreExport!)) {
     expect(fs.existsSync(path.join(installedDir, target))).toBe(true);
   }
+  expect(fs.existsSync(path.join(installedDir, 'filesystem.ts'))).toBe(true);
   expect(packageJson.peerDependenciesMeta['@earendil-works/pi-coding-agent']?.optional).toBe(true);
   expect(packageJson.peerDependenciesMeta['@earendil-works/pi-tui']?.optional).toBe(true);
   expect(fs.existsSync(path.join(appDir, 'node_modules', '@earendil-works', 'pi-coding-agent'))).toBe(false);

--- a/packages/relay/core.test.ts
+++ b/packages/relay/core.test.ts
@@ -64,6 +64,11 @@ describe('/core filesystem boundary', () => {
       () => core.deposit(root, validAddr, letter({ from: { ...validLetter.from, addr: badAddr } })),
       () => core.drain(root, badAddr),
       () => core.unreadCount(root, badAddr),
+      () => core.claimInbox(root, badAddr),
+      () => core.recoverInboxClaims(root, badAddr),
+      () => core.readClaimedLetter(root, badAddr, '0'.repeat(32), `${validLetter.ts}-${validLetter.id}.json`),
+      () => core.ackClaimedLetter(root, badAddr, '0'.repeat(32), `${validLetter.ts}-${validLetter.id}.json`),
+      () => core.requeueClaimedLetter(root, badAddr, '0'.repeat(32), `${validLetter.ts}-${validLetter.id}.json`),
       () => core.watchInbox(root, badAddr, () => {}),
       () => core.trackIncomingAsk(root, badAddr, validLetter),
       () =>
@@ -140,6 +145,7 @@ describe('/core filesystem boundary', () => {
       () => core.deposit(root, addr, validLetter),
       () => core.drain(root, addr),
       () => core.unreadCount(root, addr),
+      () => core.claimInbox(root, addr),
       () => core.watchInbox(root, addr, () => {}),
     ]) {
       expect(call).toThrow(/symlink/i);
@@ -197,7 +203,7 @@ describe('/core filesystem boundary', () => {
 
     const inbox = path.join(root, `${addr}.inbox`);
     fs.mkdirSync(inbox);
-    fs.symlinkSync(sentinel, path.join(inbox, `${validLetter.ts}-${validLetter.id.slice(0, 6)}.json`), 'file');
+    fs.symlinkSync(sentinel, path.join(inbox, `${validLetter.ts}-${validLetter.id}.json`), 'file');
     expect(() => core.drain(root, addr)).toThrow(/symlink/i);
     fs.rmSync(inbox, { recursive: true, force: true });
 
@@ -215,10 +221,104 @@ describe('/core filesystem boundary', () => {
     expect(fs.existsSync(path.join(root, `${addr}.inbox`))).toBe(false);
   });
 
-  it('rejects traversal in aliases and ask/message identifiers', async () => {
+  it('durably claims same-millisecond letters without collisions and recovers by opaque tokens', async () => {
     const base = fixture();
     const root = path.join(base, 'relay');
     const addr = core.deriveAddr('/receiver', 'session');
+    const ts = Date.now();
+    const first = letter({ id: 'reply-prefix-000000000000000000000001', kind: 'reply', ts, body: 'first' });
+    const second = letter({ id: 'reply-prefix-000000000000000000000002', kind: 'reply', ts, body: 'second' });
+
+    core.deposit(root, addr, first);
+    core.deposit(root, addr, second);
+    expect(core.unreadCount(root, addr)).toBe(2);
+
+    const claim = core.claimInbox(root, addr)!;
+    expect(claim.claimToken).toMatch(/^[a-f0-9]{32}$/);
+    expect(claim.claimToken).not.toContain('/');
+    expect(claim.fileTokens).toEqual([`${ts}-${first.id}.json`, `${ts}-${second.id}.json`]);
+    expect(claim.fileTokens.every((token) => !token.includes('/'))).toBe(true);
+    expect(core.unreadCount(root, addr)).toBe(0);
+    expect(await core.awaitReceipt(root, addr, first, 1)).toBe('queued');
+
+    // A new process can recover the same stable claim/file tokens and read
+    // letters without retaining a path or descriptor from claimInbox.
+    expect(core.recoverInboxClaims(root, addr)).toEqual([claim]);
+    expect(core.readClaimedLetter(root, addr, claim.claimToken, claim.fileTokens[0]!)?.body).toBe('first');
+    expect(core.readClaimedLetter(root, addr, claim.claimToken, claim.fileTokens[1]!)?.body).toBe('second');
+
+    const journal = fs.openSync(path.join(base, 'journal'), 'w');
+    fs.writeFileSync(journal, JSON.stringify({ claim: claim.claimToken, file: claim.fileTokens[0] }));
+    fs.fsyncSync(journal);
+    fs.closeSync(journal);
+    expect(core.ackClaimedLetter(root, addr, claim.claimToken, claim.fileTokens[0]!)).toBe(true);
+    expect(await core.awaitReceipt(root, addr, first, 1)).toBe('delivered');
+
+    const later = letter({ id: 'later-message', ts: ts + 1, body: 'new inbox' });
+    core.deposit(root, addr, later);
+    expect(core.requeueClaimedLetter(root, addr, claim.claimToken, claim.fileTokens[1]!)).toBe(true);
+    expect(core.recoverInboxClaims(root, addr)).toEqual([]);
+    expect(core.drain(root, addr).map((entry) => entry.body)).toEqual(['second', 'new inbox']);
+  });
+
+  it('never follows symlinked durable claims or claimed letters', () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const outside = path.join(base, 'outside');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const claimToken = 'a'.repeat(32);
+    const validLetter = letter();
+    const fileToken = `${validLetter.ts}-${validLetter.id}.json`;
+    const sentinel = path.join(outside, 'sentinel.json');
+    fs.mkdirSync(root);
+    fs.mkdirSync(outside);
+    fs.writeFileSync(sentinel, 'sentinel');
+
+    fs.symlinkSync(outside, path.join(root, `${addr}.claims`), 'dir');
+    core.deposit(root, addr, validLetter);
+    for (const call of [
+      () => core.claimInbox(root, addr),
+      () => core.recoverInboxClaims(root, addr),
+      () => core.readClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.ackClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.requeueClaimedLetter(root, addr, claimToken, fileToken),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    fs.unlinkSync(path.join(root, `${addr}.claims`));
+
+    const claims = path.join(root, `${addr}.claims`);
+    fs.mkdirSync(claims);
+    fs.symlinkSync(outside, path.join(claims, claimToken), 'dir');
+    for (const call of [
+      () => core.recoverInboxClaims(root, addr),
+      () => core.readClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.ackClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.requeueClaimedLetter(root, addr, claimToken, fileToken),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    fs.unlinkSync(path.join(claims, claimToken));
+
+    const claim = path.join(claims, claimToken);
+    fs.mkdirSync(claim);
+    fs.symlinkSync(sentinel, path.join(claim, fileToken), 'file');
+    for (const call of [
+      () => core.recoverInboxClaims(root, addr),
+      () => core.readClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.ackClaimedLetter(root, addr, claimToken, fileToken),
+      () => core.requeueClaimedLetter(root, addr, claimToken, fileToken),
+    ]) {
+      expect(call).toThrow(/symlink/i);
+    }
+    expect(fs.readFileSync(sentinel, 'utf8')).toBe('sentinel');
+  });
+
+  it('rejects traversal in aliases, claims, and ask/message identifiers', async () => {
+    const base = fixture();
+    const root = path.join(base, 'relay');
+    const addr = core.deriveAddr('/receiver', 'session');
+    const validLetter = letter();
     const badId = '../../../escaped';
     const badAlias = '../../../escaped';
 
@@ -240,6 +340,9 @@ describe('/core filesystem boundary', () => {
       () => core.readOutgoingAsk(root, addr, badId),
       () => core.clearAsk(root, addr, badId),
       () => core.resolveAskByRef(root, addr, badId),
+      () => core.readClaimedLetter(root, addr, badId, `${validLetter.ts}-${validLetter.id}.json`),
+      () => core.ackClaimedLetter(root, addr, '0'.repeat(32), badId),
+      () => core.requeueClaimedLetter(root, addr, '0'.repeat(32), badId),
     ];
 
     for (const call of calls) expect(call).toThrow(TypeError);
@@ -295,7 +398,7 @@ it('builds, packs, installs, and imports the real core package without Pi or TUI
       '--input-type=module',
       '--eval',
       `const core = await import('@nicknisi/pi-relay/core');
-for (const name of ['deriveAddr', 'deposit', 'drain', 'claimAlias', 'pendingAsks', 'OutboundPolicy']) {
+for (const name of ['deriveAddr', 'deposit', 'drain', 'claimInbox', 'recoverInboxClaims', 'readClaimedLetter', 'ackClaimedLetter', 'requeueClaimedLetter', 'claimAlias', 'pendingAsks', 'OutboundPolicy']) {
   if (typeof core[name] !== 'function') throw new Error(\`Missing core export: \${name}\`);
 }
 for (const name of ['recordPath', 'inboxDir', 'asksDir', 'aliasPath', 'auditLogPath', 'writeRecord', 'writeAlias', 'appendAudit']) {

--- a/packages/relay/core.ts
+++ b/packages/relay/core.ts
@@ -1,19 +1,25 @@
 /** Pi-free relay registry, mailbox, and policy API for non-extension consumers. */
 import {
+  ackClaimedLetter as ackClaimedLetterInternal,
   awaitReceipt as awaitReceiptInternal,
+  claimInbox as claimInboxInternal,
   clearAsk as clearAskInternal,
   deposit as depositInternal,
   drain as drainInternal,
   pendingAsks as pendingAsksInternal,
   readAudit as readAuditInternal,
+  readClaimedLetter as readClaimedLetterInternal,
   readIncomingAsk as readIncomingAskInternal,
   readOutgoingAsk as readOutgoingAskInternal,
+  recoverInboxClaims as recoverInboxClaimsInternal,
+  requeueClaimedLetter as requeueClaimedLetterInternal,
   resolveAskByRef as resolveAskByRefInternal,
   trackIncomingAsk as trackIncomingAskInternal,
   trackOutgoingAsk as trackOutgoingAskInternal,
   unreadCount as unreadCountInternal,
   watchInbox as watchInboxInternal,
   type AuditRecord,
+  type InboxClaim,
   type Letter,
   type OutAsk,
 } from './mailbox.js';
@@ -32,7 +38,15 @@ import {
   type SessionRecord,
 } from './registry.js';
 
-export { MAX_BODY_CHARS, previewBody, type AuditRecord, type Letter, type LetterKind, type OutAsk } from './mailbox.js';
+export {
+  MAX_BODY_CHARS,
+  previewBody,
+  type AuditRecord,
+  type InboxClaim,
+  type Letter,
+  type LetterKind,
+  type OutAsk,
+} from './mailbox.js';
 export {
   BACKLOG_CAP,
   DEDUPE_WINDOW_MS,
@@ -54,6 +68,8 @@ export {
 
 const ADDRESS_PATTERN = /^[a-f0-9]{12}$/;
 const ASK_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/;
+const INBOX_CLAIM_TOKEN_PATTERN = /^[a-f0-9]{32}$/;
+const INBOX_FILE_TOKEN_PATTERN = /^(0|[1-9][0-9]*)-[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}\.json$/;
 
 function assertAddress(addr: string): void {
   if (!ADDRESS_PATTERN.test(addr)) throw new TypeError(`Invalid relay address: ${addr}`);
@@ -67,13 +83,29 @@ function assertAskId(id: string): void {
   if (!ASK_ID_PATTERN.test(id)) throw new TypeError(`Invalid relay ask/message id: ${id}`);
 }
 
+function assertInboxClaimToken(token: string): void {
+  if (!INBOX_CLAIM_TOKEN_PATTERN.test(token)) throw new TypeError(`Invalid relay inbox claim token: ${token}`);
+}
+
+function assertInboxFileToken(token: string): void {
+  if (!INBOX_FILE_TOKEN_PATTERN.test(token)) throw new TypeError(`Invalid relay inbox file token: ${token}`);
+}
+
 function assertLetter(letter: Letter): void {
   if (typeof letter !== 'object' || letter === null) throw new TypeError('Invalid relay letter');
   assertAskId(letter.id);
   if (typeof letter.from !== 'object' || letter.from === null) throw new TypeError('Invalid relay letter sender');
   assertAddress(letter.from.addr);
+  if (typeof letter.from.name !== 'string' || typeof letter.from.cwd !== 'string') {
+    throw new TypeError('Invalid relay letter sender');
+  }
+  if (!['message', 'ask', 'reply', 'cancel'].includes(letter.kind) || typeof letter.body !== 'string') {
+    throw new TypeError('Invalid relay letter payload');
+  }
   if (letter.replyTo !== undefined) assertAskId(letter.replyTo);
-  if (!Number.isFinite(letter.ts)) throw new TypeError(`Invalid relay letter timestamp: ${letter.ts}`);
+  if (!Number.isSafeInteger(letter.ts) || letter.ts < 0) {
+    throw new TypeError(`Invalid relay letter timestamp: ${letter.ts}`);
+  }
 }
 
 function isSafeLetter(letter: Letter): boolean {
@@ -182,6 +214,38 @@ export function drain(root: string, addr: string): Letter[] {
 export function unreadCount(root: string, addr: string): number {
   assertAddress(addr);
   return unreadCountInternal(root, addr);
+}
+
+export function claimInbox(root: string, addr: string): InboxClaim | null {
+  assertAddress(addr);
+  return claimInboxInternal(root, addr);
+}
+
+export function recoverInboxClaims(root: string, addr: string): InboxClaim[] {
+  assertAddress(addr);
+  return recoverInboxClaimsInternal(root, addr);
+}
+
+export function readClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): Letter | null {
+  assertAddress(addr);
+  assertInboxClaimToken(claimToken);
+  assertInboxFileToken(fileToken);
+  const letter = readClaimedLetterInternal(root, addr, claimToken, fileToken);
+  return letter && isSafeLetter(letter) ? letter : null;
+}
+
+export function ackClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): boolean {
+  assertAddress(addr);
+  assertInboxClaimToken(claimToken);
+  assertInboxFileToken(fileToken);
+  return ackClaimedLetterInternal(root, addr, claimToken, fileToken);
+}
+
+export function requeueClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): boolean {
+  assertAddress(addr);
+  assertInboxClaimToken(claimToken);
+  assertInboxFileToken(fileToken);
+  return requeueClaimedLetterInternal(root, addr, claimToken, fileToken);
 }
 
 export function watchInbox(root: string, addr: string, onMail: () => void): () => void {

--- a/packages/relay/filesystem.ts
+++ b/packages/relay/filesystem.ts
@@ -116,6 +116,62 @@ function verifyDirectoryFd(fd: number, label: string): fs.Stats {
   return stat;
 }
 
+function isProtectedSystemPath(stat: fs.Stats): boolean {
+  return stat.uid === 0 && (stat.mode & 0o022) === 0;
+}
+
+function canonicalTraversalPath(absolute: string): string {
+  let candidate = absolute;
+  for (let redirect = 0; redirect < 40; redirect++) {
+    const parsed = path.parse(candidate);
+    const components = candidate.slice(parsed.root.length).split(path.sep).filter(Boolean);
+    let current = parsed.root;
+    let redirected = false;
+
+    for (const [index, component] of components.entries()) {
+      current = path.join(current, component);
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(current);
+      } catch (error) {
+        if (isErrorCode(error, 'ENOENT')) return candidate;
+        throw error;
+      }
+
+      if (stat.isSymbolicLink()) {
+        if (index === components.length - 1) unsafe(`Refusing symlinked relay root: ${absolute}`);
+
+        let canonicalTarget: string;
+        let targetStat: fs.Stats;
+        const parentStat = fs.statSync(path.dirname(current));
+        try {
+          canonicalTarget = fs.realpathSync.native(current);
+          targetStat = fs.lstatSync(canonicalTarget);
+        } catch (error) {
+          unsafe(`Refusing unsafe system ancestor symlink: ${current}`, error);
+        }
+        if (
+          !isProtectedSystemPath(parentStat) ||
+          !isProtectedSystemPath(stat) ||
+          !targetStat.isDirectory() ||
+          !isProtectedSystemPath(targetStat)
+        ) {
+          unsafe(`Refusing user-controlled ancestor symlink: ${current}`);
+        }
+
+        candidate = path.join(canonicalTarget, ...components.slice(index + 1));
+        redirected = true;
+        break;
+      }
+
+      if (!stat.isDirectory()) unsafe(`Relay path is not a directory: ${current}`);
+    }
+
+    if (!redirected) return candidate;
+  }
+  unsafe(`Refusing relay path with too many system symlinks: ${absolute}`);
+}
+
 function openDirectoryAt(
   directoryFd: number,
   name: string,
@@ -410,23 +466,72 @@ export interface RelayWatcher {
   unref(): void;
 }
 
-/** Open every configured-root component without following symlinks and return the pinned root descriptor. */
-export function openRelayRoot(root: string, create = false): RelayDirectoryHandle | null {
-  const absolute = path.resolve(root);
-  const components = absolute.split(path.sep).filter(Boolean);
-  let fd = fs.openSync(path.parse(absolute).root, READ_DIRECTORY_FLAGS);
+function ensureRootDirectory(absolute: string): void {
+  const parsed = path.parse(absolute);
+  const components = absolute.slice(parsed.root.length).split(path.sep).filter(Boolean);
+  const rootName = components.pop();
+  if (rootName === undefined) return;
+
+  let fd = fs.openSync(parsed.root, READ_DIRECTORY_FLAGS);
   try {
-    verifyDirectoryFd(fd, path.parse(absolute).root);
-    for (const [index, component] of components.entries()) {
-      const next = openDirectoryAt(fd, component, create, absolute, create && index === components.length - 1);
+    verifyDirectoryFd(fd, parsed.root);
+    for (const component of components) {
+      const next = openDirectoryAt(fd, component, true, absolute);
+      fs.closeSync(fd);
+      fd = next!;
+    }
+    try {
+      mkdirAt(fd, rootName);
+    } catch (error) {
+      if (!isErrorCode(error, 'EEXIST')) throw error;
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function openRootFd(absolute: string): number | null {
+  const parsed = path.parse(absolute);
+  const components = absolute.slice(parsed.root.length).split(path.sep).filter(Boolean);
+  let fd = fs.openSync(parsed.root, READ_DIRECTORY_FLAGS);
+  try {
+    verifyDirectoryFd(fd, parsed.root);
+    for (const component of components) {
+      const next = openDirectoryAt(fd, component, false, absolute);
       if (next === null) return null;
       fs.closeSync(fd);
       fd = next;
     }
-    const handle = new RelayDirectoryHandle(fd, absolute);
+    const rootFd = fd;
     fd = -1;
-    return handle;
+    return rootFd;
   } finally {
     if (fd >= 0) fs.closeSync(fd);
   }
+}
+
+/** Open every canonical configured-root component without following symlinks and return its pinned descriptor. */
+export function openRelayRoot(root: string, create = false): RelayDirectoryHandle | null {
+  const absolute = path.resolve(root);
+  const traversalPath = canonicalTraversalPath(absolute);
+  if (create) ensureRootDirectory(traversalPath);
+
+  let canonicalRoot: string;
+  try {
+    canonicalRoot = fs.realpathSync.native(traversalPath);
+  } catch (error) {
+    if (!create && isErrorCode(error, 'ENOENT')) return null;
+    throw error;
+  }
+
+  const fd = openRootFd(canonicalRoot);
+  if (fd === null) return null;
+  if (create) {
+    try {
+      fs.fchmodSync(fd, 0o700);
+    } catch {
+      // best-effort on filesystems that support modes
+    }
+  }
+  return new RelayDirectoryHandle(fd, absolute);
 }

--- a/packages/relay/filesystem.ts
+++ b/packages/relay/filesystem.ts
@@ -1,0 +1,432 @@
+/** Descriptor-relative, symlink-safe filesystem operations for the relay store. Pi-free. */
+import { randomBytes } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import koffi from 'koffi';
+
+if (process.platform !== 'darwin' && process.platform !== 'linux') {
+  throw new Error(`Relay filesystem operations are unsupported on ${process.platform}`);
+}
+
+const NOFOLLOW = fs.constants.O_NOFOLLOW ?? 0;
+const DIRECTORY = fs.constants.O_DIRECTORY ?? 0;
+const CLOEXEC = process.platform === 'darwin' ? 0x01000000 : 0x00080000;
+const READ_DIRECTORY_FLAGS = fs.constants.O_RDONLY | NOFOLLOW | DIRECTORY | CLOEXEC;
+const AT_REMOVEDIR = 0x80;
+
+function loadLibc(): ReturnType<typeof koffi.load> {
+  const candidates =
+    process.platform === 'darwin'
+      ? ['/usr/lib/libSystem.B.dylib']
+      : [
+          'libc.so.6',
+          `/lib/libc.musl-${process.arch === 'arm64' ? 'aarch64' : process.arch}.so.1`,
+          `/usr/lib/libc.musl-${process.arch === 'arm64' ? 'aarch64' : process.arch}.so.1`,
+        ];
+  for (const candidate of candidates) {
+    try {
+      return koffi.load(candidate);
+    } catch {
+      // try the next libc name (glibc first, then musl)
+    }
+  }
+  throw new Error(`Relay could not load libc on ${process.platform}/${process.arch}`);
+}
+
+const libc = loadLibc();
+const nativeOpenAt = libc.func('int openat(int, const char *, int, ...)');
+const nativeMkdirAt = libc.func('int mkdirat(int, const char *, uint32_t)');
+const nativeUnlinkAt = libc.func('int unlinkat(int, const char *, int)');
+const nativeRenameAt = libc.func('int renameat(int, const char *, int, const char *)');
+const nativeDup = libc.func('int dup(int)');
+const nativeFdOpenDir = libc.func('void *fdopendir(int)');
+const nativeReadDir = libc.func('void *readdir(void *)');
+const nativeCloseDir = libc.func('int closedir(void *)');
+const nativeStrError = libc.func('const char *strerror(int)');
+const errnoNames = new Map(Object.entries(koffi.os.errno).map(([name, value]) => [value, name]));
+
+/** An existing relay path is unsafe to traverse or is not the expected type. */
+export class RelayFilesystemError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'RelayFilesystemError';
+  }
+}
+
+export function rethrowFilesystemError(error: unknown): void {
+  if (error instanceof RelayFilesystemError) throw error;
+}
+
+export function assertPathSegment(segment: string, label = 'relay path component'): void {
+  if (
+    segment.length === 0 ||
+    segment === '.' ||
+    segment === '..' ||
+    segment.includes('/') ||
+    segment.includes('\\') ||
+    segment.includes('\0')
+  ) {
+    throw new RelayFilesystemError(`Unsafe ${label}: ${segment}`);
+  }
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return (error as NodeJS.ErrnoException)?.code === code;
+}
+
+function unsafe(message: string, cause?: unknown): never {
+  throw new RelayFilesystemError(message, cause === undefined ? undefined : { cause });
+}
+
+function syscallError(syscall: string, target: string): NodeJS.ErrnoException {
+  const errno = koffi.errno();
+  const code = errnoNames.get(errno) ?? `ERRNO_${errno}`;
+  const error = new Error(`${syscall} ${target}: ${nativeStrError(errno)}`) as NodeJS.ErrnoException;
+  error.code = code;
+  error.errno = errno;
+  error.syscall = syscall;
+  error.path = target;
+  return error;
+}
+
+function openAt(directoryFd: number, name: string, flags: number, mode = 0): number {
+  const fd =
+    flags & fs.constants.O_CREAT
+      ? nativeOpenAt(directoryFd, name, flags, 'uint32_t', mode)
+      : nativeOpenAt(directoryFd, name, flags);
+  if (fd < 0) throw syscallError('openat', name);
+  return fd;
+}
+
+function mkdirAt(directoryFd: number, name: string): void {
+  if (nativeMkdirAt(directoryFd, name, 0o700) < 0) throw syscallError('mkdirat', name);
+}
+
+function unlinkAt(directoryFd: number, name: string, flags = 0): void {
+  if (nativeUnlinkAt(directoryFd, name, flags) < 0) throw syscallError('unlinkat', name);
+}
+
+function renameAt(directoryFd: number, from: string, to: string): void {
+  if (nativeRenameAt(directoryFd, from, directoryFd, to) < 0) throw syscallError('renameat', `${from} -> ${to}`);
+}
+
+function verifyDirectoryFd(fd: number, label: string): fs.Stats {
+  const stat = fs.fstatSync(fd);
+  if (!stat.isDirectory()) unsafe(`Relay path is not a directory: ${label}`);
+  return stat;
+}
+
+function openDirectoryAt(
+  directoryFd: number,
+  name: string,
+  create: boolean,
+  label: string,
+  chmodExisting = false,
+): number | null {
+  assertPathSegment(name);
+  let created = false;
+  if (create) {
+    try {
+      mkdirAt(directoryFd, name);
+      created = true;
+    } catch (error) {
+      if (!isErrorCode(error, 'EEXIST')) throw error;
+    }
+  }
+
+  let fd: number;
+  try {
+    fd = openAt(directoryFd, name, READ_DIRECTORY_FLAGS);
+  } catch (error) {
+    if (!create && isErrorCode(error, 'ENOENT')) return null;
+    if (isErrorCode(error, 'ELOOP') || isErrorCode(error, 'ENOTDIR')) {
+      unsafe(`Refusing symlinked or non-directory relay path component: ${label}`, error);
+    }
+    throw error;
+  }
+  try {
+    verifyDirectoryFd(fd, label);
+    if (created || chmodExisting) {
+      try {
+        fs.fchmodSync(fd, 0o700);
+      } catch {
+        // best-effort on filesystems that support modes
+      }
+    }
+    return fd;
+  } catch (error) {
+    fs.closeSync(fd);
+    throw error;
+  }
+}
+
+export interface RelayDirent {
+  name: string;
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}
+
+const DT_DIRECTORY = 4;
+const DT_REGULAR = 8;
+const DT_SYMLINK = 10;
+
+function readDirectoryFd(fd: number): RelayDirent[] {
+  const duplicate = nativeDup(fd);
+  if (duplicate < 0) throw syscallError('dup', String(fd));
+  const directory = nativeFdOpenDir(duplicate);
+  if (directory === null) {
+    fs.closeSync(duplicate);
+    throw syscallError('fdopendir', String(fd));
+  }
+
+  const entries: RelayDirent[] = [];
+  try {
+    for (;;) {
+      koffi.errno(0);
+      const pointer = nativeReadDir(directory);
+      if (pointer === null) {
+        if (koffi.errno() !== 0) throw syscallError('readdir', String(fd));
+        break;
+      }
+      const bytes = Buffer.from(koffi.view(pointer, process.platform === 'darwin' ? 1048 : 280));
+      const type = bytes[process.platform === 'darwin' ? 20 : 18]!;
+      const nameOffset = process.platform === 'darwin' ? 21 : 19;
+      const nameLength =
+        process.platform === 'darwin'
+          ? bytes.readUInt16LE(18)
+          : bytes.subarray(nameOffset).indexOf(0) === -1
+            ? bytes.length - nameOffset
+            : bytes.subarray(nameOffset).indexOf(0);
+      const name = bytes.subarray(nameOffset, nameOffset + nameLength).toString();
+      if (name === '.' || name === '..') continue;
+      entries.push({
+        name,
+        isFile: () => type === DT_REGULAR,
+        isDirectory: () => type === DT_DIRECTORY,
+        isSymbolicLink: () => type === DT_SYMLINK,
+      });
+    }
+  } finally {
+    nativeCloseDir(directory);
+  }
+  return entries;
+}
+
+function openRegularFileAt(directoryFd: number, name: string, flags: number, mode = 0): number | null {
+  assertPathSegment(name, 'relay file name');
+  let fd: number;
+  try {
+    fd = openAt(directoryFd, name, flags | NOFOLLOW | CLOEXEC, mode);
+  } catch (error) {
+    if (isErrorCode(error, 'ENOENT')) return null;
+    if (isErrorCode(error, 'ELOOP')) unsafe(`Refusing symlinked relay file: ${name}`, error);
+    throw error;
+  }
+  try {
+    if (!fs.fstatSync(fd).isFile()) unsafe(`Relay path is not a regular file: ${name}`);
+    return fd;
+  } catch (error) {
+    fs.closeSync(fd);
+    throw error;
+  }
+}
+
+/** A pinned directory descriptor. All child and leaf access is relative to this descriptor. */
+export class RelayDirectoryHandle {
+  readonly #fd: number;
+  readonly #label: string;
+  #closed = false;
+
+  constructor(fd: number, label: string) {
+    this.#fd = fd;
+    this.#label = label;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    fs.closeSync(this.#fd);
+  }
+
+  openDirectory(name: string, create = false): RelayDirectoryHandle | null {
+    this.#assertOpen();
+    const label = `${this.#label}/${name}`;
+    const fd = openDirectoryAt(this.#fd, name, create, label, create);
+    return fd === null ? null : new RelayDirectoryHandle(fd, label);
+  }
+
+  readDirectory(): RelayDirent[] {
+    this.#assertOpen();
+    return readDirectoryFd(this.#fd);
+  }
+
+  readFile(fileName: string): string | null {
+    this.#assertOpen();
+    const fd = openRegularFileAt(this.#fd, fileName, fs.constants.O_RDONLY);
+    if (fd === null) return null;
+    try {
+      return fs.readFileSync(fd, 'utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  writeFileAtomic(fileName: string, contents: string): void {
+    this.#assertOpen();
+    assertPathSegment(fileName, 'relay file name');
+
+    let temporary = '';
+    let fd: number | null = null;
+    for (let attempt = 0; attempt < 10; attempt++) {
+      temporary = `${fileName}.${randomBytes(16).toString('hex')}.tmp`;
+      try {
+        fd = openRegularFileAt(
+          this.#fd,
+          temporary,
+          fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL,
+          0o600,
+        );
+        break;
+      } catch (error) {
+        if (!isErrorCode(error, 'EEXIST')) throw error;
+      }
+    }
+    if (fd === null) throw new Error(`Could not create an exclusive relay temporary file for ${fileName}`);
+
+    let renamed = false;
+    try {
+      fs.writeFileSync(fd, contents, 'utf8');
+      fs.fsyncSync(fd);
+      this.verifyFile(fileName);
+      renameAt(this.#fd, temporary, fileName);
+      renamed = true;
+    } finally {
+      fs.closeSync(fd);
+      if (!renamed) {
+        try {
+          unlinkAt(this.#fd, temporary);
+        } catch {
+          // best-effort cleanup of the random file created by this call
+        }
+      }
+    }
+  }
+
+  unlinkFile(fileName: string): boolean {
+    this.#assertOpen();
+    const fd = openRegularFileAt(this.#fd, fileName, fs.constants.O_RDONLY);
+    if (fd === null) return false;
+    fs.closeSync(fd);
+    try {
+      unlinkAt(this.#fd, fileName);
+      return true;
+    } catch (error) {
+      if (isErrorCode(error, 'ENOENT')) return false;
+      throw error;
+    }
+  }
+
+  fileExists(fileName: string): boolean {
+    this.#assertOpen();
+    const fd = openRegularFileAt(this.#fd, fileName, fs.constants.O_RDONLY);
+    if (fd === null) return false;
+    fs.closeSync(fd);
+    return true;
+  }
+
+  verifyFile(fileName: string): void {
+    this.#assertOpen();
+    const fd = openRegularFileAt(this.#fd, fileName, fs.constants.O_RDONLY);
+    if (fd !== null) fs.closeSync(fd);
+  }
+
+  appendFile(fileName: string, contents: string): number {
+    this.#assertOpen();
+    const fd = openRegularFileAt(
+      this.#fd,
+      fileName,
+      fs.constants.O_WRONLY | fs.constants.O_APPEND | fs.constants.O_CREAT,
+      0o600,
+    );
+    if (fd === null) throw new Error(`Could not open relay file for append: ${fileName}`);
+    try {
+      fs.writeFileSync(fd, contents, 'utf8');
+      return fs.fstatSync(fd).size;
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  renameFile(fromName: string, toName: string): void {
+    this.#assertOpen();
+    const from = openRegularFileAt(this.#fd, fromName, fs.constants.O_RDONLY);
+    if (from === null) return;
+    fs.closeSync(from);
+    this.verifyFile(toName);
+    renameAt(this.#fd, fromName, toName);
+  }
+
+  removeDirectory(name: string): void {
+    this.#assertOpen();
+    const directory = this.openDirectory(name);
+    if (directory === null) return;
+    try {
+      for (const entry of directory.readDirectory()) {
+        if (entry.isSymbolicLink()) unsafe(`Refusing symlinked relay entry: ${entry.name}`);
+        if (!entry.isFile()) unsafe(`Relay directory contains a non-file entry: ${entry.name}`);
+        directory.unlinkFile(entry.name);
+      }
+      unlinkAt(this.#fd, name, AT_REMOVEDIR);
+    } finally {
+      directory.close();
+    }
+  }
+
+  watch(listener: () => void): RelayWatcher {
+    this.#assertOpen();
+    let previous = fs.fstatSync(this.#fd).mtimeMs;
+    const timer = setInterval(() => {
+      const current = fs.fstatSync(this.#fd).mtimeMs;
+      if (current !== previous) {
+        previous = current;
+        listener();
+      }
+    }, 250);
+    timer.unref();
+    return {
+      close: () => clearInterval(timer),
+      unref: () => timer.unref(),
+    };
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) throw new Error('Relay directory descriptor is closed');
+  }
+}
+
+export interface RelayWatcher {
+  close(): void;
+  unref(): void;
+}
+
+/** Open every configured-root component without following symlinks and return the pinned root descriptor. */
+export function openRelayRoot(root: string, create = false): RelayDirectoryHandle | null {
+  const absolute = path.resolve(root);
+  const components = absolute.split(path.sep).filter(Boolean);
+  let fd = fs.openSync(path.parse(absolute).root, READ_DIRECTORY_FLAGS);
+  try {
+    verifyDirectoryFd(fd, path.parse(absolute).root);
+    for (const [index, component] of components.entries()) {
+      const next = openDirectoryAt(fd, component, create, absolute, create && index === components.length - 1);
+      if (next === null) return null;
+      fs.closeSync(fd);
+      fd = next;
+    }
+    const handle = new RelayDirectoryHandle(fd, absolute);
+    fd = -1;
+    return handle;
+  } finally {
+    if (fd >= 0) fs.closeSync(fd);
+  }
+}

--- a/packages/relay/filesystem.ts
+++ b/packages/relay/filesystem.ts
@@ -106,8 +106,14 @@ function unlinkAt(directoryFd: number, name: string, flags = 0): void {
   if (nativeUnlinkAt(directoryFd, name, flags) < 0) throw syscallError('unlinkat', name);
 }
 
-function renameAt(directoryFd: number, from: string, to: string): void {
-  if (nativeRenameAt(directoryFd, from, directoryFd, to) < 0) throw syscallError('renameat', `${from} -> ${to}`);
+function renameAt(fromDirectoryFd: number, from: string, toDirectoryFd: number, to: string): void {
+  if (nativeRenameAt(fromDirectoryFd, from, toDirectoryFd, to) < 0) {
+    throw syscallError('renameat', `${from} -> ${to}`);
+  }
+}
+
+function sameFile(left: fs.Stats, right: fs.Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
 }
 
 function verifyDirectoryFd(fd: number, label: string): fs.Stats {
@@ -355,7 +361,8 @@ export class RelayDirectoryHandle {
       fs.writeFileSync(fd, contents, 'utf8');
       fs.fsyncSync(fd);
       this.verifyFile(fileName);
-      renameAt(this.#fd, temporary, fileName);
+      renameAt(this.#fd, temporary, this.#fd, fileName);
+      this.sync();
       renamed = true;
     } finally {
       fs.closeSync(fd);
@@ -420,7 +427,98 @@ export class RelayDirectoryHandle {
     if (from === null) return;
     fs.closeSync(from);
     this.verifyFile(toName);
-    renameAt(this.#fd, fromName, toName);
+    renameAt(this.#fd, fromName, this.#fd, toName);
+  }
+
+  /** Atomically move one pinned child directory beneath another pinned directory. */
+  moveDirectoryTo(name: string, target: RelayDirectoryHandle, targetName: string): RelayDirectoryHandle | null {
+    this.#assertOpen();
+    target.#assertOpen();
+    assertPathSegment(name);
+    assertPathSegment(targetName);
+
+    const source = this.openDirectory(name);
+    if (source === null) return null;
+    try {
+      const existing = target.openDirectory(targetName);
+      if (existing !== null) {
+        existing.close();
+        unsafe(`Relay destination directory already exists: ${targetName}`);
+      }
+
+      const sourceStat = fs.fstatSync(source.#fd);
+      renameAt(this.#fd, name, target.#fd, targetName);
+      const moved = target.openDirectory(targetName);
+      if (moved === null) unsafe(`Relay directory move disappeared: ${targetName}`);
+      try {
+        if (!sameFile(sourceStat, fs.fstatSync(moved.#fd))) {
+          unsafe(`Relay directory changed during move: ${name}`);
+        }
+      } finally {
+        moved.close();
+      }
+      this.sync();
+      target.sync();
+      return source;
+    } catch (error) {
+      source.close();
+      throw error;
+    }
+  }
+
+  /** Atomically move one regular file between pinned directories without following links. */
+  moveFileTo(fileName: string, target: RelayDirectoryHandle, targetName = fileName): boolean {
+    this.#assertOpen();
+    target.#assertOpen();
+    assertPathSegment(fileName, 'relay file name');
+    assertPathSegment(targetName, 'relay file name');
+
+    const sourceFd = openRegularFileAt(this.#fd, fileName, fs.constants.O_RDONLY);
+    if (sourceFd === null) return false;
+    try {
+      if (target.fileExists(targetName)) return false;
+      const sourceStat = fs.fstatSync(sourceFd);
+      renameAt(this.#fd, fileName, target.#fd, targetName);
+      const movedFd = openRegularFileAt(target.#fd, targetName, fs.constants.O_RDONLY);
+      if (movedFd === null) unsafe(`Relay file move disappeared: ${targetName}`);
+      try {
+        if (!sameFile(sourceStat, fs.fstatSync(movedFd))) unsafe(`Relay file changed during move: ${fileName}`);
+      } finally {
+        fs.closeSync(movedFd);
+      }
+      this.sync();
+      target.sync();
+      return true;
+    } finally {
+      fs.closeSync(sourceFd);
+    }
+  }
+
+  /** Remove a child directory only when it is still a real, empty directory. */
+  removeEmptyDirectory(name: string): boolean {
+    this.#assertOpen();
+    const directory = this.openDirectory(name);
+    if (directory === null) return false;
+    try {
+      if (directory.readDirectory().length > 0) return false;
+      try {
+        unlinkAt(this.#fd, name, AT_REMOVEDIR);
+        this.sync();
+        return true;
+      } catch (error) {
+        if (isErrorCode(error, 'ENOENT') || isErrorCode(error, 'ENOTEMPTY') || isErrorCode(error, 'EEXIST')) {
+          return false;
+        }
+        throw error;
+      }
+    } finally {
+      directory.close();
+    }
+  }
+
+  sync(): void {
+    this.#assertOpen();
+    fs.fsyncSync(this.#fd);
   }
 
   removeDirectory(name: string): void {

--- a/packages/relay/index.ts
+++ b/packages/relay/index.ts
@@ -34,6 +34,7 @@ import {
   clearAsk,
   drain,
   deposit,
+  outgoingAskIds,
   pendingAsks,
   previewBody,
   readAudit,
@@ -770,15 +771,7 @@ export default function relay(pi: ExtensionAPI) {
 
 /** Find an outgoing ask id by exact id or unique prefix (for cancel ergonomics). */
 function resolveOutAskId(root: string, addr: string, idOrPrefix: string): string | undefined {
-  let names: string[];
-  try {
-    names = fs.readdirSync(path.join(root, `${addr}.asks`));
-  } catch {
-    return undefined;
-  }
-  const ids = names
-    .filter((f) => f.startsWith('out-') && f.endsWith('.json'))
-    .map((f) => f.slice('out-'.length, -'.json'.length));
+  const ids = outgoingAskIds(root, addr);
   if (ids.includes(idOrPrefix)) return idOrPrefix;
   const matches = ids.filter((id) => id.startsWith(idOrPrefix));
   return matches.length === 1 ? matches[0] : undefined;

--- a/packages/relay/mailbox.ts
+++ b/packages/relay/mailbox.ts
@@ -14,6 +14,7 @@
  *   body, only a short preview.
  */
 
+import { randomBytes } from 'node:crypto';
 import * as path from 'node:path';
 import {
   assertPathSegment,
@@ -37,10 +38,37 @@ export interface Letter {
 
 export const MAX_BODY_CHARS = 32 * 1024;
 
+const MESSAGE_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$/;
+const INBOX_FILE_TOKEN_PATTERN = /^(0|[1-9][0-9]*)-([a-zA-Z0-9][a-zA-Z0-9_-]{0,127})\.json$/;
+const INBOX_CLAIM_TOKEN_PATTERN = /^[a-f0-9]{32}$/;
+
 function letterFileName(letter: Letter): string {
-  const name = `${letter.ts}-${letter.id.slice(0, 6)}.json`;
+  if (!MESSAGE_ID_PATTERN.test(letter.id)) throw new TypeError(`Invalid relay message id: ${letter.id}`);
+  if (!Number.isSafeInteger(letter.ts) || letter.ts < 0) {
+    throw new TypeError(`Invalid relay letter timestamp: ${letter.ts}`);
+  }
+  const name = `${letter.ts}-${letter.id}.json`;
   assertPathSegment(name, 'relay letter file name');
   return name;
+}
+
+function inboxFileTokenParts(fileToken: string): { ts: number; id: string } | null {
+  const match = INBOX_FILE_TOKEN_PATTERN.exec(fileToken);
+  if (match === null) return null;
+  const ts = Number(match[1]);
+  return Number.isSafeInteger(ts) ? { ts, id: match[2]! } : null;
+}
+
+function assertInboxClaimToken(claimToken: string): void {
+  if (!INBOX_CLAIM_TOKEN_PATTERN.test(claimToken)) {
+    throw new TypeError(`Invalid relay inbox claim token: ${claimToken}`);
+  }
+}
+
+function assertInboxFileToken(fileToken: string): void {
+  if (inboxFileTokenParts(fileToken) === null) {
+    throw new TypeError(`Invalid relay inbox file token: ${fileToken}`);
+  }
 }
 
 /** Atomic deposit: write to a random exclusive tmp sibling, then rename into place. */
@@ -188,12 +216,252 @@ export function watchInbox(root: string, addr: string, onMail: () => void): () =
   };
 }
 
+// ── Durable inbox claims ────────────────────────────────────────────────
+// A claim atomically renames the current inbox beneath <addr>.claims and
+// immediately creates a fresh inbox for new deposits. Tokens, never paths,
+// are the public persistence boundary for crash recovery.
+
+export interface InboxClaim {
+  claimToken: string;
+  fileTokens: string[];
+}
+
+function claimsDirectoryName(addr: string): string {
+  return `${addr}.claims`;
+}
+
+function inboxFileTokens(directory: RelayDirectoryHandle): string[] {
+  return directory
+    .readDirectory()
+    .filter((entry) => {
+      if (inboxFileTokenParts(entry.name) === null) return false;
+      if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked claimed letter: ${entry.name}`);
+      return entry.isFile();
+    })
+    .map((entry) => entry.name)
+    .sort();
+}
+
+/** Atomically detach the current non-empty inbox and return its durable tokens. */
+export function claimInbox(root: string, addr: string): InboxClaim | null {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root, true)!;
+  try {
+    const inboxName = `${addr}.inbox`;
+    const inbox = relay.openDirectory(inboxName);
+    if (inbox === null) return null;
+    try {
+      if (inboxFileTokens(inbox).length === 0) return null;
+    } finally {
+      inbox.close();
+    }
+
+    const claims = relay.openDirectory(claimsDirectoryName(addr), true)!;
+    try {
+      let claimToken = '';
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const candidate = randomBytes(16).toString('hex');
+        const existing = claims.openDirectory(candidate);
+        if (existing === null) {
+          claimToken = candidate;
+          break;
+        }
+        existing.close();
+      }
+      if (claimToken === '') throw new Error('Could not allocate an exclusive relay inbox claim token');
+
+      const claimed = relay.moveDirectoryTo(inboxName, claims, claimToken);
+      if (claimed === null) return null;
+      try {
+        claimed.sync();
+        claims.sync();
+        const replacement = relay.openDirectory(inboxName, true)!;
+        replacement.close();
+        relay.sync();
+        return { claimToken, fileTokens: inboxFileTokens(claimed) };
+      } finally {
+        claimed.close();
+      }
+    } finally {
+      claims.close();
+    }
+  } finally {
+    relay.close();
+  }
+}
+
+/** Enumerate durable claims left by this or a crashed consumer. */
+export function recoverInboxClaims(root: string, addr: string): InboxClaim[] {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
+  try {
+    const claims = relay.openDirectory(claimsDirectoryName(addr));
+    if (claims === null) return [];
+    try {
+      const out: InboxClaim[] = [];
+      for (const entry of claims.readDirectory()) {
+        if (!INBOX_CLAIM_TOKEN_PATTERN.test(entry.name)) continue;
+        if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked inbox claim: ${entry.name}`);
+        if (!entry.isDirectory()) continue;
+        const claim = claims.openDirectory(entry.name);
+        if (claim === null) continue;
+        try {
+          out.push({ claimToken: entry.name, fileTokens: inboxFileTokens(claim) });
+        } finally {
+          claim.close();
+        }
+      }
+      return out.sort((left, right) => left.claimToken.localeCompare(right.claimToken));
+    } finally {
+      claims.close();
+    }
+  } finally {
+    relay.close();
+  }
+}
+
+/** Read and validate one claimed letter without exposing or following a path. */
+export function readClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): Letter | null {
+  assertPathSegment(addr, 'relay address');
+  assertInboxClaimToken(claimToken);
+  assertInboxFileToken(fileToken);
+  const expected = inboxFileTokenParts(fileToken)!;
+  const relay = openRelayRoot(root);
+  if (relay === null) return null;
+  try {
+    const claims = relay.openDirectory(claimsDirectoryName(addr));
+    if (claims === null) return null;
+    try {
+      const claim = claims.openDirectory(claimToken);
+      if (claim === null) return null;
+      try {
+        const raw = claim.readFile(fileToken);
+        if (raw === null) return null;
+        const parsed = JSON.parse(raw) as Letter;
+        if (
+          parsed === null ||
+          typeof parsed !== 'object' ||
+          parsed.id !== expected.id ||
+          parsed.ts !== expected.ts ||
+          typeof parsed.body !== 'string'
+        ) {
+          return null;
+        }
+        return parsed;
+      } catch (error) {
+        rethrowFilesystemError(error);
+        return null;
+      } finally {
+        claim.close();
+      }
+    } finally {
+      claims.close();
+    }
+  } finally {
+    relay.close();
+  }
+}
+
+function finishClaimedLetter(
+  root: string,
+  addr: string,
+  claimToken: string,
+  fileToken: string,
+  requeue: boolean,
+): boolean {
+  assertPathSegment(addr, 'relay address');
+  assertInboxClaimToken(claimToken);
+  assertInboxFileToken(fileToken);
+  const relay = openRelayRoot(root, requeue);
+  if (relay === null) return false;
+  try {
+    const claims = relay.openDirectory(claimsDirectoryName(addr));
+    if (claims === null) return false;
+    try {
+      const claim = claims.openDirectory(claimToken);
+      if (claim === null) return false;
+      let finished: boolean;
+      try {
+        if (requeue) {
+          const inbox = relay.openDirectory(`${addr}.inbox`, true)!;
+          try {
+            finished = claim.moveFileTo(fileToken, inbox);
+            relay.sync();
+          } finally {
+            inbox.close();
+          }
+        } else {
+          finished = claim.unlinkFile(fileToken);
+          if (finished) claim.sync();
+        }
+      } finally {
+        claim.close();
+      }
+      if (finished) claims.removeEmptyDirectory(claimToken);
+      return finished;
+    } finally {
+      claims.close();
+    }
+  } finally {
+    relay.close();
+  }
+}
+
+/** Permanently acknowledge/delete one claimed letter. Idempotent. */
+export function ackClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): boolean {
+  return finishClaimedLetter(root, addr, claimToken, fileToken, false);
+}
+
+/** Atomically return one claimed letter to the current inbox. */
+export function requeueClaimedLetter(root: string, addr: string, claimToken: string, fileToken: string): boolean {
+  return finishClaimedLetter(root, addr, claimToken, fileToken, true);
+}
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function fileExistsInClaims(relay: RelayDirectoryHandle, addr: string, fileName: string): boolean {
+  const claims = relay.openDirectory(claimsDirectoryName(addr));
+  if (claims === null) return false;
+  try {
+    for (const entry of claims.readDirectory()) {
+      if (!INBOX_CLAIM_TOKEN_PATTERN.test(entry.name)) continue;
+      if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked inbox claim: ${entry.name}`);
+      if (!entry.isDirectory()) continue;
+      const claim = claims.openDirectory(entry.name);
+      if (claim === null) continue;
+      try {
+        if (claim.fileExists(fileName)) return true;
+      } finally {
+        claim.close();
+      }
+    }
+    return false;
+  } finally {
+    claims.close();
+  }
+}
+
+function receiptFileExists(relay: RelayDirectoryHandle, addr: string, fileName: string): boolean {
+  // Check claims on both sides of the live inbox. This avoids observing a
+  // false absence while a descriptor-relative rename moves in either
+  // direction between a claim and the current inbox.
+  if (fileExistsInClaims(relay, addr, fileName)) return true;
+  const inbox = relay.openDirectory(`${addr}.inbox`);
+  if (inbox !== null) {
+    try {
+      if (inbox.fileExists(fileName)) return true;
+    } finally {
+      inbox.close();
+    }
+  }
+  return fileExistsInClaims(relay, addr, fileName);
+}
 
 /**
  * Consumption receipt: after depositing to a LIVE target, wait briefly for
- * the letter to vanish. 'delivered' means the receiver's drainer took it —
- * stronger than any transport ack.
+ * the exact letter to vanish from both the live inbox and durable claims.
+ * 'delivered' means the receiver acknowledged it, not merely claimed it.
  */
 export async function awaitReceipt(
   root: string,
@@ -205,19 +473,13 @@ export async function awaitReceipt(
   const relay = openRelayRoot(root);
   if (relay === null) return 'delivered';
   try {
-    const inbox = relay.openDirectory(`${toAddr}.inbox`);
-    if (inbox === null) return 'delivered';
-    try {
-      const fileName = letterFileName(letter);
-      const deadline = Date.now() + timeoutMs;
-      while (Date.now() < deadline) {
-        if (!inbox.fileExists(fileName)) return 'delivered';
-        await sleep(100);
-      }
-      return inbox.fileExists(fileName) ? 'queued' : 'delivered';
-    } finally {
-      inbox.close();
+    const fileName = letterFileName(letter);
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!receiptFileExists(relay, toAddr, fileName)) return 'delivered';
+      await sleep(100);
     }
+    return receiptFileExists(relay, toAddr, fileName) ? 'queued' : 'delivered';
   } finally {
     relay.close();
   }

--- a/packages/relay/mailbox.ts
+++ b/packages/relay/mailbox.ts
@@ -14,9 +14,15 @@
  *   body, only a short preview.
  */
 
-import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { asksDir, inboxDir } from './registry.js';
+import {
+  assertPathSegment,
+  openRelayRoot,
+  rethrowFilesystemError,
+  RelayDirectoryHandle,
+  RelayFilesystemError,
+  type RelayWatcher,
+} from './filesystem.js';
 
 export type LetterKind = 'message' | 'ask' | 'reply' | 'cancel';
 
@@ -32,27 +38,38 @@ export interface Letter {
 export const MAX_BODY_CHARS = 32 * 1024;
 
 function letterFileName(letter: Letter): string {
-  return `${letter.ts}-${letter.id.slice(0, 6)}.json`;
+  const name = `${letter.ts}-${letter.id.slice(0, 6)}.json`;
+  assertPathSegment(name, 'relay letter file name');
+  return name;
 }
 
-/** Atomic deposit: write to a tmp sibling, then rename into place. */
+/** Atomic deposit: write to a random exclusive tmp sibling, then rename into place. */
 export function deposit(root: string, toAddr: string, letter: Letter): void {
-  const dir = inboxDir(root, toAddr);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  const name = letterFileName(letter);
-  const tmp = path.join(dir, `${name}.${process.pid}.tmp`);
-  fs.writeFileSync(tmp, JSON.stringify(letter), { mode: 0o600 });
-  fs.renameSync(tmp, path.join(dir, name));
-  // Send-side choke point: every send/ask/reply/cancel goes through here.
-  appendAudit(root, {
-    ts: Date.now(),
-    event: 'deposit',
-    kind: letter.kind,
-    from: letter.from.addr,
-    to: toAddr,
-    messageId: letter.id,
-    preview: previewBody(letter.body),
-  });
+  assertPathSegment(toAddr, 'relay address');
+  const relay = openRelayRoot(root, true)!;
+  try {
+    // Refuse an unsafe audit target before committing the atomic letter; this
+    // avoids reporting failure after a delivery has already landed.
+    relay.verifyFile('audit.log');
+    const inbox = relay.openDirectory(`${toAddr}.inbox`, true)!;
+    try {
+      inbox.writeFileAtomic(letterFileName(letter), JSON.stringify(letter));
+    } finally {
+      inbox.close();
+    }
+    // Send-side choke point: every send/ask/reply/cancel goes through here.
+    appendAuditToDirectory(relay, {
+      ts: Date.now(),
+      event: 'deposit',
+      kind: letter.kind,
+      from: letter.from.addr,
+      to: toAddr,
+      messageId: letter.id,
+      preview: previewBody(letter.body),
+    });
+  } finally {
+    relay.close();
+  }
 }
 
 /**
@@ -62,47 +79,78 @@ export function deposit(root: string, toAddr: string, letter: Letter): void {
  * caller must re-deposit any letter it fails to deliver (checkInbox does).
  */
 export function drain(root: string, addr: string): Letter[] {
-  const dir = inboxDir(root, addr);
-  let names: string[];
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
   try {
-    names = fs
-      .readdirSync(dir)
-      .filter((f) => f.endsWith('.json'))
-      .sort();
-  } catch {
-    return [];
-  }
-  const out: Letter[] = [];
-  for (const name of names) {
-    const file = path.join(dir, name);
-    let raw: string;
+    const inbox = relay.openDirectory(`${addr}.inbox`);
+    if (inbox === null) return [];
     try {
-      raw = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue;
-    }
-    try {
-      fs.unlinkSync(file);
-    } catch {
-      continue; // another drainer took it
-    }
-    try {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed.id === 'string' && typeof parsed.body === 'string') {
-        out.push(parsed as Letter);
+      const names = inbox
+        .readDirectory()
+        .filter((entry) => {
+          if (!entry.name.endsWith('.json')) return false;
+          if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay letter: ${entry.name}`);
+          return entry.isFile();
+        })
+        .map((entry) => entry.name)
+        .sort();
+      const out: Letter[] = [];
+      for (const name of names) {
+        let raw: string | null;
+        try {
+          raw = inbox.readFile(name);
+        } catch (error) {
+          rethrowFilesystemError(error);
+          continue;
+        }
+        if (raw === null) continue;
+        try {
+          if (!inbox.unlinkFile(name)) continue; // another drainer took it
+        } catch (error) {
+          rethrowFilesystemError(error);
+          continue;
+        }
+        try {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed.id === 'string' && typeof parsed.body === 'string') out.push(parsed as Letter);
+        } catch {
+          // corrupt letter — discarded, cannot fail future drains
+        }
       }
-    } catch {
-      // corrupt letter — discarded, cannot fail future drains
+      return out;
+    } finally {
+      inbox.close();
     }
+  } catch (error) {
+    rethrowFilesystemError(error);
+    return [];
+  } finally {
+    relay.close();
   }
-  return out;
 }
 
 export function unreadCount(root: string, addr: string): number {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return 0;
   try {
-    return fs.readdirSync(inboxDir(root, addr)).filter((f) => f.endsWith('.json')).length;
-  } catch {
+    const inbox = relay.openDirectory(`${addr}.inbox`);
+    if (inbox === null) return 0;
+    try {
+      return inbox.readDirectory().filter((entry) => {
+        if (!entry.name.endsWith('.json')) return false;
+        if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay letter: ${entry.name}`);
+        return entry.isFile();
+      }).length;
+    } finally {
+      inbox.close();
+    }
+  } catch (error) {
+    rethrowFilesystemError(error);
     return 0;
+  } finally {
+    relay.close();
   }
 }
 
@@ -113,20 +161,30 @@ export function unreadCount(root: string, addr: string): number {
  * a process alive.
  */
 export function watchInbox(root: string, addr: string, onMail: () => void): () => void {
-  const dir = inboxDir(root, addr);
-  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  let watcher: fs.FSWatcher | undefined;
+  assertPathSegment(addr, 'relay address');
+  let relay: RelayDirectoryHandle | null = null;
+  let inbox: RelayDirectoryHandle | null = null;
+  let watcher: RelayWatcher | undefined;
   try {
-    watcher = fs.watch(dir, () => onMail());
+    relay = openRelayRoot(root, true)!;
+    inbox = relay.openDirectory(`${addr}.inbox`, true)!;
+    watcher = inbox.watch(onMail);
     watcher.unref();
-  } catch {
-    // poll-only fallback
+  } catch (error) {
+    inbox?.close();
+    relay?.close();
+    inbox = null;
+    relay = null;
+    rethrowFilesystemError(error);
+    // poll-only fallback for ordinary watch failures
   }
   const poll = setInterval(onMail, 3000);
   poll.unref();
   return () => {
     watcher?.close();
     clearInterval(poll);
+    inbox?.close();
+    relay?.close();
   };
 }
 
@@ -143,13 +201,26 @@ export async function awaitReceipt(
   letter: Letter,
   timeoutMs = 1500,
 ): Promise<'delivered' | 'queued'> {
-  const file = path.join(inboxDir(root, toAddr), letterFileName(letter));
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!fs.existsSync(file)) return 'delivered';
-    await sleep(100);
+  assertPathSegment(toAddr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return 'delivered';
+  try {
+    const inbox = relay.openDirectory(`${toAddr}.inbox`);
+    if (inbox === null) return 'delivered';
+    try {
+      const fileName = letterFileName(letter);
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (!inbox.fileExists(fileName)) return 'delivered';
+        await sleep(100);
+      }
+      return inbox.fileExists(fileName) ? 'queued' : 'delivered';
+    } finally {
+      inbox.close();
+    }
+  } finally {
+    relay.close();
   }
-  return fs.existsSync(file) ? 'queued' : 'delivered';
 }
 
 // ── Ask tracking ─────────────────────────────────────────────────────────
@@ -164,55 +235,92 @@ export interface OutAsk {
   ts: number;
 }
 
-function asksPath(root: string, addr: string, askId: string): string {
-  return path.join(asksDir(root, addr), `${askId}.json`);
+function askFileName(askId: string): string {
+  assertPathSegment(askId, 'relay ask id');
+  return `${askId}.json`;
 }
 
-function outAskPath(root: string, addr: string, askId: string): string {
-  return path.join(asksDir(root, addr), `out-${askId}.json`);
+function outAskFileName(askId: string): string {
+  assertPathSegment(askId, 'relay ask id');
+  return `out-${askId}.json`;
 }
 
-function writeJson0600(file: string, value: unknown): void {
-  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-  const tmp = `${file}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(value), { mode: 0o600 });
-  fs.renameSync(tmp, file);
+function writeAskJson(root: string, addr: string, fileName: string, value: unknown): void {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root, true)!;
+  try {
+    const asks = relay.openDirectory(`${addr}.asks`, true)!;
+    try {
+      asks.writeFileAtomic(fileName, JSON.stringify(value));
+    } finally {
+      asks.close();
+    }
+  } finally {
+    relay.close();
+  }
 }
 
 export function trackIncomingAsk(root: string, addr: string, letter: Letter): void {
-  writeJson0600(asksPath(root, addr, letter.id), letter);
+  writeAskJson(root, addr, askFileName(letter.id), letter);
 }
 
 export function trackOutgoingAsk(root: string, addr: string, out: OutAsk): void {
-  writeJson0600(outAskPath(root, addr, out.askId), out);
+  writeAskJson(root, addr, outAskFileName(out.askId), out);
+}
+
+function readAskFile(root: string, addr: string, fileName: string): unknown | null {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return null;
+  try {
+    const asks = relay.openDirectory(`${addr}.asks`);
+    if (asks === null) return null;
+    try {
+      const raw = asks.readFile(fileName);
+      return raw === null ? null : JSON.parse(raw);
+    } finally {
+      asks.close();
+    }
+  } catch (error) {
+    rethrowFilesystemError(error);
+    return null;
+  } finally {
+    relay.close();
+  }
 }
 
 export function readIncomingAsk(root: string, addr: string, askId: string): Letter | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(asksPath(root, addr, askId), 'utf8'));
-    return parsed && typeof parsed.id === 'string' ? (parsed as Letter) : null;
-  } catch {
-    return null;
-  }
+  const parsed = readAskFile(root, addr, askFileName(askId));
+  return parsed && typeof (parsed as Letter).id === 'string' ? (parsed as Letter) : null;
 }
 
 export function readOutgoingAsk(root: string, addr: string, askId: string): OutAsk | null {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(outAskPath(root, addr, askId), 'utf8'));
-    return parsed && typeof parsed.toAddr === 'string' ? (parsed as OutAsk) : null;
-  } catch {
-    return null;
-  }
+  const parsed = readAskFile(root, addr, outAskFileName(askId));
+  return parsed && typeof (parsed as OutAsk).toAddr === 'string' ? (parsed as OutAsk) : null;
 }
 
 /** Remove both sides of an ask id (incoming and/or outgoing). Idempotent. */
 export function clearAsk(root: string, addr: string, askId: string): void {
-  for (const file of [asksPath(root, addr, askId), outAskPath(root, addr, askId)]) {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return;
+  try {
+    const asks = relay.openDirectory(`${addr}.asks`);
+    if (asks === null) return;
     try {
-      fs.unlinkSync(file);
-    } catch {
-      // already gone
+      for (const fileName of [askFileName(askId), outAskFileName(askId)]) {
+        try {
+          asks.unlinkFile(fileName);
+        } catch (error) {
+          rethrowFilesystemError(error);
+          // deletion remains best-effort for ordinary I/O failures
+        }
+      }
+    } finally {
+      asks.close();
     }
+  } finally {
+    relay.close();
   }
 }
 
@@ -252,37 +360,49 @@ export function auditLogPath(root: string): string {
 /** Audit log cap: at ~1 MB the current log becomes audit.log.1 (single generation) and a fresh log starts. */
 const AUDIT_MAX_BYTES = 1024 * 1024;
 
+function appendAuditToDirectory(directory: RelayDirectoryHandle, record: AuditRecord): void {
+  try {
+    const size = directory.appendFile('audit.log', `${JSON.stringify(record)}\n`);
+    // Bounded growth: rotate once past the cap, keeping one previous generation.
+    if (size > AUDIT_MAX_BYTES) directory.renameFile('audit.log', 'audit.log.1');
+  } catch {
+    // audit failure (including an unsafe path) never breaks the mail path
+  }
+}
+
 /** Append one audit record. Best-effort: never throws (audit must not break delivery). */
 export function appendAudit(root: string, record: AuditRecord): void {
+  let relay: RelayDirectoryHandle | null = null;
   try {
-    const file = auditLogPath(root);
-    if (!fs.existsSync(file)) fs.writeFileSync(file, '', { mode: 0o600 });
-    fs.appendFileSync(file, `${JSON.stringify(record)}\n`);
-    // Bounded growth: rotate once past the cap, keeping one previous generation.
-    if (fs.statSync(file).size > AUDIT_MAX_BYTES) {
-      fs.renameSync(file, `${file}.1`);
-    }
+    relay = openRelayRoot(root, true)!;
+    appendAuditToDirectory(relay, record);
   } catch {
-    // audit failure never breaks the mail path
+    // audit failure (including an unsafe path) never breaks the mail path
+  } finally {
+    relay?.close();
   }
 }
 
 /** Read the last `limit` audit entries (oldest-first within that tail). */
 export function readAudit(root: string, limit = 50): AuditRecord[] {
-  let raw: string;
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
+  let raw: string | null;
   try {
-    raw = fs.readFileSync(auditLogPath(root), 'utf8');
-  } catch {
+    raw = relay.readFile('audit.log');
+  } catch (error) {
+    rethrowFilesystemError(error);
     return [];
+  } finally {
+    relay.close();
   }
+  if (raw === null) return [];
   const out: AuditRecord[] = [];
   for (const line of raw.split('\n')) {
     if (line.length === 0) continue;
     try {
       const parsed = JSON.parse(line);
-      if (parsed && typeof parsed.ts === 'number' && typeof parsed.event === 'string') {
-        out.push(parsed as AuditRecord);
-      }
+      if (parsed && typeof parsed.ts === 'number' && typeof parsed.event === 'string') out.push(parsed as AuditRecord);
     } catch {
       // skip corrupt line — append-only, never fatal
     }
@@ -298,23 +418,70 @@ export function resolveAskByRef(root: string, addr: string, replyTo: string): Le
 
 /** Asks we have received and not yet answered, oldest first. */
 export function pendingAsks(root: string, addr: string): Letter[] {
-  let names: string[];
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
   try {
-    names = fs
-      .readdirSync(asksDir(root, addr))
-      .filter((f) => f.endsWith('.json') && !f.startsWith('out-'))
-      .sort();
-  } catch {
-    return [];
-  }
-  const out: Letter[] = [];
-  for (const name of names) {
+    const asks = relay.openDirectory(`${addr}.asks`);
+    if (asks === null) return [];
     try {
-      const parsed = JSON.parse(fs.readFileSync(path.join(asksDir(root, addr), name), 'utf8'));
-      if (parsed && typeof parsed.id === 'string') out.push(parsed as Letter);
-    } catch {
-      // skip corrupt entry
+      const names = asks
+        .readDirectory()
+        .filter((entry) => {
+          if (!entry.name.endsWith('.json') || entry.name.startsWith('out-')) return false;
+          if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay ask: ${entry.name}`);
+          return entry.isFile();
+        })
+        .map((entry) => entry.name)
+        .sort();
+      const out: Letter[] = [];
+      for (const name of names) {
+        try {
+          const raw = asks.readFile(name);
+          if (raw === null) continue;
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed.id === 'string') out.push(parsed as Letter);
+        } catch (error) {
+          rethrowFilesystemError(error);
+          // skip corrupt entry
+        }
+      }
+      return out;
+    } finally {
+      asks.close();
     }
+  } catch (error) {
+    rethrowFilesystemError(error);
+    return [];
+  } finally {
+    relay.close();
   }
-  return out;
+}
+
+/** Outgoing ask ids, used by the Pi entry point for prefix resolution. */
+export function outgoingAskIds(root: string, addr: string): string[] {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
+  try {
+    const asks = relay.openDirectory(`${addr}.asks`);
+    if (asks === null) return [];
+    try {
+      return asks
+        .readDirectory()
+        .filter((entry) => {
+          if (!entry.name.startsWith('out-') || !entry.name.endsWith('.json')) return false;
+          if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay ask: ${entry.name}`);
+          return entry.isFile();
+        })
+        .map((entry) => entry.name.slice('out-'.length, -'.json'.length));
+    } finally {
+      asks.close();
+    }
+  } catch (error) {
+    rethrowFilesystemError(error);
+    return [];
+  } finally {
+    relay.close();
+  }
 }

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -18,6 +18,7 @@
     "dist",
     "index.ts",
     "core.ts",
+    "filesystem.ts",
     "registry.ts",
     "mailbox.ts",
     "policy.ts",
@@ -38,6 +39,7 @@
     "build": "node ../../scripts/build.ts"
   },
   "dependencies": {
+    "koffi": "^3.1.4",
     "typebox": "^1.1.0"
   },
   "peerDependencies": {

--- a/packages/relay/registry.ts
+++ b/packages/relay/registry.ts
@@ -294,6 +294,59 @@ function dirHasJson(root: string, name: string): boolean {
   }
 }
 
+function claimsHaveJson(root: string, addr: string): boolean {
+  const relay = openRelayRoot(root);
+  if (relay === null) return false;
+  try {
+    const claims = relay.openDirectory(`${addr}.claims`);
+    if (claims === null) return false;
+    try {
+      for (const entry of claims.readDirectory()) {
+        if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay claim: ${entry.name}`);
+        if (!entry.isDirectory()) continue;
+        const claim = claims.openDirectory(entry.name);
+        if (claim === null) continue;
+        try {
+          if (
+            claim.readDirectory().some((file) => {
+              if (!file.name.endsWith('.json')) return false;
+              if (file.isSymbolicLink()) {
+                throw new RelayFilesystemError(`Refusing symlinked claimed letter: ${file.name}`);
+              }
+              return file.isFile();
+            })
+          ) {
+            return true;
+          }
+        } finally {
+          claim.close();
+        }
+      }
+      return false;
+    } finally {
+      claims.close();
+    }
+  } finally {
+    relay.close();
+  }
+}
+
+function removeClaims(directory: RelayDirectoryHandle, addr: string): void {
+  const claimsName = `${addr}.claims`;
+  const claims = directory.openDirectory(claimsName);
+  if (claims === null) return;
+  try {
+    for (const entry of claims.readDirectory()) {
+      if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay claim: ${entry.name}`);
+      if (!entry.isDirectory()) continue;
+      claims.removeDirectory(entry.name);
+    }
+  } finally {
+    claims.close();
+  }
+  directory.removeDirectory(claimsName);
+}
+
 /**
  * Reclaim dead sessions' files. Rules (mail outranks tidiness):
  * - a running session is never touched;
@@ -310,7 +363,10 @@ function dirHasJson(root: string, name: string): boolean {
 export function sweep(root: string, now: number = Date.now(), sessionExists?: (sessionId: string) => boolean): void {
   for (const record of listRecords(root)) {
     if (presenceOf(record, now) !== 'offline') continue;
-    const hasMail = dirHasJson(root, `${record.addr}.inbox`) || dirHasJson(root, `${record.addr}.asks`);
+    const hasMail =
+      dirHasJson(root, `${record.addr}.inbox`) ||
+      dirHasJson(root, `${record.addr}.asks`) ||
+      claimsHaveJson(root, record.addr);
     const expired = now - record.lastSeenAt >= SWEEP_MAIL_KEEP_MS;
     if (hasMail && !expired) continue;
     if (!expired && (sessionExists?.(record.sessionId) ?? true)) continue;
@@ -319,6 +375,7 @@ export function sweep(root: string, now: number = Date.now(), sessionExists?: (s
       try {
         relay.removeDirectory(`${record.addr}.inbox`);
         relay.removeDirectory(`${record.addr}.asks`);
+        removeClaims(relay, record.addr);
         try {
           relay.unlinkFile(`${record.addr}.json`);
         } catch (error) {

--- a/packages/relay/registry.ts
+++ b/packages/relay/registry.ts
@@ -16,8 +16,14 @@
  */
 
 import * as crypto from 'node:crypto';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
+import {
+  assertPathSegment,
+  openRelayRoot,
+  rethrowFilesystemError,
+  RelayDirectoryHandle,
+  RelayFilesystemError,
+} from './filesystem.js';
 
 export interface SessionRecord {
   addr: string;
@@ -42,23 +48,22 @@ export function deriveAddr(cwd: string, sessionId: string): string {
 }
 
 export function ensureRoot(root: string): void {
-  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
-  try {
-    fs.chmodSync(root, 0o700);
-  } catch {
-    // best-effort on filesystems that support modes
-  }
+  const directory = openRelayRoot(root, true)!;
+  directory.close();
 }
 
 export function recordPath(root: string, addr: string): string {
+  assertPathSegment(addr, 'relay address');
   return path.join(root, `${addr}.json`);
 }
 
 export function inboxDir(root: string, addr: string): string {
+  assertPathSegment(addr, 'relay address');
   return path.join(root, `${addr}.inbox`);
 }
 
 export function asksDir(root: string, addr: string): string {
+  assertPathSegment(addr, 'relay address');
   return path.join(root, `${addr}.asks`);
 }
 
@@ -80,15 +85,23 @@ export function aliasesDir(root: string): string {
 }
 
 export function aliasPath(root: string, name: string): string {
+  assertPathSegment(name, 'relay alias');
   return path.join(aliasesDir(root), `${name}.json`);
 }
 
 export function writeAlias(root: string, alias: AliasRecord): void {
-  const file = aliasPath(root, alias.name);
-  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-  const tmp = `${file}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(alias, null, 2), { mode: 0o600 });
-  fs.renameSync(tmp, file);
+  if (!isValidAliasName(alias.name)) throw new TypeError(`Invalid relay alias: ${alias.name}`);
+  const relay = openRelayRoot(root, true)!;
+  try {
+    const aliases = relay.openDirectory('aliases', true)!;
+    try {
+      aliases.writeFileAtomic(`${alias.name}.json`, JSON.stringify(alias, null, 2));
+    } finally {
+      aliases.close();
+    }
+  } finally {
+    relay.close();
+  }
 }
 
 /** Alias names: lowercase alnum start, then alnum/_/-, 1-32 chars. */
@@ -96,35 +109,65 @@ export function isValidAliasName(name: string): boolean {
   return /^[a-z0-9][a-z0-9_-]{0,31}$/.test(name);
 }
 
+function readAliasFromDirectory(directory: RelayDirectoryHandle, name: string): AliasRecord | null {
+  const raw = directory.readFile(`${name}.json`);
+  if (raw === null) return null;
+  const parsed = JSON.parse(raw);
+  if (parsed && typeof parsed.name === 'string' && typeof parsed.addr === 'string') return parsed as AliasRecord;
+  return null;
+}
+
 export function readAlias(root: string, name: string): AliasRecord | null {
   // The name can come from LLM-controlled tool input — never let it reach
   // the filesystem unvalidated (e.g. '@../../../../tmp/x').
   if (!isValidAliasName(name)) return null;
+  const relay = openRelayRoot(root);
+  if (relay === null) return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(aliasPath(root, name), 'utf8'));
-    if (parsed && typeof parsed.name === 'string' && typeof parsed.addr === 'string') {
-      return parsed as AliasRecord;
+    const aliases = relay.openDirectory('aliases');
+    if (aliases === null) return null;
+    try {
+      return readAliasFromDirectory(aliases, name);
+    } catch (error) {
+      rethrowFilesystemError(error);
+      return null;
+    } finally {
+      aliases.close();
     }
-    return null;
-  } catch {
-    return null;
+  } finally {
+    relay.close();
   }
 }
 
 export function listAliases(root: string): AliasRecord[] {
-  let entries: fs.Dirent[];
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
   try {
-    entries = fs.readdirSync(aliasesDir(root), { withFileTypes: true });
-  } catch {
+    const aliases = relay.openDirectory('aliases');
+    if (aliases === null) return [];
+    try {
+      const out: AliasRecord[] = [];
+      for (const entry of aliases.readDirectory()) {
+        if (!entry.name.endsWith('.json')) continue;
+        if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay alias: ${entry.name}`);
+        if (!entry.isFile()) continue;
+        try {
+          const alias = readAliasFromDirectory(aliases, entry.name.slice(0, -'.json'.length));
+          if (alias) out.push(alias);
+        } catch (error) {
+          rethrowFilesystemError(error);
+        }
+      }
+      return out.sort((a, b) => a.claimedAt - b.claimedAt);
+    } finally {
+      aliases.close();
+    }
+  } catch (error) {
+    rethrowFilesystemError(error);
     return [];
+  } finally {
+    relay.close();
   }
-  const out: AliasRecord[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
-    const alias = readAlias(root, entry.name.slice(0, -'.json'.length));
-    if (alias) out.push(alias);
-  }
-  return out.sort((a, b) => a.claimedAt - b.claimedAt);
 }
 
 /** Last-claim-wins: overwrites any prior owner. */
@@ -135,48 +178,80 @@ export function claimAlias(root: string, name: string, addr: string, sessionId: 
 }
 
 export function clearAlias(root: string, name: string): void {
+  if (!isValidAliasName(name)) return;
+  const relay = openRelayRoot(root);
+  if (relay === null) return;
   try {
-    fs.unlinkSync(aliasPath(root, name));
-  } catch {
-    // already gone
+    const aliases = relay.openDirectory('aliases');
+    if (aliases === null) return;
+    try {
+      aliases.unlinkFile(`${name}.json`);
+    } catch (error) {
+      rethrowFilesystemError(error);
+      // deletion remains best-effort for ordinary I/O failures
+    } finally {
+      aliases.close();
+    }
+  } finally {
+    relay.close();
   }
 }
 
 export function writeRecord(root: string, record: SessionRecord): void {
-  ensureRoot(root);
-  const file = recordPath(root, record.addr);
-  const tmp = `${file}.${process.pid}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(record, null, 2), { mode: 0o600 });
-  fs.renameSync(tmp, file);
+  const relay = openRelayRoot(root, true)!;
+  try {
+    relay.writeFileAtomic(`${record.addr}.json`, JSON.stringify(record, null, 2));
+  } finally {
+    relay.close();
+  }
+}
+
+function readRecordFromDirectory(directory: RelayDirectoryHandle, addr: string): SessionRecord | null {
+  const raw = directory.readFile(`${addr}.json`);
+  if (raw === null) return null;
+  const parsed = JSON.parse(raw);
+  if (parsed && typeof parsed.addr === 'string' && typeof parsed.pid === 'number') return parsed as SessionRecord;
+  return null;
 }
 
 export function readRecord(root: string, addr: string): SessionRecord | null {
+  assertPathSegment(addr, 'relay address');
+  const relay = openRelayRoot(root);
+  if (relay === null) return null;
   try {
-    const parsed = JSON.parse(fs.readFileSync(recordPath(root, addr), 'utf8'));
-    if (parsed && typeof parsed.addr === 'string' && typeof parsed.pid === 'number') {
-      return parsed as SessionRecord;
-    }
+    return readRecordFromDirectory(relay, addr);
+  } catch (error) {
+    rethrowFilesystemError(error);
     return null;
-  } catch {
-    return null;
+  } finally {
+    relay.close();
   }
 }
 
 /** Read-only listing, oldest first. Never mutates anything. */
 export function listRecords(root: string): SessionRecord[] {
-  let entries: fs.Dirent[];
+  const relay = openRelayRoot(root);
+  if (relay === null) return [];
   try {
-    entries = fs.readdirSync(root, { withFileTypes: true });
-  } catch {
+    const out: SessionRecord[] = [];
+    for (const entry of relay.readDirectory()) {
+      if (!entry.name.endsWith('.json')) continue;
+      if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay record: ${entry.name}`);
+      if (!entry.isFile()) continue;
+      try {
+        const record = readRecordFromDirectory(relay, entry.name.slice(0, -'.json'.length));
+        if (record) out.push(record);
+      } catch (error) {
+        rethrowFilesystemError(error);
+      }
+    }
+    return out.sort((a, b) => a.startedAt - b.startedAt);
+  } catch (error) {
+    rethrowFilesystemError(error);
     return [];
+  } finally {
+    relay.close();
   }
-  const out: SessionRecord[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
-    const record = readRecord(root, entry.name.slice(0, -'.json'.length));
-    if (record) out.push(record);
-  }
-  return out.sort((a, b) => a.startedAt - b.startedAt);
 }
 
 function pidAlive(pid: number): boolean {
@@ -196,19 +271,26 @@ export function presenceOf(record: SessionRecord, now: number = Date.now()): Pre
   return now - record.lastSeenAt < HEARTBEAT_STALE_MS ? 'live' : 'stalled';
 }
 
-function dirHasJson(dir: string): boolean {
+function dirHasJson(root: string, name: string): boolean {
+  const relay = openRelayRoot(root);
+  if (relay === null) return false;
   try {
-    return fs.readdirSync(dir).some((f) => f.endsWith('.json'));
-  } catch {
+    const directory = relay.openDirectory(name);
+    if (directory === null) return false;
+    try {
+      return directory.readDirectory().some((entry) => {
+        if (!entry.name.endsWith('.json')) return false;
+        if (entry.isSymbolicLink()) throw new RelayFilesystemError(`Refusing symlinked relay entry: ${entry.name}`);
+        return entry.isFile();
+      });
+    } finally {
+      directory.close();
+    }
+  } catch (error) {
+    rethrowFilesystemError(error);
     return false;
-  }
-}
-
-function rmrf(target: string): void {
-  try {
-    fs.rmSync(target, { recursive: true, force: true });
-  } catch {
-    // sweep is best-effort
+  } finally {
+    relay.close();
   }
 }
 
@@ -228,16 +310,24 @@ function rmrf(target: string): void {
 export function sweep(root: string, now: number = Date.now(), sessionExists?: (sessionId: string) => boolean): void {
   for (const record of listRecords(root)) {
     if (presenceOf(record, now) !== 'offline') continue;
-    const hasMail = dirHasJson(inboxDir(root, record.addr)) || dirHasJson(asksDir(root, record.addr));
+    const hasMail = dirHasJson(root, `${record.addr}.inbox`) || dirHasJson(root, `${record.addr}.asks`);
     const expired = now - record.lastSeenAt >= SWEEP_MAIL_KEEP_MS;
     if (hasMail && !expired) continue;
     if (!expired && (sessionExists?.(record.sessionId) ?? true)) continue;
-    rmrf(inboxDir(root, record.addr));
-    rmrf(asksDir(root, record.addr));
-    try {
-      fs.unlinkSync(recordPath(root, record.addr));
-    } catch {
-      // already gone
+    const relay = openRelayRoot(root);
+    if (relay !== null) {
+      try {
+        relay.removeDirectory(`${record.addr}.inbox`);
+        relay.removeDirectory(`${record.addr}.asks`);
+        try {
+          relay.unlinkFile(`${record.addr}.json`);
+        } catch (error) {
+          rethrowFilesystemError(error);
+          // deletion remains best-effort for ordinary I/O failures
+        }
+      } finally {
+        relay.close();
+      }
     }
   }
   // Aliases are swept when the owning session dies: an alias whose record

--- a/packages/relay/relay.test.ts
+++ b/packages/relay/relay.test.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from 'node:fs';
+import { createRequire, syncBuiltinESMExports } from 'node:module';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -25,6 +26,7 @@ import {
   pendingAsks,
   previewBody,
   readAudit,
+  readIncomingAsk,
   readOutgoingAsk,
   resolveAskByRef,
   trackIncomingAsk,
@@ -51,9 +53,10 @@ import {
   type SessionRecord,
 } from './registry.js';
 
+const require = createRequire(import.meta.url);
 const dirs: string[] = [];
 function tmpRoot(): string {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-relay-test-'));
+  const dir = fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'pi-relay-test-')));
   dirs.push(dir);
   return dir;
 }
@@ -61,6 +64,33 @@ function tmpRoot(): string {
 afterEach(() => {
   while (dirs.length > 0) fs.rmSync(dirs.pop()!, { recursive: true, force: true });
 });
+
+let swapSequence = 0;
+function swapWhenPinned(target: string, replacement: string, operation: () => void): string {
+  const parked = `${target}.pinned-${++swapSequence}`;
+  const identity = fs.statSync(target);
+  const mutableFs = require('node:fs') as { fstatSync: typeof fs.fstatSync };
+  const originalFstatSync = mutableFs.fstatSync;
+  let swapped = false;
+  mutableFs.fstatSync = ((fd: number) => {
+    const stat = originalFstatSync(fd);
+    if (!swapped && stat.dev === identity.dev && stat.ino === identity.ino) {
+      fs.renameSync(target, parked);
+      fs.renameSync(replacement, target);
+      swapped = true;
+    }
+    return stat;
+  }) as typeof fs.fstatSync;
+  syncBuiltinESMExports();
+  try {
+    operation();
+  } finally {
+    mutableFs.fstatSync = originalFstatSync;
+    syncBuiltinESMExports();
+  }
+  expect(swapped).toBe(true);
+  return parked;
+}
 
 function record(over: Partial<SessionRecord> = {}): SessionRecord {
   const now = Date.now();
@@ -102,6 +132,22 @@ describe('registry', () => {
     expect(presenceOf(record({ lastSeenAt: Date.now() - 60_000 }))).toBe('stalled');
     expect(presenceOf(record({ offline: true }))).toBe('offline');
     expect(presenceOf(record({ pid: 2_000_000_000 }))).toBe('offline'); // dead pid
+  });
+
+  it('uses random exclusive temp files without overwriting a predictable temp', () => {
+    const root = tmpRoot();
+    const value = record();
+    const outside = path.join(root, 'outside');
+    const predictable = path.join(root, `${value.addr}.json.${process.pid}.tmp`);
+    fs.writeFileSync(outside, 'outside-sentinel');
+    fs.symlinkSync(outside, predictable, 'file');
+
+    writeRecord(root, value);
+    writeRecord(root, { ...value, name: 'updated' });
+
+    expect(fs.readFileSync(outside, 'utf8')).toBe('outside-sentinel');
+    expect(fs.lstatSync(predictable).isSymbolicLink()).toBe(true);
+    expect(readRecord(root, value.addr)?.name).toBe('updated');
   });
 
   it('listing has no side effects and survives garbage files', () => {
@@ -237,6 +283,152 @@ describe('mailbox', () => {
     expect(unreadCount(root, addr)).toBe(1);
     // "resume": drain-on-start
     expect(drain(root, addr).map((l) => l.body)).toEqual(['while you were out']);
+  });
+});
+
+describe('descriptor-relative filesystem safety', () => {
+  it('keeps record reads on a pinned root after the configured root is swapped', () => {
+    const root = tmpRoot();
+    const replacement = `${root}.replacement`;
+    fs.mkdirSync(replacement);
+    writeRecord(root, record({ name: 'pinned' }));
+    writeRecord(replacement, record({ name: 'attacker' }));
+
+    const result: { current: SessionRecord | null } = { current: null };
+    const parked = swapWhenPinned(root, replacement, () => {
+      result.current = readRecord(root, record().addr);
+    });
+
+    expect(result.current?.name).toBe('pinned');
+    expect(JSON.parse(fs.readFileSync(path.join(root, `${record().addr}.json`), 'utf8')).name).toBe('attacker');
+    expect(JSON.parse(fs.readFileSync(path.join(parked, `${record().addr}.json`), 'utf8')).name).toBe('pinned');
+  });
+
+  it('deletes aliases through the pinned aliases descriptor after a child swap', () => {
+    const root = tmpRoot();
+    writeAlias(root, { name: 'ci', addr: 'aaaa1111bbbb', sessionId: 'pinned', claimedAt: 1 });
+    const aliases = path.join(root, 'aliases');
+    const replacement = path.join(root, 'aliases.replacement');
+    fs.mkdirSync(replacement);
+    fs.writeFileSync(path.join(replacement, 'ci.json'), '{"sessionId":"attacker"}');
+
+    const parked = swapWhenPinned(aliases, replacement, () => clearAlias(root, 'ci'));
+
+    expect(fs.existsSync(path.join(parked, 'ci.json'))).toBe(false);
+    expect(fs.readFileSync(path.join(aliases, 'ci.json'), 'utf8')).toContain('attacker');
+  });
+
+  it('appends audit records to the pinned root after a root swap', () => {
+    const root = tmpRoot();
+    const replacement = `${root}.replacement`;
+    fs.mkdirSync(replacement);
+    fs.writeFileSync(path.join(root, 'audit.log'), '');
+    fs.writeFileSync(path.join(replacement, 'audit.log'), 'attacker-sentinel\n');
+
+    const parked = swapWhenPinned(root, replacement, () =>
+      appendAudit(root, {
+        ts: 1,
+        event: 'deliver',
+        kind: 'message',
+        from: 'aaaa1111bbbb',
+        to: 'cccc2222dddd',
+        messageId: 'audit-race',
+        preview: 'safe',
+      }),
+    );
+
+    expect(fs.readFileSync(path.join(parked, 'audit.log'), 'utf8')).toContain('audit-race');
+    expect(fs.readFileSync(path.join(root, 'audit.log'), 'utf8')).toBe('attacker-sentinel\n');
+  });
+
+  it('deposits and drains through pinned inbox descriptors after child swaps', () => {
+    const depositRoot = tmpRoot();
+    const addr = 'race00000001';
+    const inbox = path.join(depositRoot, `${addr}.inbox`);
+    const replacement = `${inbox}.replacement`;
+    fs.mkdirSync(inbox);
+    fs.mkdirSync(replacement);
+    const deposited = letter({ id: 'deposit-race', ts: 1000 });
+
+    const parkedInbox = swapWhenPinned(inbox, replacement, () => deposit(depositRoot, addr, deposited));
+    expect(fs.readdirSync(inbox)).toEqual([]);
+    expect(fs.readdirSync(parkedInbox).some((name) => name.endsWith('.json'))).toBe(true);
+
+    const drainRoot = tmpRoot();
+    const drainInbox = path.join(drainRoot, `${addr}.inbox`);
+    const drainReplacement = `${drainInbox}.replacement`;
+    fs.mkdirSync(drainInbox);
+    fs.mkdirSync(drainReplacement);
+    fs.writeFileSync(path.join(drainInbox, '1000-pinned.json'), JSON.stringify(letter({ id: 'drain-race' })));
+    fs.writeFileSync(path.join(drainReplacement, '1000-attacker.json'), JSON.stringify(letter({ body: 'attacker' })));
+
+    let drained: Letter[] = [];
+    const parkedDrain = swapWhenPinned(drainInbox, drainReplacement, () => {
+      drained = drain(drainRoot, addr);
+    });
+    expect(drained.map((entry) => entry.id)).toEqual(['drain-race']);
+    expect(fs.readdirSync(parkedDrain)).toEqual([]);
+    expect(fs.readdirSync(drainInbox)).toEqual(['1000-attacker.json']);
+  });
+
+  it('reads and clears asks through the pinned asks descriptor after child swaps', () => {
+    const root = tmpRoot();
+    const addr = 'race00000002';
+    const ask = letter({ id: 'ask-race', kind: 'ask' });
+    trackIncomingAsk(root, addr, ask);
+    const asks = path.join(root, `${addr}.asks`);
+    const replacement = `${asks}.replacement`;
+    fs.mkdirSync(replacement);
+    fs.writeFileSync(
+      path.join(replacement, `${ask.id}.json`),
+      JSON.stringify(letter({ id: ask.id, body: 'attacker' })),
+    );
+
+    const result: { current: Letter | null } = { current: null };
+    const parked = swapWhenPinned(asks, replacement, () => {
+      result.current = readIncomingAsk(root, addr, ask.id);
+    });
+    expect(result.current?.body).toBe('hello');
+
+    const current = asks;
+    const secondReplacement = `${asks}.second-replacement`;
+    fs.mkdirSync(secondReplacement);
+    fs.writeFileSync(
+      path.join(secondReplacement, `${ask.id}.json`),
+      JSON.stringify(letter({ body: 'second-attacker' })),
+    );
+    const parkedReplacement = swapWhenPinned(current, secondReplacement, () => clearAsk(root, addr, ask.id));
+    expect(fs.existsSync(path.join(parkedReplacement, `${ask.id}.json`))).toBe(false);
+    expect(fs.existsSync(path.join(parked, `${ask.id}.json`))).toBe(true);
+    expect(fs.readFileSync(path.join(current, `${ask.id}.json`), 'utf8')).toContain('second-attacker');
+  });
+
+  it('keeps a watch on the pinned inbox and closes its descriptors', async () => {
+    const root = tmpRoot();
+    const descriptorDirectory = process.platform === 'darwin' ? '/dev/fd' : '/proc/self/fd';
+    const descriptorCount = () => fs.readdirSync(descriptorDirectory).length;
+    const addr = 'race00000003';
+    const inbox = path.join(root, `${addr}.inbox`);
+    const replacement = `${inbox}.replacement`;
+    fs.mkdirSync(inbox);
+    fs.mkdirSync(replacement);
+    let calls = 0;
+    let unwatch = () => {};
+    const before = descriptorCount();
+
+    const parked = swapWhenPinned(inbox, replacement, () => {
+      unwatch = watchInbox(root, addr, () => calls++);
+    });
+    expect(descriptorCount()).toBeGreaterThanOrEqual(before + 2);
+    try {
+      fs.writeFileSync(path.join(parked, 'mail.json'), '{}');
+      const deadline = Date.now() + 2000;
+      while (calls === 0 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(calls).toBeGreaterThan(0);
+    } finally {
+      unwatch();
+    }
+    expect(descriptorCount()).toBe(before);
   });
 });
 

--- a/packages/relay/relay.test.ts
+++ b/packages/relay/relay.test.ts
@@ -20,6 +20,7 @@ import {
   appendAudit,
   auditLogPath,
   awaitReceipt,
+  claimInbox,
   clearAsk,
   deposit,
   drain,
@@ -28,6 +29,7 @@ import {
   readAudit,
   readIncomingAsk,
   readOutgoingAsk,
+  recoverInboxClaims,
   resolveAskByRef,
   trackIncomingAsk,
   trackOutgoingAsk,
@@ -201,6 +203,19 @@ describe('registry', () => {
     sweep(root);
     expect(listRecords(root)).toHaveLength(1);
     expect(unreadCount(root, record().addr)).toBe(1);
+  });
+
+  it('treats a recoverable durable claim as undelivered mail', () => {
+    const root = tmpRoot();
+    const crashed = record({ offline: true, pid: 2_000_000_005 });
+    writeRecord(root, crashed);
+    deposit(root, crashed.addr, letter());
+    const claim = claimInbox(root, crashed.addr)!;
+
+    sweep(root, Date.now(), () => false);
+
+    expect(readRecord(root, crashed.addr)).not.toBeNull();
+    expect(recoverInboxClaims(root, crashed.addr)).toEqual([claim]);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
 
   packages/relay:
     dependencies:
+      koffi:
+        specifier: ^3.1.4
+        version: 3.1.4
       typebox:
         specifier: ^1.1.0
         version: 1.3.7
@@ -700,6 +703,81 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@koromix/koffi-darwin-arm64@3.1.4':
+    resolution: {integrity: sha512-/9o0uahf25sNXz7CczfMAsgdHrrrkDK3/d1W5ygJUC7QnpWo80103yTYpYahWP3vTABK5yjzKtURgssv1paskA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@koromix/koffi-darwin-x64@3.1.4':
+    resolution: {integrity: sha512-6IOhfAHbrySr6lYRU720Hg+IMQvtMpN08k9Ppf9WF8NxYRdHLnW1FJm7zCbClfrwudtjhS/piwDYwgAkO5u8cg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@koromix/koffi-freebsd-arm64@3.1.4':
+    resolution: {integrity: sha512-JKCWC0awdVvq7Nd/etn4PXFTa7uvyHn7IzqtaOZ3r4dJRdwQVby7Ai/wsQo8UUrJfAYlALkLYgFgU8wgsnAE/A==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-ia32@3.1.4':
+    resolution: {integrity: sha512-gU9pShDRLMZzftdGW+mTzyL8Cpa/7nzHPHe5vFakjGgtIzVFzdFBqwli4oB+tFsx44W1VqMMlvMMVlnz54ERiQ==}
+    cpu: [ia32]
+    os: [freebsd]
+
+  '@koromix/koffi-freebsd-x64@3.1.4':
+    resolution: {integrity: sha512-2kppLX97xBM3WoQET6noN4W02zT2fkFRXHYluAwcCcmkEax8AVJ1CYs6hxcZ3kaNPc+5P7yMw3V/b1lg2v3aMw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@koromix/koffi-linux-arm64@3.1.4':
+    resolution: {integrity: sha512-yYbypuGVGqrNchkAMY59kj+7TZ1c1u9lXRG1+74X9T8G4rOaushoVONNYLuu+ygpbwsKzz/NvEDtRioRU/dQlQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@koromix/koffi-linux-ia32@3.1.4':
+    resolution: {integrity: sha512-IoA/8Qfc6ZEmwMw2Nf4aSp9RfJnxh0UHhdqD4FsVXm0vC797kLMuzj744vv5tll+waVfjrU10jREqjtnMVFoQw==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@koromix/koffi-linux-loong64@3.1.4':
+    resolution: {integrity: sha512-ZUTdea+9dg6CV9J9CIGbhTh0FtSBgvcGKqDrlp9BVQF71jEDKOri1by/TrDe8yQUyC5kzWN8vWnkzES5wT0xDg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@koromix/koffi-linux-riscv64@3.1.4':
+    resolution: {integrity: sha512-CINyyhNYV/8MX52MGhYcik2G6PXH+KEU2JEO7dOONlsGol4lSGyW40RvYA4RQgNYk8q8imGSEScL08X8eOXnaA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@koromix/koffi-linux-x64@3.1.4':
+    resolution: {integrity: sha512-x3XnAy/tUTTCX/gMpV7VJNpOQIVQvzNhNYDrpyIeS9Q8/f1qLsE0vp0tj7A/YEDIfMVLqoJtyamfRJc04+vk4w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@koromix/koffi-openbsd-ia32@3.1.4':
+    resolution: {integrity: sha512-r9p/fffvmBm7+iT5BZ+c17gZJ280jvmbinrPZqjG14rF9I4lk7xrlV79YfsexkeN4mcPjF2hSPtbMNFBoQU3Dw==}
+    cpu: [ia32]
+    os: [openbsd]
+
+  '@koromix/koffi-openbsd-x64@3.1.4':
+    resolution: {integrity: sha512-SNp5AxOzheC2YaWPu3Y86wxRHHWf6V9NMl5Ot5nu9OpnP61Yinzug7JwsCeXtcZZTbKLsfsWoT7y4n17UYpOVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@koromix/koffi-win32-arm64@3.1.4':
+    resolution: {integrity: sha512-oS8ETU35AelOD6DY7xmmz9qq26Xl38upXWiZbsdxbtH9UEIY0QpenQOuCK/0+q4CtfiLorRUlglGkO9YgPAIeA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@koromix/koffi-win32-ia32@3.1.4':
+    resolution: {integrity: sha512-zd7Qh8s4fzblD9zzuDf44XCbujYg3QrffhgcNJg79/YC6ABT2m0CUtX4yFic9EWm2ps8NPAM25kCTCXPpt3eaw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@koromix/koffi-win32-x64@3.1.4':
+    resolution: {integrity: sha512-BPeQXc1bRd0QBOklvsP+AjoRnUzKbPNE6rfx7VNxrebhh09MKld2ibstgKWn6ejQLEcfKEoUJ+WAWIhX4AOsIg==}
+    cpu: [x64]
+    os: [win32]
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1689,6 +1767,9 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  koffi@3.1.4:
+    resolution: {integrity: sha512-KHX39XIg7afe8ds+0MHPoLiKR9dCzsVK4oAmBUSaeJlcX0xur22f15C2DILbZ6GJ9eyqC+e6Sb1cTG7M17z+Tg==}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -2774,6 +2855,51 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@koromix/koffi-darwin-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-darwin-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-freebsd-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-loong64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-riscv64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-linux-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-openbsd-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-openbsd-x64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-arm64@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-ia32@3.1.4':
+    optional: true
+
+  '@koromix/koffi-win32-x64@3.1.4':
+    optional: true
+
   '@manypkg/find-root@1.1.0':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -3581,6 +3707,24 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
+
+  koffi@3.1.4:
+    optionalDependencies:
+      '@koromix/koffi-darwin-arm64': 3.1.4
+      '@koromix/koffi-darwin-x64': 3.1.4
+      '@koromix/koffi-freebsd-arm64': 3.1.4
+      '@koromix/koffi-freebsd-ia32': 3.1.4
+      '@koromix/koffi-freebsd-x64': 3.1.4
+      '@koromix/koffi-linux-arm64': 3.1.4
+      '@koromix/koffi-linux-ia32': 3.1.4
+      '@koromix/koffi-linux-loong64': 3.1.4
+      '@koromix/koffi-linux-riscv64': 3.1.4
+      '@koromix/koffi-linux-x64': 3.1.4
+      '@koromix/koffi-openbsd-ia32': 3.1.4
+      '@koromix/koffi-openbsd-x64': 3.1.4
+      '@koromix/koffi-win32-arm64': 3.1.4
+      '@koromix/koffi-win32-ia32': 3.1.4
+      '@koromix/koffi-win32-x64': 3.1.4
 
   load-tsconfig@0.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 allowBuilds:
   '@google/genai': set this to true or false
   esbuild: set this to true or false
+  koffi: false
   protobufjs: set this to true or false
 
 # Transitive deps of the pi packages (typecheck-only here); their postinstalls aren't needed.


### PR DESCRIPTION
## Summary

- pin Relay filesystem operations to opened directory descriptors and reject traversal/symlink races
- canonicalize protected system root aliases such as macOS `/var` without weakening containment
- preserve complete mailbox message IDs so same-millisecond deliveries cannot collide
- add durable inbox claim/read/ack/requeue operations with crash-recovery tokens
- harden registry, mailbox, audit, alias, receipt, watch, and inbound-refusal paths with focused regression coverage
- include a Relay patch changeset for the hardening work

## Stack

- #75 — Pi-free core export
- **This PR** — filesystem and durable inbox hardening

## Testing

- `pnpm test` (219 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
