### PR TITLE
feat(spinner): shimmer the working-message text

### DIFF
--- a/.changeset/spinner-shimmer.md
+++ b/.changeset/spinner-shimmer.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-spinner': minor
+---
+
+Shimmer the spinner verb text (Claude Code-style sweeping highlight) while the agent works. Only the text shimmers — the spinner glyph is untouched. Configurable via `~/.pi/agent/configs/spinner.json` (`shimmer`, `shimmerIntervalMs`, `shimmerPeriodMs`, `baseColor`, `highlightColor`, `bandWidth`, `hideSpinner`).

--- a/packages/spinner/README.md
+++ b/packages/spinner/README.md
@@ -12,8 +12,8 @@ pi install /Users/nicknisi/Developer/pi-extensions/packages/spinner-verbs
 
 No slash commands, tools, keybindings, widgets, or custom entry types. It only hooks two events:
 
-- `turn_start` — calls `ctx.ui.setWorkingMessage("<random verb>...")`, replacing the spinner's working text for the duration of the turn.
-- `turn_end` — calls `ctx.ui.setWorkingMessage()` with no argument, resetting the working message to pi's default.
+- `turn_start` — picks a random verb and, while the turn runs, repaints it via `ctx.ui.setWorkingMessage()` on an interval with a Claude Code-style shimmer: a highlight band sweeping left → right across the text. Only the text shimmers — the spinner glyph next to it is untouched.
+- `turn_end` — stops the shimmer timer and calls `ctx.ui.setWorkingMessage()` with no argument, resetting the working message to pi's default.
 
 ## Usage
 
@@ -27,16 +27,43 @@ A new phrase is sampled independently each turn, so repeats are possible.
 
 ## Configuration
 
-None. No config files, no options, no environment variables. The verb list is a hardcoded `VERBS` array in `index.ts`; edit the source to add or remove phrases.
+Optional, via `~/.pi/agent/configs/spinner.json` (loaded once at extension load). All keys are optional:
+
+```json
+{
+  "shimmer": true,
+  "shimmerIntervalMs": 80,
+  "shimmerPeriodMs": 2000,
+  "baseColor": "muted",
+  "highlightColor": "text",
+  "bandWidth": 6,
+  "hideSpinner": false
+}
+```
+
+| Key                 | Default   | Meaning                                                                                                        |
+| ------------------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| `shimmer`           | `true`    | Animate the verb text with a sweeping highlight. Set `false` for the old static message.                       |
+| `shimmerIntervalMs` | `80`      | Milliseconds between shimmer frames.                                                                           |
+| `shimmerPeriodMs`   | `2000`    | Milliseconds for one full left-to-right sweep.                                                                 |
+| `baseColor`         | `"muted"` | Theme colour token or `#rrggbb` hex for the resting text. `muted` matches pi's default working-message colour. |
+| `highlightColor`    | `"text"`  | Theme colour token or `#rrggbb` hex the highlight sweeps toward.                                               |
+| `bandWidth`         | `6`       | Width of the highlight band, in characters.                                                                    |
+| `hideSpinner`       | `false`   | Hide the spinner glyph entirely (via `ctx.ui.setWorkingIndicator({ frames: [] })`), leaving only the text.     |
+
+On themes that don't emit truecolor sequences, the smooth gradient degrades to a two-tone band using the configured theme tokens.
+
+The verb list is a hardcoded `VERBS` array in `index.ts`; edit the source to add or remove phrases.
 
 ## Dependencies
 
 - `@earendil-works/pi-coding-agent` (peer, `*`) — uses `ExtensionAPI`, specifically `pi.on` for the `turn_start` / `turn_end` events and `ctx.ui.setWorkingMessage()`.
 
-No npm dependencies, no workspace dependencies, no build step. The package ships raw TypeScript (`"exports": "./index.ts"`, `"pi.extensions": ["./index.ts"]`).
+No npm dependencies, no workspace dependencies, no build step. The package ships raw TypeScript (`"pi.extensions": ["./index.ts"]`). The shimmer also uses `getAgentDir` and `ctx.ui.theme` from the same peer.
 
 ## Caveats
 
-- Depends on the `turn_start` / `turn_end` event names and the `ctx.ui.setWorkingMessage()` API, which are pi extension-API surface; a pi release that renames or removes either will break this extension.
+- Depends on the `turn_start` / `turn_end` event names and the `ctx.ui.setWorkingMessage()` / `ctx.ui.theme` APIs, which are pi extension-API surface; a pi release that renames or removes either will break this extension.
+- The shimmer repaints the working message every `shimmerIntervalMs` (default 80ms), the same cadence as pi's built-in spinner animation.
 - The selection uses `Math.random()` with no deduplication, so the same phrase can appear on consecutive turns.
 - Because it hooks `turn_start` without checking event payload, it overrides the working message even in contexts where another extension may have set one; the last `setWorkingMessage` call wins.

--- a/packages/spinner/index.ts
+++ b/packages/spinner/index.ts
@@ -4,9 +4,14 @@
  * Replaces the default working message with a random fun verb
  * on each turn. A mix of The Office, Lord of the Rings,
  * Arnold Schwarzenegger, and Predator references.
+ *
+ * The verb text shimmers (Claude Code-style sweeping highlight) while the
+ * agent works; the spinner glyph itself is untouched. Configurable via
+ * ~/.pi/agent/configs/spinner.json — see shimmer.ts for options.
  */
 
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import { CONFIG, shimmerFrame } from './shimmer.js';
 
 const VERBS = [
   '1-up collecting',
@@ -1145,11 +1150,30 @@ function randomVerb(): string {
 }
 
 export default function (pi: ExtensionAPI) {
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const stopTimer = () => {
+    if (timer) {
+      clearInterval(timer);
+      timer = undefined;
+    }
+  };
+
   pi.on('turn_start', async (_event, ctx) => {
-    ctx.ui.setWorkingMessage(`${randomVerb()}...`);
+    stopTimer();
+    if (CONFIG.HIDE_SPINNER) ctx.ui.setWorkingIndicator({ frames: [] });
+    const message = `${randomVerb()}...`;
+    if (!CONFIG.SHIMMER) {
+      ctx.ui.setWorkingMessage(message);
+      return;
+    }
+    const frame = () => ctx.ui.setWorkingMessage(shimmerFrame(message, ctx.ui.theme));
+    frame();
+    timer = setInterval(frame, CONFIG.SHIMMER_INTERVAL_MS);
   });
 
   pi.on('turn_end', async (_event, ctx) => {
+    stopTimer();
     ctx.ui.setWorkingMessage();
   });
 }

--- a/packages/spinner/package.json
+++ b/packages/spinner/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "dist",
-    "index.ts"
+    "index.ts",
+    "shimmer.ts"
   ],
   "type": "module",
   "exports": {

--- a/packages/spinner/shimmer.ts
+++ b/packages/spinner/shimmer.ts
@@ -1,0 +1,147 @@
+/**
+ * Shimmer rendering + config for the spinner working message.
+ *
+ * Renders one frame of a Claude Code-style shimmer: the message text sits in
+ * a base colour while a highlight band sweeps left → right, positioned by
+ * wall-clock time. Only the text shimmers — the spinner glyph next to it is a
+ * separate segment of pi's Loader and is never touched.
+ *
+ * Config is loaded once at extension load from <agent-dir>/configs/spinner.json.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { getAgentDir, type Theme, type ThemeColor } from '@earendil-works/pi-coding-agent';
+
+export const DEFAULT_CONFIG = {
+  /** Sweep a highlight across the working-message text while the agent works. */
+  SHIMMER: true,
+  /** Milliseconds between shimmer frames. */
+  SHIMMER_INTERVAL_MS: 80,
+  /** Milliseconds for one full left-to-right sweep. */
+  SHIMMER_PERIOD_MS: 2000,
+  /** Theme colour token or hex for the resting text (pi paints the working
+   * message "muted" by default, so that is the seamless choice). */
+  BASE_COLOR: 'muted',
+  /** Theme colour token or hex the highlight sweeps toward. */
+  HIGHLIGHT_COLOR: 'text',
+  /** Width of the highlight band, in characters. */
+  BAND_WIDTH: 6,
+  /** Hide the spinner glyph entirely, leaving only the working-message text. */
+  HIDE_SPINNER: false,
+};
+
+interface SpinnerUserConfig {
+  shimmer?: boolean;
+  shimmerIntervalMs?: number;
+  shimmerPeriodMs?: number;
+  baseColor?: string;
+  highlightColor?: string;
+  bandWidth?: number;
+  hideSpinner?: boolean;
+}
+
+function positiveNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && value > 0 ? value : fallback;
+}
+
+function loadConfig() {
+  let user: SpinnerUserConfig = {};
+  try {
+    user = JSON.parse(readFileSync(join(getAgentDir(), 'configs', 'spinner.json'), 'utf8'));
+  } catch {
+    // Missing or malformed config — run with defaults.
+  }
+  return {
+    SHIMMER: typeof user.shimmer === 'boolean' ? user.shimmer : DEFAULT_CONFIG.SHIMMER,
+    SHIMMER_INTERVAL_MS: positiveNumber(user.shimmerIntervalMs, DEFAULT_CONFIG.SHIMMER_INTERVAL_MS),
+    SHIMMER_PERIOD_MS: positiveNumber(user.shimmerPeriodMs, DEFAULT_CONFIG.SHIMMER_PERIOD_MS),
+    BASE_COLOR: typeof user.baseColor === 'string' ? user.baseColor : DEFAULT_CONFIG.BASE_COLOR,
+    HIGHLIGHT_COLOR: typeof user.highlightColor === 'string' ? user.highlightColor : DEFAULT_CONFIG.HIGHLIGHT_COLOR,
+    BAND_WIDTH: positiveNumber(user.bandWidth, DEFAULT_CONFIG.BAND_WIDTH),
+    HIDE_SPINNER: typeof user.hideSpinner === 'boolean' ? user.hideSpinner : DEFAULT_CONFIG.HIDE_SPINNER,
+  };
+}
+
+export const CONFIG = loadConfig();
+
+// ─── colour helpers ────────────────────────────────────────────────────────
+
+type Rgb = [number, number, number];
+
+function hexToRgb(hex: string): Rgb | null {
+  const h = hex.replace('#', '');
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) return null;
+  return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+}
+
+/** Resolve a theme token or hex colour to RGB. Returns null when the theme
+ * doesn't emit a truecolor sequence for the token (e.g. 256-colour themes). */
+function resolveRgb(theme: Theme, color: string): Rgb | null {
+  if (color.startsWith('#')) return hexToRgb(color);
+  try {
+    const painted = theme.fg(color as ThemeColor, 'x');
+    const m = painted.match(/\x1b\[38;2;(\d+);(\d+);(\d+)m/);
+    if (m) return [Number(m[1]), Number(m[2]), Number(m[3])];
+  } catch {
+    /* unknown token */
+  }
+  return null;
+}
+
+/** Paint text with a theme token or hex colour; unknown colours pass through. */
+function paint(theme: Theme, color: string, text: string): string {
+  if (color.startsWith('#')) {
+    const rgb = hexToRgb(color);
+    return rgb ? `\x1b[38;2;${rgb[0]};${rgb[1]};${rgb[2]}m${text}\x1b[0m` : text;
+  }
+  try {
+    return theme.fg(color as ThemeColor, text);
+  } catch {
+    return text;
+  }
+}
+
+function mixRgb(a: Rgb, b: Rgb, t: number): Rgb {
+  return [
+    Math.round(a[0] + (b[0] - a[0]) * t),
+    Math.round(a[1] + (b[1] - a[1]) * t),
+    Math.round(a[2] + (b[2] - a[2]) * t),
+  ];
+}
+
+/**
+ * Render one shimmer frame of `text` for the given wall-clock time. Every
+ * character carries an explicit foreground colour so the frame looks the same
+ * regardless of the colour the loader wraps around the message.
+ */
+export function shimmerFrame(text: string, theme: Theme, now = Date.now()): string {
+  const chars = [...text];
+  const band = CONFIG.BAND_WIDTH;
+  // The band starts fully off-screen left and exits fully off-screen right.
+  const cycle = chars.length + band * 2;
+  const head = ((now % CONFIG.SHIMMER_PERIOD_MS) / CONFIG.SHIMMER_PERIOD_MS) * cycle - band;
+
+  const base = resolveRgb(theme, CONFIG.BASE_COLOR);
+  const highlight = resolveRgb(theme, CONFIG.HIGHLIGHT_COLOR);
+
+  // Non-truecolor theme: fall back to a two-tone band using theme tokens.
+  if (!base || !highlight) {
+    return chars
+      .map((ch, i) =>
+        ch === ' ' ? ch : paint(theme, Math.abs(i - head) <= band / 2 ? CONFIG.HIGHLIGHT_COLOR : CONFIG.BASE_COLOR, ch),
+      )
+      .join('');
+  }
+
+  const painted = chars
+    .map((ch, i) => {
+      if (ch === ' ') return ch;
+      const t = Math.max(0, 1 - Math.abs(i - head) / band);
+      const eased = t * t * (3 - 2 * t); // smoothstep falloff
+      const [r, g, b] = mixRgb(base, highlight, eased);
+      return `\x1b[38;2;${r};${g};${b}m${ch}`;
+    })
+    .join('');
+  return `${painted}\x1b[0m`;
+}


### PR DESCRIPTION
## What

Claude Code-style shimmer for the spinner verb text: a highlight band sweeps left → right across the working message while the agent works. Only the text shimmers — the spinner glyph next to it is a separate `Loader` segment and is untouched.

## How

- `setWorkingMessage()` live-updates the active working indicator, so the extension repaints the verb on an interval (default 80ms, same cadence as pi's built-in spinner) with per-character truecolor codes mixed between a base and highlight colour (smoothstep falloff).
- On themes that don't emit truecolor sequences, degrades to a two-tone band via theme tokens.
- New `hideSpinner` option hides the spinner glyph entirely (`ctx.ui.setWorkingIndicator({ frames: [] })`), leaving only the shimmering text.

## Config

Optional `~/.pi/agent/configs/spinner.json`:

| Key | Default |
| --- | --- |
| `shimmer` | `true` |
| `shimmerIntervalMs` | `80` |
| `shimmerPeriodMs` | `2000` |
| `baseColor` | `"muted"` |
| `highlightColor` | `"text"` |
| `bandWidth` | `6` |
| `hideSpinner` | `false` |

Colours accept theme tokens or `#rrggbb` hex.

Changeset included (minor).
