### PR TITLE
feat: add claude-design package

### DIFF
--- a/.changeset/lazy-drinks-design.md
+++ b/.changeset/lazy-drinks-design.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-claude-design': minor
+---
+
+New package: Claude Design (claude.ai/design) in pi via Anthropic's official MCP server. Adds a `design` skill that drives the full brief → artboards → preview → iterate → implement workflow, `/design-login`/`/design-status`/`/design-logout` commands, and a dependency-free `claude-design-auth` CLI whose `token` command wires into pi-mcp-adapter as a `!command` Authorization header. Same PKCE flow as Claude Code's `/design-login`; tokens refresh lazily, only when the server is actually used.

--- a/README.md
+++ b/README.md
@@ -46,17 +46,18 @@ Local paths are added to pi's settings without copying — edits in the repo are
 
 ### Behavior & plumbing
 
-| Package                                  | What it does                                                                                                                 | Adds                                                |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| [agent-urls](packages/agent-urls/)       | `agent://` / `history://` URIs for pi-subagents runs; list and read run outputs/transcripts                                  | `/agent`, `list_agent_runs`, `read_agent_url` tools |
-| [artifacts](packages/artifacts/)         | `artifact` tool: render markdown/HTML to styled browser pages from a lazy localhost server, with live reload                 | `artifact` tool, `/artifacts`                       |
-| [auto-theme](packages/auto-theme/)       | Sync pi theme with macOS system appearance (dark↔light pairs)                                                                | —                                                   |
-| [claude-compat](packages/claude-compat/) | Claude Code compatibility: `CLAUDE_PLUGIN_ROOT` path shimming + `` !`command` `` dynamic SKILL.md placeholders (allowlisted) | two extension entry points                          |
-| [cloak](packages/cloak/)                 | Redact secrets from `read` tool results before they reach model context, via glob-scoped regex rules                         | `/cloak-status`, `cloak.json`                       |
-| [fast](packages/fast/)                   | Toggle premium faster inference for supported Anthropic Claude and OpenAI Codex models                                       | `/fast`, footer status                              |
-| [model-switch](packages/model-switch/)   | Cycle or fuzzy-pick from a machine-local, sectioned model list, skipping missing or unauthenticated entries                  | `/model-cycle`, configurable shortcuts              |
-| [session-name](packages/session-name/)   | Auto-name sessions (heuristic or LLM), mirror to terminal title, name-focused session picker                                 | `/sn`, `/sessions`                                  |
-| [stash](packages/stash/)                 | `ctrl+s` parks the prompt draft on a LIFO stack; pop or auto-restore                                                         | `ctrl+s`, stash widget                              |
+| Package                                  | What it does                                                                                                                 | Adds                                                      |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| [agent-urls](packages/agent-urls/)       | `agent://` / `history://` URIs for pi-subagents runs; list and read run outputs/transcripts                                  | `/agent`, `list_agent_runs`, `read_agent_url` tools       |
+| [artifacts](packages/artifacts/)         | `artifact` tool: render markdown/HTML to styled browser pages from a lazy localhost server, with live reload                 | `artifact` tool, `/artifacts`                             |
+| [auto-theme](packages/auto-theme/)       | Sync pi theme with macOS system appearance (dark↔light pairs)                                                                | —                                                         |
+| [claude-compat](packages/claude-compat/) | Claude Code compatibility: `CLAUDE_PLUGIN_ROOT` path shimming + `` !`command` `` dynamic SKILL.md placeholders (allowlisted) | two extension entry points                                |
+| [claude-design](packages/claude-design/) | Claude Design (claude.ai/design) in pi: `design` skill over the official MCP server, plus login commands and auth CLI        | `design` skill, `/design-login`, `claude-design-auth` CLI |
+| [cloak](packages/cloak/)                 | Redact secrets from `read` tool results before they reach model context, via glob-scoped regex rules                         | `/cloak-status`, `cloak.json`                             |
+| [fast](packages/fast/)                   | Toggle premium faster inference for supported Anthropic Claude and OpenAI Codex models                                       | `/fast`, footer status                                    |
+| [model-switch](packages/model-switch/)   | Cycle or fuzzy-pick from a machine-local, sectioned model list, skipping missing or unauthenticated entries                  | `/model-cycle`, configurable shortcuts                    |
+| [session-name](packages/session-name/)   | Auto-name sessions (heuristic or LLM), mirror to terminal title, name-focused session picker                                 | `/sn`, `/sessions`                                        |
+| [stash](packages/stash/)                 | `ctrl+s` parks the prompt draft on a LIFO stack; pop or auto-restore                                                         | `ctrl+s`, stash widget                                    |
 
 ### Library
 

--- a/packages/claude-design/README.md
+++ b/packages/claude-design/README.md
@@ -1,0 +1,83 @@
+# @nicknisi/pi-claude-design
+
+Connects pi to Anthropic's official Claude Design MCP server (`https://api.anthropic.com/v1/design/mcp`) so you can create and edit [claude.ai/design](https://claude.ai/design) projects from a pi session — the same workflow as Claude Code's `/design`.
+
+> **Read [Warnings](#warnings) before installing.** This package authenticates using an OAuth client identity that Anthropic registered for its own products, not for third-party clients.
+
+## Why this exists
+
+Anthropic does not support generic MCP clients for Claude Design (verified against the live endpoints, 2026-08):
+
+- OAuth authorization-server metadata (RFC 8414) is behind a Cloudflare JS challenge on `claude.ai`, so standard discovery fails for any non-browser client. Spec-fallback default endpoints (`/authorize`, `/token`, `/register` on the issuer) are challenged too.
+- There is no dynamic client registration endpoint anywhere (`claude.ai`, `claude.com`, `platform.claude.com`, `api.anthropic.com`), so a generic client can never obtain a client id.
+
+The only working integration path is the one Claude Code's `/design-login` uses: a PKCE flow against fixed endpoints with Anthropic's pre-registered Design OAuth client id. This package runs that exact flow locally, in ~150 lines of dependency-free code you can read, instead of executing a third-party proxy.
+
+## What it adds
+
+**`design` skill** — any "design me…" request (or `/skill:design <brief>`) drives the full workflow: loads Anthropic's own design system prompt from the server (`get_claude_design_prompt`), creates or reuses a claude.ai/design project, applies your bound design system, writes `.dc.html` design files, returns rendered previews with a visual verify loop, iterates on feedback and inline web comments, and can import the chosen direction into your codebase.
+
+**Pi extension** — three commands:
+
+| Command          | Purpose                                                                     |
+| ---------------- | --------------------------------------------------------------------------- |
+| `/design-login`  | Browser PKCE authorization; paste the `CODE#STATE` value into the input box |
+| `/design-status` | Show credential state and expiry                                            |
+| `/design-logout` | Delete stored credentials                                                   |
+
+**`claude-design-auth`** — a Node CLI for use outside pi (no dependencies):
+
+| Command     | Purpose                                                                      |
+| ----------- | ---------------------------------------------------------------------------- |
+| `login`     | Browser PKCE authorization; paste the `CODE#STATE` value back                |
+| `token`     | Print `Bearer <access-token>`, refreshing only when expired (for MCP config) |
+| `status`    | Show credential state and expiry                                             |
+| `logout`    | Delete stored credentials                                                    |
+| `selfcheck` | Run inline assertions                                                        |
+
+Everything is lazy: nothing runs at pi startup, the MCP server connects on first tool use, and `token` makes zero network calls while the stored access token is still valid. If you never touch Design in a session, no request is made.
+
+## Setup
+
+1. Install the package (`pi install npm:@nicknisi/pi-claude-design` or a local path in `settings.json` `packages`), then run `/design-login` in pi. Approve in the browser and paste the `CODE#STATE` value. Outside pi: `npx -p @nicknisi/pi-claude-design claude-design-auth login`.
+
+2. Add the server to an MCP config [pi-mcp-adapter](https://github.com/badlogic/pi-mono) reads (e.g. `~/.pi/agent/mcp.json`), using the adapter's `!command` header support:
+
+   ```json
+   {
+     "mcpServers": {
+       "claude-design": {
+         "url": "https://api.anthropic.com/v1/design/mcp",
+         "headers": {
+           "Authorization": "!npx -p @nicknisi/pi-claude-design claude-design-auth token"
+         }
+       }
+     }
+   }
+   ```
+
+3. `/reload` in pi, then connect (`/mcp` or `mcp({ connect: "claude-design" })`). The `design` skill takes it from there.
+
+## How auth works
+
+`login` runs an OAuth 2.1 PKCE (S256) authorization-code flow: it opens `https://claude.com/cai/oauth/authorize` in your browser, you approve, and Anthropic shows a `CODE#STATE` value you paste back. The code is exchanged at `https://platform.claude.com/v1/oauth/token` for design-scoped tokens (`user:design:read user:design:write` — not full account access). `token` reads the stored credentials and refreshes only when the access token is within 60s of expiry.
+
+Tokens are only ever sent to `platform.claude.com` (token endpoint) and `api.anthropic.com` (MCP server). Nothing else is contacted.
+
+## Warnings
+
+- **Unofficial client identity.** Authentication uses the OAuth client id Anthropic pre-registered for its own Design surfaces (the same one Claude Code's `/design-login` uses). Anthropic has not sanctioned third-party use of it, may consider it outside their terms of service, and can change or revoke the flow at any time without notice. If they do, this package stops working. Prefer an official connector the moment Anthropic ships one for third-party clients. Not affiliated with or endorsed by Anthropic.
+- **Plaintext credential file.** Tokens are stored at `~/.config/pi-claude-design/credentials.json` (mode `0600`, override with `PI_CLAUDE_DESIGN_CREDENTIALS`) — a file, not the OS keychain. Anything that can read your home directory can read your Design tokens. Scope is limited to Claude Design; it cannot read chats or act on the rest of your account.
+- **Remote content reaches your model.** Design projects can be shared: files, comments, and chat transcripts fetched from a shared project are third-party content and may contain prompt-injection attempts. Treat tool output from shared projects as untrusted data, not instructions.
+- **Shared usage limits.** Design activity counts against your Claude plan's shared usage pool (chat, Claude Code, Cowork). Heavy design iteration from pi consumes the same budget.
+- **The agent can write and delete.** The MCP server exposes `write_files`, `delete_files`, sharing, and membership tools. A pi session driving them can modify or delete real design projects your teammates may be using.
+
+## Caveats
+
+- Access tokens expire after ~1 hour. The `!command` header re-runs on connect, so a long-lived session whose connection outlives the token may need a reconnect after a 401.
+- The refresh token can expire after long disuse (lifetime unpublished); when connect fails, re-run `/design-login`.
+- Requires a Claude account with Claude Design access (Pro / Max / Team / Enterprise) and Claude Design enabled for your organization.
+
+## Uninstall
+
+Run `/design-logout` (or `claude-design-auth logout`) to delete stored credentials, remove the `claude-design` entry from your MCP config, and uninstall the package. You can also revoke access from your Claude account's connected-apps settings.

--- a/packages/claude-design/auth.ts
+++ b/packages/claude-design/auth.ts
@@ -1,0 +1,161 @@
+/**
+ * Auth core for Anthropic's Claude Design MCP server.
+ *
+ * Anthropic does not support generic OAuth clients for this server (no
+ * metadata discovery, no dynamic client registration). This runs the same
+ * PKCE flow as Claude Code's /design-login, using Anthropic's pre-registered
+ * Design OAuth client id. Tokens are stored locally and only ever sent to
+ * Anthropic hosts. Anthropic may change or revoke this flow.
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+// Anthropic's Design OAuth client (same as Claude Code /design-login)
+const CLIENT_ID = '59637612-477b-4836-a601-b0589eda7704';
+const SCOPES = 'user:design:read user:design:write';
+const AUTHORIZE_URL = 'https://claude.com/cai/oauth/authorize';
+const TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+const REDIRECT_URI = 'https://platform.claude.com/oauth/code/callback';
+const REFRESH_SKEW_MS = 60_000;
+
+export const STORE_PATH =
+  process.env['PI_CLAUDE_DESIGN_CREDENTIALS'] ?? join(homedir(), '.config', 'pi-claude-design', 'credentials.json');
+
+interface TokenStore {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}
+
+interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+export interface LoginStart {
+  url: string;
+  state: string;
+  verifier: string;
+}
+
+const b64url = (buf: Buffer): string => buf.toString('base64url');
+
+async function loadStore(): Promise<TokenStore | null> {
+  try {
+    return JSON.parse(await readFile(STORE_PATH, 'utf8')) as TokenStore;
+  } catch {
+    return null;
+  }
+}
+
+async function saveStore(store: TokenStore): Promise<void> {
+  await mkdir(dirname(STORE_PATH), { recursive: true });
+  await writeFile(STORE_PATH, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+async function postToken(body: Record<string, string>): Promise<TokenResponse> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`Token request failed (${res.status}): ${text.slice(0, 300)}`);
+  return JSON.parse(text) as TokenResponse;
+}
+
+function toStore(data: TokenResponse, previous?: TokenStore): TokenStore {
+  const refreshToken = data.refresh_token ?? previous?.refreshToken;
+  if (!refreshToken) throw new Error('Token response missing refresh_token');
+  return {
+    accessToken: data.access_token,
+    refreshToken,
+    expiresAt: Date.now() + Number(data.expires_in ?? 3600) * 1000,
+  };
+}
+
+export function parsePastedCode(raw: string): { code: string; state: string } | null {
+  const parts = raw
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .split('#');
+  const [code, state] = parts;
+  if (parts.length !== 2 || !code || !state) return null;
+  return { code, state };
+}
+
+/** Build the browser authorization URL plus the PKCE secrets needed to finish. */
+export function startLogin(): LoginStart {
+  const verifier = b64url(randomBytes(32));
+  const challenge = b64url(createHash('sha256').update(verifier).digest());
+  const state = b64url(randomBytes(32));
+  const url = new URL(AUTHORIZE_URL);
+  url.search = String(
+    new URLSearchParams({
+      code: 'true',
+      client_id: CLIENT_ID,
+      response_type: 'code',
+      redirect_uri: REDIRECT_URI,
+      scope: SCOPES,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state,
+    }),
+  );
+  return { url: String(url), state, verifier };
+}
+
+/** Exchange the pasted CODE#STATE value for tokens and persist them. */
+export async function completeLogin(start: LoginStart, rawPaste: string): Promise<void> {
+  const pasted = parsePastedCode(rawPaste);
+  if (!pasted) throw new Error('Expected a value like CODE#STATE');
+  if (pasted.state !== start.state) throw new Error('State mismatch — paste the code from this login attempt');
+
+  const data = await postToken({
+    grant_type: 'authorization_code',
+    code: pasted.code,
+    redirect_uri: REDIRECT_URI,
+    client_id: CLIENT_ID,
+    code_verifier: start.verifier,
+    state: pasted.state,
+  });
+  const granted = data.scope ?? SCOPES;
+  for (const scope of SCOPES.split(' ')) {
+    if (!granted.includes(scope)) throw new Error(`Design scope not granted: ${scope}`);
+  }
+  await saveStore(toStore(data));
+}
+
+/** Return a valid access token, refreshing first when expired or near expiry. */
+export async function freshAccessToken(): Promise<string> {
+  let store = await loadStore();
+  if (!store?.accessToken || !store.refreshToken) {
+    throw new Error('Not logged in. Run /design-login in pi or: claude-design-auth login');
+  }
+  if (Date.now() >= store.expiresAt - REFRESH_SKEW_MS) {
+    const data = await postToken({
+      grant_type: 'refresh_token',
+      refresh_token: store.refreshToken,
+      client_id: CLIENT_ID,
+      scope: SCOPES,
+    });
+    store = toStore(data, store);
+    await saveStore(store);
+  }
+  return store.accessToken;
+}
+
+export async function statusText(): Promise<string> {
+  const store = await loadStore();
+  if (!store) return `logged_out (${STORE_PATH})`;
+  const state = Date.now() >= store.expiresAt ? 'expired (will auto-refresh)' : 'logged_in';
+  return `${state}, expires ${new Date(store.expiresAt).toISOString()} (${STORE_PATH})`;
+}
+
+export async function logout(): Promise<void> {
+  await rm(STORE_PATH, { force: true });
+}

--- a/packages/claude-design/bin/claude-design-auth.mjs
+++ b/packages/claude-design/bin/claude-design-auth.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * CLI for Claude Design auth outside pi. Core logic lives in ../auth.ts
+ * (compiled to ../dist/auth.js). Commands: login | token | status | logout | selfcheck
+ *
+ * `token` prints "Bearer <access-token>", refreshing only when expired —
+ * wire it into pi-mcp-adapter as a `!command` Authorization header.
+ */
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+
+import {
+  STORE_PATH,
+  completeLogin,
+  freshAccessToken,
+  logout,
+  parsePastedCode,
+  startLogin,
+  statusText,
+} from '../dist/auth.js';
+
+function ask(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) =>
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer);
+    }),
+  );
+}
+
+const commands = {
+  login: async () => {
+    const start = startLogin();
+    console.log(`Open to authorize Claude Design access:\n\n${start.url}\n`);
+    if (process.platform === 'darwin') {
+      spawn('open', [start.url], { detached: true, stdio: 'ignore' }).unref();
+    }
+    await completeLogin(start, await ask('Paste the CODE#STATE value shown after approval > '));
+    console.log(`\nAuthorized. Credentials saved to ${STORE_PATH}`);
+  },
+  token: async () => {
+    process.stdout.write(`Bearer ${await freshAccessToken()}`);
+  },
+  status: async () => {
+    console.log(await statusText());
+  },
+  logout: async () => {
+    await logout();
+    console.log(`Removed ${STORE_PATH}`);
+  },
+  selfcheck: async () => {
+    const { deepStrictEqual, strictEqual, match } = await import('node:assert/strict');
+    deepStrictEqual(parsePastedCode(" 'abc#xyz' "), { code: 'abc', state: 'xyz' });
+    strictEqual(parsePastedCode('abc'), null);
+    strictEqual(parsePastedCode('abc#xyz#extra'), null);
+    strictEqual(parsePastedCode('#xyz'), null);
+    const start = startLogin();
+    match(start.url, /^https:\/\/claude\.com\/cai\/oauth\/authorize\?/);
+    match(start.url, /code_challenge_method=S256/);
+    strictEqual(new URL(start.url).searchParams.get('state'), start.state);
+    console.log('ok');
+  },
+};
+
+const run = commands[process.argv[2] || 'token'];
+if (!run) {
+  console.error('Usage: claude-design-auth <login|token|status|logout>');
+  process.exit(2);
+}
+run().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/packages/claude-design/index.ts
+++ b/packages/claude-design/index.ts
@@ -1,0 +1,52 @@
+import { spawn } from 'node:child_process';
+
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+
+import { completeLogin, logout, startLogin, statusText } from './auth.js';
+
+function openBrowser(url: string): void {
+  const opener = process.platform === 'darwin' ? 'open' : 'xdg-open';
+  spawn(opener, [url], { detached: true, stdio: 'ignore' }).unref();
+}
+
+export default function claudeDesignExtension(pi: ExtensionAPI) {
+  pi.registerCommand('design-login', {
+    description: 'Authorize Claude Design MCP access (opens browser, paste CODE#STATE back)',
+    handler: async (_args, ctx) => {
+      const start = startLogin();
+      openBrowser(start.url);
+      const pasted = await ctx.ui.input(
+        'Approve Claude Design access in the browser, then paste the CODE#STATE value:',
+        'CODE#STATE',
+      );
+      if (!pasted?.trim()) {
+        ctx.ui.notify('Login cancelled', 'warning');
+        return;
+      }
+      try {
+        await completeLogin(start, pasted);
+        ctx.ui.notify(
+          'Claude Design authorized — the claude-design MCP server will pick it up on next connect',
+          'info',
+        );
+      } catch (error) {
+        ctx.ui.notify(`Login failed: ${error instanceof Error ? error.message : String(error)}`, 'error');
+      }
+    },
+  });
+
+  pi.registerCommand('design-status', {
+    description: 'Show Claude Design credential status',
+    handler: async (_args, ctx) => {
+      ctx.ui.notify(await statusText(), 'info');
+    },
+  });
+
+  pi.registerCommand('design-logout', {
+    description: 'Delete stored Claude Design credentials',
+    handler: async (_args, ctx) => {
+      await logout();
+      ctx.ui.notify('Claude Design credentials removed', 'info');
+    },
+  });
+}

--- a/packages/claude-design/package.json
+++ b/packages/claude-design/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@nicknisi/pi-claude-design",
+  "version": "0.0.0",
+  "description": "Connect pi to Anthropic's Claude Design MCP server: /design-login command plus auth CLI for pi-mcp-adapter",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/claude-design#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/claude-design"
+  },
+  "bin": {
+    "claude-design-auth": "./bin/claude-design-auth.mjs"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "index.ts",
+    "auth.ts",
+    "skills"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "skills": [
+      "./skills"
+    ]
+  }
+}

--- a/packages/claude-design/skills/design/SKILL.md
+++ b/packages/claude-design/skills/design/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: design
+description: Create and iterate on UI designs, prototypes, decks, and mockups in Claude Design (claude.ai/design) via its official MCP server. Use when the user asks to design something, wants UI mockups or artboard options, says /design, or wants to import a Claude Design project into the codebase.
+---
+
+# Claude Design
+
+Drive Anthropic's Claude Design through the `claude-design` MCP server. Designs live in real claude.ai/design projects: rendered previews, shareable links, editable in the web UI.
+
+## Prerequisites
+
+The `claude-design` MCP tools (`claude-design_*`) must be available. If the server is not connected, connect it (`mcp({ connect: "claude-design" })`). If connecting fails with an auth error, tell the user to run `/design-login` and stop.
+
+## Workflow
+
+1. **Load Anthropic's design guidance first.** Call `claude-design_get_claude_design_prompt` and follow it — it is the same system prompt the claude.ai/design agent uses (file conventions, artboard structure, quality bar). Consult `claude-design_read_design_skill` for specific design-quality topics when relevant. Do not improvise your own conventions when theirs conflict.
+2. **Pick a project.** `claude-design_list_projects` to reuse an existing project when the user is iterating; otherwise `claude-design_create_project`. Check `claude-design_list_design_systems` and apply the user's design system when one exists.
+3. **Gather local context.** When designing for the current codebase, scan it for design tokens (tailwind config, CSS variables), existing components, and brand assets, and reflect them in the design files.
+4. **Write the design.** `claude-design_finalize_plan` with the exact paths, then `claude-design_write_files`. For multiple directions, produce distinct labeled variations (A/B/C) as separate artboards/files, per the loaded design prompt's conventions.
+5. **Show it.** `claude-design_render_preview` and give the user the `serve_url` (and project URL) to open. Do not describe the design in prose as a substitute for the preview.
+6. **Iterate.** Apply feedback with further `finalize_plan` → `write_files` rounds against the same project. Check `claude-design_list_comments` for inline comments left in the web UI and `claude-design_ack_comments` after addressing them.
+7. **Implement (optional).** When the user picks a direction and wants it built, `claude-design_read_file` the chosen files and implement them in the codebase using its real components and conventions.
+
+## Notes
+
+- Auth is lazy; the first tool call may take a moment while the server connects and refreshes the token. A 401 after a long idle session means reconnect; a persistent auth failure means `/design-login`.
+- Sharing: `claude-design_update_sharing` / `claude-design_add_member` when the user asks to share.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,8 @@ importers:
 
   packages/claude-compat: {}
 
+  packages/claude-design: {}
+
   packages/cloak: {}
 
   packages/codemode:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -143,7 +143,12 @@ function verify(name: string): string[] {
   return problems;
 }
 
-const names = buildOrder(workspacePackages());
+/** JS-only packages (e.g. a plain .mjs bin) have nothing to compile or verify. */
+function hasTsSources(name: string): boolean {
+  return readdirSync(join(packagesDir, name)).some((f) => f.endsWith('.ts'));
+}
+
+const names = buildOrder(workspacePackages()).filter(hasTsSources);
 const failed: string[] = [];
 
 for (const name of names) {


### PR DESCRIPTION
## What

New package `@nicknisi/pi-claude-design`: Claude Design (claude.ai/design) in pi via Anthropic's **official** MCP server (`api.anthropic.com/v1/design/mcp`).

- **`design` skill** — brief → project → `.dc.html` artboards → rendered preview → iterate (incl. inline web comments) → optionally implement in the codebase. Fetches Anthropic's own design system prompt from the server and follows it.
- **Extension commands** — `/design-login` (browser PKCE, paste `CODE#STATE` into an input box), `/design-status`, `/design-logout`.
- **`claude-design-auth` CLI** — dependency-free; `token` prints a Bearer header for pi-mcp-adapter's `!command` header support, refreshing only when expired. Fully lazy: nothing runs unless a design tool is actually used.
- **`scripts/build.ts`** — skip JS-only packages (this one ships a plain `.mjs` bin alongside compiled TS).

## Why the auth looks like this

Tested against the live endpoints: OAuth metadata discovery is Cloudflare-challenged, spec-fallback endpoints too, and there is no dynamic client registration anywhere — generic-client OAuth is impossible, not just broken. The only working path is the one Claude Code's `/design-login` uses: PKCE against fixed endpoints with Anthropic's pre-registered Design client id. This package implements that flow in ~150 reviewable lines instead of running a third-party proxy.

## Warnings (also in the package README)

- Borrows Anthropic's Design OAuth client identity; unsanctioned, revocable, possibly outside ToS. Not affiliated with Anthropic.
- Tokens in a plaintext `0600` file (design-scoped only, not full account).
- Shared-project content fetched via MCP is untrusted third-party input.
- Design usage draws from the Claude plan's shared usage pool.

## Verified

- `pnpm typecheck && pnpm lint && pnpm format:check && pnpm build` green; CLI `selfcheck` passes.
- End-to-end smoke test: login → lazy connect (23 tools) → project created → `.dc.html` written → preview rendered and visually verified from a pi session.