### PR TITLE
fix(relay): resolve the relay root before opening it

### DIFF
--- a/.changeset/hip-pears-shave.md
+++ b/.changeset/hip-pears-shave.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-relay': patch
+---
+
+Resolve the relay root before opening it, so a symlinked pi home no longer disables relay entirely. The filesystem hardening refuses user-controlled ancestor symlinks, which is correct for ongoing operations but rejected the common dotfiles arrangement (`~/.pi -> ~/Developer/dotfiles/home/.pi`) — and since pi keeps everything under `~/.pi`, registration failed on every start. The root is now resolved once, up front, so later operations traverse only real directories and no user symlink remains in the path to swap. Startup failures are also recorded and reported instead of discarded, so the tools name the real cause rather than reporting that `session_start` has not run.

--- a/packages/relay/index.ts
+++ b/packages/relay/index.ts
@@ -55,6 +55,7 @@ import {
   claimAlias,
   deriveAddr,
   ensureRoot,
+  resolveRelayRoot,
   isValidAliasName,
   listAliases,
   listRecords,
@@ -68,6 +69,13 @@ import {
 } from './registry.js';
 
 type AskOutcome = { replied: true; body: string; from: string } | { replied: false; reason: string };
+
+/** What to tell the caller when there is no session record to work with. */
+function describeUninitialized(startupError: string | undefined, root: string): string {
+  return startupError
+    ? `Relay failed to start: ${startupError} (relay root: ${root})`
+    : 'Relay is not initialized (no session_start yet).';
+}
 
 function toolResult(text: string, details: Record<string, unknown> = {}) {
   return { content: [{ type: 'text' as const, text }], details };
@@ -166,10 +174,19 @@ function collectResumableSessionIds(): Set<string> {
 }
 
 export default function relay(pi: ExtensionAPI) {
-  const root = process.env.PI_RELAY_DIR ?? path.join(getAgentDir(), 'relay');
+  // Resolve before any relay I/O: pi's home is commonly a dotfiles symlink,
+  // and the traversal hardening (rightly) refuses user-controlled ancestor
+  // symlinks on every operation. See resolveRelayRoot.
+  const root = resolveRelayRoot(process.env.PI_RELAY_DIR ?? path.join(getAgentDir(), 'relay'));
   const policy = new OutboundPolicy();
 
   let self: SessionRecord | undefined;
+  // Why registration failed, if it did. Without this a startup failure is
+  // indistinguishable from "session_start hasn't fired yet", and the whole
+  // extension goes quietly inert -- which is exactly how a symlinked pi home
+  // disabled relay machine-wide for a day and a half before anyone noticed.
+  let startupError: string | undefined;
+  const uninitializedText = (): string => describeUninitialized(startupError, root);
   let unwatch: (() => void) | undefined;
   let heartbeat: ReturnType<typeof setInterval> | undefined;
   const askWaiters = new Map<string, (outcome: AskOutcome) => void>();
@@ -478,6 +495,7 @@ export default function relay(pi: ExtensionAPI) {
 
   pi.on('session_start', (_event, ctx: ExtensionContext) => {
     try {
+      startupError = undefined;
       ensureRoot(root);
       const sessionId = ctx.sessionManager.getSessionId();
       const cwd = ctx.sessionManager.getCwd() ?? ctx.cwd;
@@ -524,8 +542,11 @@ export default function relay(pi: ExtensionAPI) {
       // processing"); by the time this fires, steer/triggerTurn work.
       const initialDrain = setTimeout(checkInbox, 1200);
       initialDrain.unref();
-    } catch {
-      // registration failure never breaks the session
+    } catch (error) {
+      // A failure here must never break the session -- but it must not be
+      // invisible either. Record it so every tool can say what actually
+      // happened instead of implying session_start simply hasn't run.
+      startupError = error instanceof Error ? error.message : String(error);
     }
   });
 
@@ -588,7 +609,7 @@ export default function relay(pi: ExtensionAPI) {
     }),
 
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
-      if (!self) return toolResult('Relay is not initialized (no session_start yet).');
+      if (!self) return toolResult(uninitializedText());
 
       switch (params.action) {
         case 'list':
@@ -823,7 +844,7 @@ export default function relay(pi: ExtensionAPI) {
       if (sub === 'log') {
         const limit = Math.max(1, Math.min(500, Number(rest[0] ?? 50)));
         const entries = self ? readAudit(root, limit) : [];
-        const text = self ? formatAudit(entries) : 'Relay is not initialized (no session_start yet).';
+        const text = self ? formatAudit(entries) : uninitializedText();
         if (!self || !ctx.hasUI) {
           pi.sendMessage({ customType: AUDIT_TYPE, content: text, display: true, details: { kind: 'relay-audit' } });
           return;
@@ -833,9 +854,7 @@ export default function relay(pi: ExtensionAPI) {
       }
       if (!self || !ctx.hasUI) {
         // Plain-text fallback (print/rpc mode): the entry renderer never runs there.
-        const text = self
-          ? formatListing(listRecords(root), self.addr, (r) => presenceOf(r))
-          : 'Relay is not initialized (no session_start yet).';
+        const text = self ? formatListing(listRecords(root), self.addr, (r) => presenceOf(r)) : uninitializedText();
         pi.sendMessage({
           customType: LIST_TYPE,
           content: text,

--- a/packages/relay/registry.ts
+++ b/packages/relay/registry.ts
@@ -16,6 +16,7 @@
  */
 
 import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   assertPathSegment,
@@ -45,6 +46,42 @@ export const SWEEP_MAIL_KEEP_MS = 30 * 24 * 60 * 60 * 1000;
 
 export function deriveAddr(cwd: string, sessionId: string): string {
   return crypto.createHash('sha256').update(`${cwd}${sessionId}`).digest('hex').slice(0, 12);
+}
+
+/**
+ * Pin the relay root to its real location, once, before any relay I/O.
+ *
+ * The traversal hardening refuses *user-controlled* ancestor symlinks, because
+ * a user-writable symlink can be swapped between the check and the use. That
+ * is the right rule for every operation after startup — but it also rejects a
+ * legitimate, stable arrangement: a dotfiles setup where `~/.pi` is a symlink
+ * into a managed repo. Since pi keeps everything under `~/.pi`, that made the
+ * relay root unopenable and the whole extension silently inert.
+ *
+ * Resolving once at startup keeps the property that matters. Every later
+ * operation traverses only real directories, so there is no user symlink left
+ * in the path to swap; repointing `~/.pi` afterwards cannot redirect this
+ * process. It is a pin, not a bypass.
+ *
+ * The root may not exist yet on a first run, so resolve the deepest ancestor
+ * that does and re-apply the remainder.
+ */
+export function resolveRelayRoot(root: string): string {
+  const absolute = path.resolve(root);
+  const tail: string[] = [];
+  let current = absolute;
+  for (;;) {
+    try {
+      return path.join(fs.realpathSync(current), ...tail);
+    } catch (error) {
+      if (!(error instanceof Error && 'code' in error && error.code === 'ENOENT')) throw error;
+      const parent = path.dirname(current);
+      // Filesystem root does not exist: nothing sane left to resolve against.
+      if (parent === current) return absolute;
+      tail.unshift(path.basename(current));
+      current = parent;
+    }
+  }
 }
 
 export function ensureRoot(root: string): void {

--- a/packages/relay/relay.test.ts
+++ b/packages/relay/relay.test.ts
@@ -45,6 +45,8 @@ import {
   claimAlias,
   clearAlias,
   deriveAddr,
+  ensureRoot,
+  resolveRelayRoot,
   isValidAliasName,
   listAliases,
   listRecords,
@@ -739,5 +741,42 @@ describe('format', () => {
   it('pins refusal strings', () => {
     expect(refusalUnknown('nobody', ['"alpha" (aaaa11)'])).toContain('No session matches');
     expect(refusalAmbiguous('al', ['"alpha" (aaaa11)', '"alpine" (bbbb22)'])).toContain('ambiguous');
+  });
+});
+
+describe('relay root resolution', () => {
+  // pi's home is commonly a dotfiles symlink (`~/.pi -> ~/Developer/dotfiles/home/.pi`).
+  // The traversal hardening refuses user-controlled ancestor symlinks, so an
+  // unresolved root made every relay operation throw -- and because
+  // session_start swallowed it, relay went silently inert machine-wide.
+  // Note the rest of this suite calls fs.realpathSync.native() on its temp
+  // dirs, which is exactly why that path was never covered.
+  it('resolves a user-symlinked ancestor so the hardened root can be opened', () => {
+    const real = tmpRoot();
+    const link = path.join(tmpRoot(), 'link');
+    fs.symlinkSync(real, link, 'dir');
+    const root = path.join(link, 'relay');
+
+    // The hardening rejects the symlinked path itself -- deliberately.
+    expect(() => ensureRoot(root)).toThrow(/symlink/i);
+
+    // Resolving first yields the same directory by its real path, which opens.
+    const resolved = resolveRelayRoot(root);
+    expect(resolved).toBe(path.join(real, 'relay'));
+    expect(() => ensureRoot(resolved)).not.toThrow();
+  });
+
+  it('resolves a root whose directories do not exist yet', () => {
+    const real = tmpRoot();
+    const link = path.join(tmpRoot(), 'link');
+    fs.symlinkSync(real, link, 'dir');
+    // First run: nothing under the root exists, so the deepest existing
+    // ancestor is resolved and the missing tail re-applied.
+    expect(resolveRelayRoot(path.join(link, 'a', 'b', 'relay'))).toBe(path.join(real, 'a', 'b', 'relay'));
+  });
+
+  it('leaves an already-real path unchanged', () => {
+    const real = tmpRoot();
+    expect(resolveRelayRoot(path.join(real, 'relay'))).toBe(path.join(real, 'relay'));
   });
 });


### PR DESCRIPTION
Relay has been inert on my machine since ~Aug 14: no session registered, and every relay tool answered `Relay is not initialized (no session_start yet).` It was not one session — **51 stale records, zero recent ones** — so relay was dead for every session on the machine for about a day and a half.

Two causes, compounding.

## The root could not be opened

`~/.pi` is a symlink into a dotfiles repo (`~/.pi -> ~/Developer/dotfiles/home/.pi`). The traversal hardening in #76 refuses *user-controlled* ancestor symlinks — the right rule for ongoing operations, since a user-writable symlink can be swapped between the check and the use. But pi keeps everything under `~/.pi`, so the rule rejected the only path relay ever uses:

```
RelayFilesystemError: Refusing user-controlled ancestor symlink: /Users/nicknisi/.pi
```

Demonstrating that it is the *path* being rejected, not the directory:

```
ensureRoot('/Users/nicknisi/.pi/agent/relay')                          -> THROW (symlinked ancestor)
ensureRoot('/Users/nicknisi/Developer/dotfiles/home/.pi/agent/relay')  -> OK    (same directory)
```

The root is now resolved once, before any relay I/O. That keeps the property the hardening exists for rather than dropping it: after resolution every operation traverses only real directories, so there is no user symlink left in the path to swap, and repointing `~/.pi` afterwards cannot redirect a running process. It is a pin, not a bypass. A root that does not exist yet resolves its deepest existing ancestor and re-applies the remainder.

## Why it took a day and a half to notice

`session_start` caught every failure and discarded it:

```ts
} catch {
  // registration failure never breaks the session
}
```

Never breaking the session is right. Discarding the reason is not — it made a hard failure indistinguishable from "the event has not fired yet", and sent me looking for a missing `session_start` rather than a throwing one. The failure is now recorded and surfaced:

```
Relay failed to start: Refusing user-controlled ancestor symlink: /Users/nicknisi/.pi (relay root: /Users/nicknisi/.pi/agent/relay)
```

## Why the existing tests could not catch it

Every test calls `fs.realpathSync.native()` on its own temp dir — a reasonable workaround for macOS's `/tmp` symlink — so a symlinked root was never exercised. The suite was green while the extension was completely dead in the one layout that matters.

The new tests cover a symlinked ancestor, a not-yet-existing root, and an already-real path, and **all three were verified to fail with the resolver reverted**.

## Verification

- `pnpm typecheck`, `pnpm lint`, all 28 packages build
- 54 relay tests pass; the 3 new ones fail without the fix
- Against the real machine: resolves `~/.pi/agent/relay` -> `~/Developer/dotfiles/home/.pi/agent/relay`, opens cleanly, and still sees all 51 existing records (no history orphaned)
