### PR TITLE
fix(composer): restore focused border in fullscreen

### DIFF
--- a/.changeset/bright-composers-focus.md
+++ b/.changeset/bright-composers-focus.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-composer': patch
+---
+
+Restore focused-border updates in fullscreen Pi sessions, whose viewport listener consumes terminal focus events before extension input listeners run. Also initialize tmux focus from attached clients so background sessions start dim.

--- a/packages/composer/README.md
+++ b/packages/composer/README.md
@@ -240,11 +240,12 @@ Peer dependencies (`*`):
 - `@earendil-works/pi-coding-agent` — `ExtensionAPI`, `ExtensionContext`,
   `CustomEditor`, `KeybindingsManager`, `Theme`, `ThemeColor` types; the
   `session_start` / `session_shutdown` events; `ctx.ui.setEditorComponent`.
-- `@earendil-works/pi-tui` — `TUI` and `EditorTheme` types, `visibleWidth`
-  for width arithmetic over ANSI-styled strings, and `tui.addInputListener` /
-  `tui.requestRender` for focus tracking.
+- `@earendil-works/pi-tui` — `TUI` and `EditorTheme` types, `isViewportTUI`
+  for focus-reporting ownership, `visibleWidth` for width arithmetic over
+  ANSI-styled strings, and `tui.requestRender` for focus updates.
 
-No npm runtime dependencies; `node:fs` / `node:os` / `node:path` only.
+No npm runtime dependencies; `node:child_process` / `node:fs` / `node:os` /
+`node:path` only.
 
 ## Caveats
 
@@ -265,12 +266,13 @@ No npm runtime dependencies; `node:fs` / `node:os` / `node:path` only.
 - **Narrow terminals**: if `width < 5 + BOX_PAD_X * padMultiplier`
   (`padMultiplier` is 3 boxed, 1 unboxed) or the stock render produces fewer
   than 2 lines, the component falls back to pi's stock rendering.
-- **Focus tracking (DECSET 1004)**: pi itself never enables focus reporting, so
-  the extension enables it (`\x1b[?1004h`) and installs a `process.on("exit")`
-  hook to disable it — otherwise the shell inherits a mode that spews `[I`/`[O`
-  into the prompt. Shutdown hooks also disable it. If the process is killed
-  with a signal that bypasses the exit hook, the terminal can be left in
-  focus-reporting mode.
+- **Focus tracking (DECSET 1004)**: fullscreen pi owns focus reporting;
+  composer reasserts it during setup but only disables it in other TUI modes.
+  Composer observes raw stdin because fullscreen pi consumes CSI I / CSI O in
+  its viewport listener before extension input listeners run. When composer
+  owns reporting, shutdown and process-exit hooks disable it so the shell does
+  not inherit `[I`/`[O`. A signal that bypasses the exit hook can still leave
+  focus reporting enabled.
 - **tmux**: the focus indicator only changes state if tmux has
   `focus-events on` (and the outer terminal passes focus events through).
   Outside tmux it works only if the terminal itself emits CSI I / CSI O.

--- a/packages/composer/index.ts
+++ b/packages/composer/index.ts
@@ -73,14 +73,17 @@ interface EditorInternals {
   moveToLineEnd(): void;
 }
 
+import { execFileSync } from 'node:child_process';
 import { CustomEditor, type ExtensionAPI, type ExtensionContext } from '@earendil-works/pi-coding-agent';
 import type { TUI, EditorTheme } from '@earendil-works/pi-tui';
 import type { KeybindingsManager } from '@earendil-works/pi-coding-agent';
-import { visibleWidth } from '@earendil-works/pi-tui';
+import { isViewportTUI, visibleWidth } from '@earendil-works/pi-tui';
 import { CONFIG, configLoadError, reloadConfig } from './config.js';
 import {
   applyColor,
   mixRgb,
+  paneHasFocusedClient,
+  parseFocusInput,
   parseLabelData,
   plainText,
   rainbowRgb,
@@ -485,25 +488,38 @@ class Composer extends CustomEditor {
 
 // ─── Extension entry ──────────────────────────────────────────────────────
 
-// Terminal focus tracking — delineates the focused tmux pane. We enable
-// terminal focus reporting (DECSET 1004) so tmux (with `focus-events on`)
-// sends CSI I / CSI O when this pane gains/loses focus, and swap the border
-// colour accordingly. pi itself never enables 1004, so we must both enable
-// it and clean it up on exit — otherwise the shell inherits a mode that
-// spews `[I`/`[O` into the prompt.
-
-const FOCUS_IN = '\x1b[I';
-const FOCUS_OUT = '\x1b[O';
+// Terminal focus tracking — delineates the focused tmux pane. Fullscreen pi
+// owns DECSET 1004; other TUI modes need composer to enable it so tmux (with
+// `focus-events on`) sends CSI I / CSI O. Observe raw stdin because fullscreen
+// pi consumes those events before extension input listeners run. When composer
+// enables 1004 itself, clean it up so the shell does not inherit `[I`/`[O`.
 
 let paneFocused = true;
+let focusCarry = '';
 let removeFocusListener: (() => void) | undefined;
+let ownsFocusReporting = false;
 let exitHookInstalled = false;
 
+function detectPaneFocus(): boolean {
+  if (!process.env.TMUX_PANE) return true;
+  try {
+    return paneHasFocusedClient(
+      process.env.TMUX_PANE,
+      execFileSync('tmux', ['list-clients', '-F', '#{client_flags}\t#{pane_id}'], { encoding: 'utf8' }),
+    );
+  } catch {
+    return true;
+  }
+}
+
 function enableFocusTracking(tui: TUI): void {
+  paneFocused = detectPaneFocus();
+  ownsFocusReporting = !isViewportTUI(tui);
   process.stdout.write('\x1b[?1004h');
   if (!exitHookInstalled) {
     exitHookInstalled = true;
     process.on('exit', () => {
+      if (!ownsFocusReporting) return;
       try {
         process.stdout.write('\x1b[?1004l');
       } catch {
@@ -512,25 +528,29 @@ function enableFocusTracking(tui: TUI): void {
     });
   }
   removeFocusListener?.();
-  removeFocusListener = tui.addInputListener((data) => {
-    const inIdx = data.lastIndexOf(FOCUS_IN);
-    const outIdx = data.lastIndexOf(FOCUS_OUT);
-    if (inIdx === -1 && outIdx === -1) return undefined;
-    paneFocused = inIdx > outIdx;
+  const onInput = (data: string | Buffer) => {
+    const parsed = parseFocusInput(focusCarry, String(data));
+    focusCarry = parsed.carry;
+    if (parsed.focused === undefined) return;
+    paneFocused = parsed.focused;
     tui.requestRender();
-    const stripped = data.replaceAll(FOCUS_IN, '').replaceAll(FOCUS_OUT, '');
-    return stripped.length === 0 ? { consume: true } : { data: stripped };
-  });
+  };
+  process.stdin.on('data', onInput);
+  removeFocusListener = () => process.stdin.off('data', onInput);
 }
 
 function disableFocusTracking(): void {
-  try {
-    process.stdout.write('\x1b[?1004l');
-  } catch {
-    /* stdout gone */
+  if (ownsFocusReporting) {
+    try {
+      process.stdout.write('\x1b[?1004l');
+    } catch {
+      /* stdout gone */
+    }
   }
   removeFocusListener?.();
   removeFocusListener = undefined;
+  ownsFocusReporting = false;
+  focusCarry = '';
   paneFocused = true;
 }
 

--- a/packages/composer/utils.test.ts
+++ b/packages/composer/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseLabelData, splitFormat, truncateCells } from './utils.js';
+import { paneHasFocusedClient, parseFocusInput, parseLabelData, splitFormat, truncateCells } from './utils.js';
 
 describe('parseLabelData', () => {
   it('returns the text when it is a non-empty string', () => {
@@ -14,6 +14,32 @@ describe('parseLabelData', () => {
     expect(parseLabelData(null)).toBeUndefined();
     expect(parseLabelData('just a string')).toBeUndefined();
     expect(parseLabelData(undefined)).toBeUndefined();
+  });
+});
+
+describe('paneHasFocusedClient', () => {
+  it('matches only panes selected by a focused tmux client', () => {
+    const clients = 'attached,UTF-8\t%1\nattached,focused,UTF-8\t%2\n';
+    expect(paneHasFocusedClient('%2', clients)).toBe(true);
+    expect(paneHasFocusedClient('%1', clients)).toBe(false);
+    expect(paneHasFocusedClient('%20', clients)).toBe(false);
+  });
+
+  it('treats sessions outside tmux as focused', () => {
+    expect(paneHasFocusedClient(undefined, '')).toBe(true);
+  });
+});
+
+describe('parseFocusInput', () => {
+  it('reads the latest focus event', () => {
+    expect(parseFocusInput('', '\x1b[I')).toEqual({ focused: true, carry: '' });
+    expect(parseFocusInput('', '\x1b[I\x1b[O')).toEqual({ focused: false, carry: '' });
+  });
+
+  it('reassembles a split focus event', () => {
+    const first = parseFocusInput('', '\x1b[');
+    expect(first).toEqual({ focused: undefined, carry: '\x1b[' });
+    expect(parseFocusInput(first.carry, 'O')).toEqual({ focused: false, carry: '' });
   });
 });
 

--- a/packages/composer/utils.ts
+++ b/packages/composer/utils.ts
@@ -24,6 +24,26 @@ export function parseLabelData(data: unknown): string | undefined {
   return typeof text === 'string' && text.trim().length > 0 ? text : undefined;
 }
 
+/** Whether this tmux pane is selected by a focused client. */
+export function paneHasFocusedClient(paneId: string | undefined, clients: string): boolean {
+  if (paneId === undefined) return true;
+  return clients.split(/\r?\n/).some((line) => {
+    const [flags, selectedPane] = line.split('\t');
+    return selectedPane === paneId && flags?.split(',').includes('focused');
+  });
+}
+
+/** Read terminal focus events from raw stdin, preserving a split CSI prefix. */
+export function parseFocusInput(carry: string, chunk: string): { focused: boolean | undefined; carry: string } {
+  const input = carry + chunk;
+  const focusIn = input.lastIndexOf('\x1b[I');
+  const focusOut = input.lastIndexOf('\x1b[O');
+  return {
+    focused: focusIn === -1 && focusOut === -1 ? undefined : focusIn > focusOut,
+    carry: input.endsWith('\x1b[') ? '\x1b[' : input.endsWith('\x1b') ? '\x1b' : '',
+  };
+}
+
 /** Truncate to `max` visible cells, appending an ellipsis when truncated. */
 export function truncateCells(s: string, max: number): string {
   if (visibleWidth(s) <= max) return s;


### PR DESCRIPTION
## Summary

- restore focused-border updates in fullscreen Pi sessions by observing raw stdin before the viewport listener consumes focus events
- initialize focus from the tmux client that is actually focused and preserve Pi/composer ownership of DECSET 1004
- cover full and split focus sequences, update documentation, and add a patch changeset

## Verification

- `pnpm exec vitest run packages/composer/utils.test.ts`
- `pnpm typecheck`
- `pnpm exec oxlint packages/composer/index.ts packages/composer/utils.ts packages/composer/utils.test.ts`
- live tmux focus cycle: unfocused `#413a50` → focused `#7c7cf8` → unfocused `#413a50`