### PR TITLE
fix(recap,session-name): model fallback and OAuth auth support

### DIFF
--- a/.changeset/polite-crabs-hunt.md
+++ b/.changeset/polite-crabs-hunt.md
@@ -1,6 +1,6 @@
 ---
-"@nicknisi/pi-recap": patch
-"@nicknisi/pi-session-name": patch
+'@nicknisi/pi-recap': patch
+'@nicknisi/pi-session-name': patch
 ---
 
 Fix model fallback and OAuth auth support in recap and session-name

--- a/.changeset/polite-crabs-hunt.md
+++ b/.changeset/polite-crabs-hunt.md
@@ -1,0 +1,9 @@
+---
+"@nicknisi/pi-recap": patch
+"@nicknisi/pi-session-name": patch
+---
+
+Fix model fallback and OAuth auth support in recap and session-name
+
+- Cache the last seen session model from `before_agent_start` and `agent_settled` events so auto-recap can fall back when the agent is idle (`ctx.model` is only set during active turns)
+- Fix auth checks to accept OAuth and header-based auth methods, not just API keys (`getApiKeyAndHeaders` returns `ok: true` with `headers` but no `apiKey` for OAuth providers)

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -26,6 +26,7 @@ let lastActivity = Date.now();
 let firedThisIdle = false;
 let timer: ReturnType<typeof setInterval> | null = null;
 let piRef: ExtensionAPI | null = null;
+let lastModel: import('@earendil-works/pi-coding-agent').ExtensionContext['model'] = undefined;
 
 function readConfig(): Config {
   try {
@@ -105,14 +106,14 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
     cfg.model && typeof cfg.model.provider === 'string' && typeof cfg.model.id === 'string'
       ? ctx.modelRegistry.find(cfg.model.provider, cfg.model.id)
       : undefined;
-  const model = configuredModel ?? ctx.model;
+  const model = configuredModel ?? ctx.model ?? lastModel;
   if (!model) {
     ctx.ui.notify('recap: no model available', 'warning');
     return '';
   }
   const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-  if (!auth?.ok || !auth.apiKey) {
-    ctx.ui.notify('recap: no API key for model', 'warning');
+  if (!auth?.ok) {
+    ctx.ui.notify(`recap: ${auth.error ?? 'no API key for model'}`, 'warning');
     return '';
   }
   const conversation = buildConversation(ctx.sessionManager.getBranch());
@@ -129,9 +130,9 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
       ],
     },
     {
-      apiKey: auth.apiKey,
       // Spread conditionally: optional in ProviderStreamOptions, and
       // exactOptionalPropertyTypes rejects an explicit undefined.
+      ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
       ...(auth.headers !== undefined && { headers: auth.headers }),
       ...(auth.env !== undefined && { env: auth.env }),
       reasoningEffort: 'low',
@@ -186,13 +187,15 @@ export default function (pi: ExtensionAPI) {
     }, TICK_MS);
   });
 
-  pi.on('before_agent_start', async () => {
+  pi.on('before_agent_start', async (_e, ctx) => {
     lastActivity = Date.now();
     firedThisIdle = false;
+    lastModel = ctx.model ?? lastModel;
   });
 
-  pi.on('agent_settled', async () => {
+  pi.on('agent_settled', async (_e, ctx) => {
     lastActivity = Date.now();
+    lastModel = ctx.model ?? lastModel;
   });
 
   pi.on('session_shutdown', async (_e, ctx) => {

--- a/packages/session-name/index.ts
+++ b/packages/session-name/index.ts
@@ -294,7 +294,7 @@ export default function sessionNameExtension(pi: ExtensionAPI): void {
     const model = resolveTitleModel(ctx);
     if (!model) return null;
     const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-    if (!auth.ok || !auth.apiKey) return null;
+    if (!auth.ok) return null;
 
     const controller = new AbortController();
     titleAbort = controller;


### PR DESCRIPTION
- Cache last seen model from `before_agent_start`/`agent_settled` so auto-recap can fall back when the agent is idle (`ctx.model` is only set during active turns)
- Fix auth checks to accept OAuth/header-based auth, not just API keys (`getApiKeyAndHeaders` returns `ok: true` with `headers` but no `apiKey` for OAuth providers)