### PR TITLE
fix(relay): fail load cleanly on Bun <= 1.3.14 where koffi panics

### DIFF
--- a/.changeset/tidy-geese-refuse.md
+++ b/.changeset/tidy-geese-refuse.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-relay': patch
+---
+
+Fail relay load with a clear error on Bun <= 1.3.14 instead of letting koffi's GC finalizer abort the process (oven-sh/bun#39263, fixed upstream after 1.3.14); newer Bun and Node load normally

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -101,6 +101,7 @@ The directory is created `0700` and every file `0600` — other users on the mac
 ## Caveats
 
 - **Mailbox semantics support Linux and macOS only.** Relay rejects user-controlled symlinks in configured-root components, permits protected root-owned system aliases such as macOS `/var`, pins root, mailbox, and durable-claim descriptors for each operation, and uses descriptor-relative `openat`/`renameat`/`unlinkat` calls, atomic renames, descriptor polling for watches, and `0600`/`0700` permission bits. Windows is unsupported.
+- **Bun <= 1.3.14 refused.** Those Bun versions abort the process when koffi's GC finalizer releases an N-API reference ([oven-sh/bun#39263](https://github.com/oven-sh/bun/issues/39263), fixed upstream after 1.3.14), so relay fails load with a clear error on them instead. Node.js and newer Bun load normally.
 - **One machine.** Delivery is a file landing in a directory; two sessions reach each other exactly when they share a filesystem. A container and its host cannot.
 - **Presence is heartbeat-accurate**, not instantaneous (within ~45s).
 - Delivery injects with `deliverAs: "steer"` (lands between tool calls) and `triggerTurn: true` (wakes an idle session).

--- a/packages/relay/filesystem.ts
+++ b/packages/relay/filesystem.ts
@@ -1,12 +1,25 @@
 /** Descriptor-relative, symlink-safe filesystem operations for the relay store. Pi-free. */
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import koffi from 'koffi';
 
 if (process.platform !== 'darwin' && process.platform !== 'linux') {
   throw new Error(`Relay filesystem operations are unsupported on ${process.platform}`);
 }
+
+// Bun <= 1.3.14 aborts the whole process when koffi's GC finalizer releases
+// an N-API reference (oven-sh/bun#39263, fixed after 1.3.14). Fail extension
+// load cleanly on those versions instead.
+const bunVersion = (globalThis as { Bun?: { version?: string } }).Bun?.version;
+if (bunVersion !== undefined) {
+  const [major = 0, minor = 0, patch = 0] = bunVersion.split('-')[0]!.split('.').map(Number);
+  if (major < 1 || (major === 1 && (minor < 3 || (minor === 3 && patch <= 14)))) {
+    throw new Error(`Relay requires Node.js or Bun > 1.3.14: koffi crashes Bun ${bunVersion} (oven-sh/bun#39263)`);
+  }
+}
+
+const koffi = createRequire(import.meta.url)('koffi') as typeof import('koffi');
 
 const NOFOLLOW = fs.constants.O_NOFOLLOW ?? 0;
 const DIRECTORY = fs.constants.O_DIRECTORY ?? 0;


### PR DESCRIPTION
## Why

koffi's GC finalizer releases an N-API reference, which Bun <= 1.3.14 treats as fatal: any process that loads relay under those Buns aborts ~1s in with `panic: napi_reference_unref` (oven-sh/bun#39263, fixed upstream after 1.3.14). Relay pulls koffi in at module top level, so merely loading the extension was enough.

## What

- `filesystem.ts` refuses to initialize koffi on Bun <= 1.3.14, throwing a clear load error (`Relay requires Node.js or Bun > 1.3.14: koffi crashes Bun <version> (oven-sh/bun#39263)`) instead of letting the process panic. koffi now loads via `createRequire` after the guard, since static imports hoist past it.
- The gate parses `Bun.version`, so newer (fixed) Bun and Node load normally — the guard self-retires and needs no follow-up release when the fixed stable ships.
- README caveat + changeset (patch).

## Verification

- `pnpm typecheck && pnpm lint && pnpm format:check` clean; relay tests 54/54.
- On Bun 1.3.14: `import('./filesystem.ts')` rejects with the clean error (previously: process abort).
- Repro of the underlying panic on 1.3.14 confirmed via the 3-line koffi repro from the upstream issue.
