### PR TITLE
fix: fall back to current model for side calls

### DIFF
--- a/.changeset/fair-pandas-relax.md
+++ b/.changeset/fair-pandas-relax.md
@@ -1,0 +1,6 @@
+---
+'@nicknisi/pi-btw': patch
+'@nicknisi/pi-recap': patch
+---
+
+Fall back to the current session model when a configured model override is absent or unavailable.

--- a/packages/btw/README.md
+++ b/packages/btw/README.md
@@ -8,7 +8,7 @@ Use it for the "quick question while the agent works" case: explanations, altern
 
 | Surface                    | Name                              | Notes                                                                                      |
 | -------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------ |
-| Slash command              | `/btw <question>`                 | Uses the model configured in `~/.pi/agent/configs/btw.json`                                |
+| Slash command              | `/btw <question>`                 | Uses the configured model override or the current session model                            |
 | Overlay window             | `BtwWindow` via `ctx.ui.custom()` | Streaming markdown thread + follow-up editor                                               |
 | Custom entry type          | `btw-answer`                      | Persisted via `pi.appendEntry()`, rendered by `pi.registerEntryRenderer()`                 |
 | Legacy custom message type | `btw-answer`                      | Old sessions stored answers as custom messages; still rendered and filtered out of context |
@@ -66,7 +66,7 @@ Fork happens _before_ the transcript card is persisted, so the forked session do
 ## How it works
 
 - On `/btw`, the current branch (`ctx.sessionManager.getBranch()`) is converted to LLM messages with `convertToLlm()`. Assistant tool calls with no matching `toolResult` are dropped first, because `/btw` can run mid-turn when tool calls are still unanswered, and Anthropic rejects `tool_use` blocks without a matching `tool_result`.
-- The side thread starts from that snapshot. Each question is sent to the configured model with a fixed system prompt (concise, no tool suggestions) via `getModelProvider(ctx, model).streamSimple(...)`, with `apiKey`/`headers` from `ctx.modelRegistry.getApiKeyAndHeaders()` and the current thinking level (`off` maps to `undefined`). Completed Q&A pairs are appended to the side thread, so follow-ups have full side-thread history plus the original branch snapshot.
+- The side thread starts from that snapshot. Each question is sent to the configured model override, or the current session model if no override is configured or it cannot be resolved, with a fixed system prompt (concise, no tool suggestions) via `getModelProvider(ctx, model).streamSimple(...)`, with `apiKey`/`headers` from `ctx.modelRegistry.getApiKeyAndHeaders()` and the current thinking level (`off` maps to `undefined`). Completed Q&A pairs are appended to the side thread, so follow-ups have full side-thread history plus the original branch snapshot.
 - The overlay is a `Component`/`Focusable` from `@earendil-works/pi-tui`, rendering a bordered box (max width 100, body capped at 30 rows or `terminal.rows - 14`) with a spinner while streaming and markdown-rendered answers.
 - On close with at least one completed turn, the thread is persisted via `pi.appendEntry<BtwEntryData>("btw-answer", { model, turns })`.
 
@@ -84,7 +84,7 @@ Optional global config: `~/.pi/agent/configs/btw.json`. Changes take effect on t
 }
 ```
 
-`model` must be a `provider/model-id` string registered in Pi with working authentication. Model IDs may contain additional slashes; only the first slash separates the provider. Missing or invalid config falls back to `fireworks/glm-latest` and invalid config emits a warning. See [`btw.example.json`](./btw.example.json).
+`model` is an optional `provider/model-id` override registered in Pi with working authentication. Model IDs may contain additional slashes; only the first slash separates the provider. If it is omitted or cannot be resolved, `/btw` uses the current session model. Invalid config emits a warning. See [`btw.example.json`](./btw.example.json).
 
 | Variable       | Values   | Default                                                                  |
 | -------------- | -------- | ------------------------------------------------------------------------ |

--- a/packages/btw/config.test.ts
+++ b/packages/btw/config.test.ts
@@ -42,6 +42,12 @@ describe('loadBtwConfig', () => {
     expect(loadBtwConfig(tempDir())).toEqual({ config: DEFAULT_BTW_CONFIG, warnings: [] });
   });
 
+  it('uses the current model when the config omits model', () => {
+    const agentDir = tempDir();
+    writeConfig(agentDir, {});
+    expect(loadBtwConfig(agentDir)).toEqual({ config: DEFAULT_BTW_CONFIG, warnings: [] });
+  });
+
   it('loads a configured provider and model', () => {
     const agentDir = tempDir();
     writeConfig(agentDir, { model: 'anthropic/claude-sonnet-4-5' });

--- a/packages/btw/config.ts
+++ b/packages/btw/config.ts
@@ -3,8 +3,8 @@ import { join } from 'node:path';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface BtwConfig {
-  /** Model as provider/model-id. Model ids may themselves contain slashes. */
-  model: string;
+  /** Optional model override as provider/model-id. Model ids may themselves contain slashes. */
+  model?: string;
 }
 
 export interface LoadedBtwConfig {
@@ -12,9 +12,7 @@ export interface LoadedBtwConfig {
   warnings: string[];
 }
 
-export const DEFAULT_BTW_CONFIG: BtwConfig = {
-  model: 'fireworks/glm-latest',
-};
+export const DEFAULT_BTW_CONFIG: BtwConfig = {};
 
 export function btwConfigPath(agentDir = getAgentDir()): string {
   return join(agentDir, 'configs', 'btw.json');
@@ -45,6 +43,7 @@ export function loadBtwConfig(agentDir = getAgentDir()): LoadedBtwConfig {
     parsed && typeof parsed === 'object' && !Array.isArray(parsed)
       ? (parsed as Record<string, unknown>).model
       : undefined;
+  if (model === undefined) return { config: { ...DEFAULT_BTW_CONFIG }, warnings: [] };
   if (typeof model !== 'string' || !parseModelSpec(model)) {
     return {
       config: { ...DEFAULT_BTW_CONFIG },

--- a/packages/btw/index.ts
+++ b/packages/btw/index.ts
@@ -415,10 +415,14 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      const modelSpec = parseModelSpec(config.model)!;
-      const model = ctx.modelRegistry.find(modelSpec.provider, modelSpec.id);
+      const modelSpec = config.model ? parseModelSpec(config.model) : undefined;
+      const configuredModel = modelSpec ? ctx.modelRegistry.find(modelSpec.provider, modelSpec.id) : undefined;
+      if (config.model && !configuredModel) {
+        ctx.ui.notify(`btw model not found: ${config.model}; using current model`, 'warning');
+      }
+      const model = configuredModel ?? ctx.model;
       if (!model) {
-        ctx.ui.notify(`btw model not found: ${config.model}`, 'error');
+        ctx.ui.notify('btw: no current model available', 'error');
         return;
       }
 

--- a/packages/recap/README.md
+++ b/packages/recap/README.md
@@ -42,10 +42,10 @@ Config file: `~/.pi/agent/configs/recap.json` (created on first `/recap-idle` wr
 }
 ```
 
-| Option        | Type                               | Default                     | Notes                                                                                                                                                                       |
-| ------------- | ---------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `idleMinutes` | number                             | `3`                         | Minutes of inactivity before an auto-recap fires. Set via `/recap-idle`.                                                                                                    |
-| `model`       | `{ provider: string; id: string }` | session model (`ctx.model`) | Optional override. Must be a model in pi's builtin catalog (`getModel` lookup); custom providers are not supported. Unknown provider/id logs a warning and skips the recap. |
+| Option        | Type                               | Default                     | Notes                                                                                        |
+| ------------- | ---------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------- |
+| `idleMinutes` | number                             | `3`                         | Minutes of inactivity before an auto-recap fires. Set via `/recap-idle`.                     |
+| `model`       | `{ provider: string; id: string }` | session model (`ctx.model`) | Optional override. If omitted or not registered in Pi, recap uses the current session model. |
 
 No environment variables are read.
 
@@ -61,7 +61,7 @@ No environment variables are read.
 Peer deps (all `@earendil-works/*`, provided by the pi host):
 
 - `@earendil-works/pi-ai` — `uuidv7` (session id for the completion call)
-- `@earendil-works/pi-ai/compat` — `complete`, `getModel` (one-shot summarization; `getModel` resolves config-specified models from the builtin catalog)
+- `@earendil-works/pi-ai/compat` — `complete` (one-shot summarization)
 - `@earendil-works/pi-coding-agent` — `ExtensionAPI`, `getMarkdownTheme`; uses `pi.registerCommand`, `pi.registerEntryRenderer`, `pi.appendEntry`, `pi.on`, `ctx.sessionManager.getBranch`, `ctx.modelRegistry.getApiKeyAndHeaders`, `ctx.isIdle`, `ctx.ui.notify`
 - `@earendil-works/pi-tui` — `Box`, `Text`, `Markdown` for the card renderer
 
@@ -71,7 +71,7 @@ No npm runtime deps, no workspace deps.
 
 - TUI only: the timer and renderer are installed in `session_start` only when `ctx.mode === "tui"`. `/recap` technically works in other modes but nothing renders the entry there.
 - Depends on several pi internals that could change across versions: `sessionManager.getBranch()`, `modelRegistry.getApiKeyAndHeaders()`, `ctx.isIdle()`, and the `session_start`/`before_agent_start`/`agent_settled` event names.
-- `getModel` is called through a deliberately widened signature (see code comment): its generics require literal catalog ids, but the config value is unvalidated JSON. An unknown model yields `undefined` and the recap is skipped with a warning. Custom-provider models cannot be used.
+- A configured model is resolved through `ctx.modelRegistry`, so registered custom providers work. An omitted or unresolved override falls back to the current session model.
 - The card background is a hardcoded truecolor escape (`#131320`) chosen to sit darker than the tokyonight base/message backgrounds (`theme.bg` only accepts named tokens). With other themes it may clash.
 - Entry content extraction is structural (filters blocks by `type === "text"` / `type === "toolCall"`), so changes to pi's message block shape would silently empty the transcript it summarizes.
 - The timer is cleared on `session_shutdown`; if a session never shuts down cleanly the interval lives until process exit.

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -1,5 +1,5 @@
 import { uuidv7 } from '@earendil-works/pi-ai';
-import { complete, getModel } from '@earendil-works/pi-ai/compat';
+import { complete } from '@earendil-works/pi-ai/compat';
 import { getAgentDir, getMarkdownTheme, type ExtensionAPI } from '@earendil-works/pi-coding-agent';
 import { Box, Markdown, Text } from '@earendil-works/pi-tui';
 import * as fs from 'node:fs';
@@ -101,12 +101,11 @@ function capLines(text: string, max: number): string {
 
 async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').ExtensionContext): Promise<string> {
   const cfg = readConfig();
-  // getModel is a static builtin-catalog read whose generics require literal
-  // provider/model ids, but recap's model comes from unvalidated JSON config.
-  // Widen the signature: an unknown provider or id yields undefined, which the
-  // guard below already reports. Custom providers are not in this catalog.
-  const lookupModel = getModel as (provider: string, id: string) => typeof ctx.model;
-  const model = cfg.model ? lookupModel(cfg.model.provider, cfg.model.id) : ctx.model;
+  const configuredModel =
+    cfg.model && typeof cfg.model.provider === 'string' && typeof cfg.model.id === 'string'
+      ? ctx.modelRegistry.find(cfg.model.provider, cfg.model.id)
+      : undefined;
+  const model = configuredModel ?? ctx.model;
   if (!model) {
     ctx.ui.notify('recap: no model available', 'warning');
     return '';


### PR DESCRIPTION
## Summary
- use the current session model when recap and btw overrides are absent or unavailable
- let recap resolve registered custom-provider models
- add config coverage and release changeset

## Verification
- pnpm test
- pnpm typecheck
- pnpm lint
- pnpm format:check