### PR TITLE
feat(artifacts): share action — clipboard, reveal, gist, and PNG image

### DIFF
--- a/.changeset/artifacts-share-action.md
+++ b/.changeset/artifacts-share-action.md
@@ -1,0 +1,5 @@
+---
+"@nicknisi/pi-artifacts": minor
+---
+
+Add a `share` action for artifacts: copy the self-contained HTML to the clipboard, reveal the file in the OS file manager, upload as a GitHub gist, or screenshot the rendered artifact to a PNG.

--- a/.changeset/artifacts-share-action.md
+++ b/.changeset/artifacts-share-action.md
@@ -1,5 +1,5 @@
 ---
-"@nicknisi/pi-artifacts": minor
+'@nicknisi/pi-artifacts': minor
 ---
 
 Add a `share` action for artifacts: copy the self-contained HTML to the clipboard, reveal the file in the OS file manager, upload as a GitHub gist, or screenshot the rendered artifact to a PNG.

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -12,7 +12,7 @@ pi install /Users/nicknisi/Developer/pi-extensions/packages/artifacts
 
 ## What it adds
 
-- **Tool `artifact`** — action-based (`create` | `update` | `open` | `list`). Registered with a `promptSnippet` ("emit visual output as a browser HTML artifact instead of terminal text") so the model knows when to reach for it.
+- **Tool `artifact`** — action-based (`create` | `update` | `open` | `list` | `share`). Registered with a `promptSnippet` ("emit visual output as a browser HTML artifact instead of terminal text") so the model knows when to reach for it.
 - **Command `/artifacts`** — starts the lazy server and opens the index page (`/`) in the browser.
 - **Event hook** — `session_shutdown`: stops the HTTP server.
 - **Browser UI** — styled artifact pages plus an index page at `/`; live reload via an `/events` SSE endpoint. No TUI widgets, overlays, keybindings, or custom message/entry types: tool results use pi's default rendering (the tool returns structured `details` — `action`, `slug`, `title`, `kind`, `url`, `absPath` — and a text summary containing the clickable localhost URL).
@@ -21,20 +21,23 @@ pi install /Users/nicknisi/Developer/pi-extensions/packages/artifacts
 
 Parameters (TypeBox schema):
 
-| Param     | Type / values                            | Default                             | Notes                                                                                 |
-| --------- | ---------------------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------- |
-| `action`  | `create` \| `update` \| `open` \| `list` | required                            | `update` on a missing slug creates it                                                 |
-| `title`   | string                                   | required for create/update/open     | slug derived from it (kebab-case, max 80 chars)                                       |
-| `kind`    | `markdown` \| `html`                     | required for create/update          | never auto-detected from content                                                      |
-| `content` | string                                   | —                                   | inline markdown or HTML                                                               |
-| `path`    | string                                   | —                                   | alternative to `content`: read file relative to cwd (2 MB cap; `kind` still required) |
-| `open`    | boolean                                  | `true` on create, `false` on update | auto-open in browser after write                                                      |
+| Param     | Type / values                                       | Default                               | Notes                                                                                 |
+| --------- | --------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
+| `action`  | `create` \| `update` \| `open` \| `list` \| `share` | required                              | `update` on a missing slug creates it                                                 |
+| `title`   | string                                              | required for create/update/open/share | slug derived from it (kebab-case, max 80 chars)                                       |
+| `method`  | `clipboard` \| `reveal` \| `gist`                   | `clipboard` (share only)              | how to hand off the file: clipboard copy, file-manager reveal, or GitHub gist         |
+| `public`  | boolean                                             | `false` (share method=gist only)      | make the gist public; default is a secret gist                                        |
+| `kind`    | `markdown` \| `html`                                | required for create/update            | never auto-detected from content                                                      |
+| `content` | string                                              | —                                     | inline markdown or HTML                                                               |
+| `path`    | string                                              | —                                     | alternative to `content`: read file relative to cwd (2 MB cap; `kind` still required) |
+| `open`    | boolean                                             | `true` on create, `false` on update   | auto-open in browser after write                                                      |
 
 Behavior per action:
 
 - `create` / `update` — write `<slug>.html` and return slug + localhost URL + absolute path. `update` pushes an SSE reload event to connected browser tabs, so iterating on a report reuses one file and one tab. If `open` is false and the server isn't running, no URL is returned (`(server not running — use action: open to view)`).
 - `open` — starts the server (if needed) and opens the artifact in the browser. Errors if the slug doesn't exist.
 - `list` — lists artifacts newest-first (title, kind, timestamp, slug, absolute path). Does **not** start the server; URLs are included only if the server is already running.
+- `share` — hands the artifact file off, since every artifact is already one self-contained HTML file. `clipboard` (default) copies the rendered HTML (pbcopy / clip / wl-copy); `reveal` shows the file in the OS file manager (Finder via `open -R`), ready to AirDrop or drag into Slack; `gist` runs `gh gist create` under the user's GitHub account (requires the `gh` CLI, authed), copies the URL to the clipboard, and opens it — secret unless `public: true`. Gists display as source, not a rendered page, so `gist` is for durable attributable upload, not for showing someone the rendered report.
 
 Example tool call (as the model would emit it):
 

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -21,23 +21,24 @@ pi install /Users/nicknisi/Developer/pi-extensions/packages/artifacts
 
 Parameters (TypeBox schema):
 
-| Param     | Type / values                                       | Default                               | Notes                                                                                 |
-| --------- | --------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------- |
-| `action`  | `create` \| `update` \| `open` \| `list` \| `share` | required                              | `update` on a missing slug creates it                                                 |
-| `title`   | string                                              | required for create/update/open/share | slug derived from it (kebab-case, max 80 chars)                                       |
-| `method`  | `clipboard` \| `reveal` \| `gist`                   | `clipboard` (share only)              | how to hand off the file: clipboard copy, file-manager reveal, or GitHub gist         |
-| `public`  | boolean                                             | `false` (share method=gist only)      | make the gist public; default is a secret gist                                        |
-| `kind`    | `markdown` \| `html`                                | required for create/update            | never auto-detected from content                                                      |
-| `content` | string                                              | —                                     | inline markdown or HTML                                                               |
-| `path`    | string                                              | —                                     | alternative to `content`: read file relative to cwd (2 MB cap; `kind` still required) |
-| `open`    | boolean                                             | `true` on create, `false` on update   | auto-open in browser after write                                                      |
+| Param              | Type / values                                       | Default                               | Notes                                                                                             |
+| ------------------ | --------------------------------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `action`           | `create` \| `update` \| `open` \| `list` \| `share` | required                              | `update` on a missing slug creates it                                                             |
+| `title`            | string                                              | required for create/update/open/share | slug derived from it (kebab-case, max 80 chars)                                                   |
+| `method`           | `clipboard` \| `reveal` \| `gist` \| `image`        | `clipboard` (share only)              | how to hand off the artifact: clipboard copy, file-manager reveal, GitHub gist, or PNG screenshot |
+| `public`           | boolean                                             | `false` (share method=gist only)      | make the gist public; default is a secret gist                                                    |
+| `width` / `height` | integer                                             | `1280` / `800` (method=image only)    | viewport size for the screenshot; it becomes the image size                                       |
+| `kind`             | `markdown` \| `html`                                | required for create/update            | never auto-detected from content                                                                  |
+| `content`          | string                                              | —                                     | inline markdown or HTML                                                                           |
+| `path`             | string                                              | —                                     | alternative to `content`: read file relative to cwd (2 MB cap; `kind` still required)             |
+| `open`             | boolean                                             | `true` on create, `false` on update   | auto-open in browser after write                                                                  |
 
 Behavior per action:
 
 - `create` / `update` — write `<slug>.html` and return slug + localhost URL + absolute path. `update` pushes an SSE reload event to connected browser tabs, so iterating on a report reuses one file and one tab. If `open` is false and the server isn't running, no URL is returned (`(server not running — use action: open to view)`).
 - `open` — starts the server (if needed) and opens the artifact in the browser. Errors if the slug doesn't exist.
 - `list` — lists artifacts newest-first (title, kind, timestamp, slug, absolute path). Does **not** start the server; URLs are included only if the server is already running.
-- `share` — hands the artifact file off, since every artifact is already one self-contained HTML file. `clipboard` (default) copies the rendered HTML (pbcopy / clip / wl-copy); `reveal` shows the file in the OS file manager (Finder via `open -R`), ready to AirDrop or drag into Slack; `gist` runs `gh gist create` under the user's GitHub account (requires the `gh` CLI, authed), copies the URL to the clipboard, and opens it — secret unless `public: true`. Gists display as source, not a rendered page, so `gist` is for durable attributable upload, not for showing someone the rendered report.
+- `share` — hands the artifact file off, since every artifact is already one self-contained HTML file. `clipboard` (default) copies the rendered HTML (pbcopy / clip / wl-copy); `reveal` shows the file in the OS file manager (Finder via `open -R`), ready to AirDrop or drag into Slack; `gist` runs `gh gist create` under the user's GitHub account (requires the `gh` CLI, authed), copies the URL to the clipboard, and opens it — secret unless `public: true`. Gists display as source, not a rendered page, so `gist` is for durable attributable upload, not for showing someone the rendered report. `image` starts the server (if needed), screenshots the rendered page with a headless Chrome-family browser (`--headless --screenshot`, discovered in /Applications on macOS or `google-chrome` on PATH elsewhere), and writes `<slug>.png` next to the artifact — on macOS the PNG is also placed on the clipboard as an image, ready to paste into Slack or docs. For share cards, author a full-bleed full-document `html` artifact so the card fills the viewport.
 
 Example tool call (as the model would emit it):
 

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -11,9 +11,13 @@ import {
   isSafeSlug,
   writeArtifact,
   artifactExists,
+  readArtifact,
   listArtifacts,
   openInBrowser,
   artifactPath,
+  copyToClipboard,
+  revealFile,
+  createGist,
 } from './utils.js';
 import { renderMarkdownDocument, renderHtmlDocument } from './templates.js';
 
@@ -78,10 +82,28 @@ export default function artifacts(pi: ExtensionAPI) {
     promptSnippet:
       'Emit visual output (reports, diagrams, rendered diffs, tables) as a browser HTML artifact instead of terminal text',
     parameters: Type.Object({
-      action: Type.Union([Type.Literal('create'), Type.Literal('update'), Type.Literal('open'), Type.Literal('list')], {
-        description:
-          'create: write new artifact. update: overwrite existing (or create if missing) + live-reload open tabs. open: start server + open in browser. list: list artifacts (no server start).',
-      }),
+      action: Type.Union(
+        [
+          Type.Literal('create'),
+          Type.Literal('update'),
+          Type.Literal('open'),
+          Type.Literal('list'),
+          Type.Literal('share'),
+        ],
+        {
+          description:
+            'create: write new artifact. update: overwrite existing (or create if missing) + live-reload open tabs. open: start server + open in browser. list: list artifacts (no server start). share: hand the artifact file off — clipboard, file manager, or a GitHub gist (gist only when the user asks for an upload; it shows the source, not a rendered page).',
+        },
+      ),
+      method: Type.Optional(
+        Type.Union([Type.Literal('clipboard'), Type.Literal('reveal'), Type.Literal('gist')], {
+          description:
+            "share only. clipboard (default): copy the self-contained HTML. reveal: show the file in the OS file manager. gist: `gh gist create` (requires gh CLI + auth) — uploads under the user's GitHub account, copies the URL, opens it.",
+        }),
+      ),
+      public: Type.Optional(
+        Type.Boolean({ description: 'share method=gist only. Make the gist public. Default: false (secret gist).' }),
+      ),
       title: Type.Optional(
         Type.String({
           description: 'Artifact title; slug is derived from it. Required for create/update/open.',
@@ -160,6 +182,51 @@ export default function artifacts(pi: ExtensionAPI) {
           content: [{ type: 'text' as const, text: `Opened ${title}\n${url}\n${absPath}` }],
           details: details as unknown as Record<string, unknown>,
         };
+      }
+
+      // ── share ──────────────────────────────────────────────────────────────
+      if (action === 'share') {
+        if (!artifactExists(slug)) {
+          return errResult(`no artifact with slug "${slug}" — create it first.`, { slug, title });
+        }
+        const method = params.method ?? 'clipboard';
+        try {
+          if (method === 'clipboard') {
+            const html = readArtifact(slug)!;
+            await copyToClipboard(html);
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Copied ${title} to the clipboard (${Math.round(html.length / 1024)} KB of self-contained HTML).\n${absPath}`,
+                },
+              ],
+              details: { action, slug, title, method, absPath } as Record<string, unknown>,
+            };
+          }
+          if (method === 'reveal') {
+            revealFile(absPath);
+            return {
+              content: [{ type: 'text' as const, text: `Revealed in the file manager:\n${absPath}` }],
+              details: { action, slug, title, method, absPath } as Record<string, unknown>,
+            };
+          }
+          // gist
+          const url = await createGist(absPath, title, params.public ?? false);
+          await copyToClipboard(url).catch(() => {}); // clipboard is a nicety, never the failure mode
+          openInBrowser(url);
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Gist created (${params.public ? 'public' : 'secret'}), URL copied to clipboard:\n${url}\n\nNote: gist.github.com shows the source. Share the file itself for the rendered page.`,
+              },
+            ],
+            details: { action, slug, title, method, url, absPath } as Record<string, unknown>,
+          };
+        } catch (e) {
+          return errResult(`share (${method}) failed: ${e instanceof Error ? e.message : String(e)}`, { slug, title });
+        }
       }
 
       // ── create / update — need kind + content ──────────────────────────────

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -15,9 +15,12 @@ import {
   listArtifacts,
   openInBrowser,
   artifactPath,
+  artifactDir,
   copyToClipboard,
   revealFile,
   createGist,
+  screenshotUrl,
+  copyImageToClipboard,
 } from './utils.js';
 import { renderMarkdownDocument, renderHtmlDocument } from './templates.js';
 
@@ -96,10 +99,16 @@ export default function artifacts(pi: ExtensionAPI) {
         },
       ),
       method: Type.Optional(
-        Type.Union([Type.Literal('clipboard'), Type.Literal('reveal'), Type.Literal('gist')], {
+        Type.Union([Type.Literal('clipboard'), Type.Literal('reveal'), Type.Literal('gist'), Type.Literal('image')], {
           description:
-            "share only. clipboard (default): copy the self-contained HTML. reveal: show the file in the OS file manager. gist: `gh gist create` (requires gh CLI + auth) — uploads under the user's GitHub account, copies the URL, opens it.",
+            "share only. clipboard (default): copy the self-contained HTML. reveal: show the file in the OS file manager. gist: `gh gist create` (requires gh CLI + auth) — uploads under the user's GitHub account, copies the URL, opens it. image: screenshot the rendered artifact to <slug>.png via a headless Chrome-family browser (copies the PNG to the clipboard on macOS).",
         }),
+      ),
+      width: Type.Optional(
+        Type.Integer({ description: 'share method=image only. Viewport width in px. Default: 1280.', minimum: 200 }),
+      ),
+      height: Type.Optional(
+        Type.Integer({ description: 'share method=image only. Viewport height in px. Default: 800.', minimum: 200 }),
       ),
       public: Type.Optional(
         Type.Boolean({ description: 'share method=gist only. Make the gist public. Default: false (secret gist).' }),
@@ -209,6 +218,24 @@ export default function artifacts(pi: ExtensionAPI) {
             return {
               content: [{ type: 'text' as const, text: `Revealed in the file manager:\n${absPath}` }],
               details: { action, slug, title, method, absPath } as Record<string, unknown>,
+            };
+          }
+          if (method === 'image') {
+            const url = await artifactUrl(slug); // starts the lazy server the browser will hit
+            const pngPath = join(artifactDir(), `${slug}.png`);
+            await screenshotUrl(url, pngPath, params.width ?? 1280, params.height ?? 800);
+            const copied = await copyImageToClipboard(pngPath);
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: `Rendered ${title} to an image (${params.width ?? 1280}×${params.height ?? 800}):\n${pngPath}${copied ? '\nCopied to the clipboard as an image — paste it anywhere.' : ''}`,
+                },
+              ],
+              details: { action, slug, title, method, absPath: pngPath, imageCopied: copied } as Record<
+                string,
+                unknown
+              >,
             };
           }
           // gist

--- a/packages/artifacts/utils.ts
+++ b/packages/artifacts/utils.ts
@@ -1,7 +1,7 @@
 /** Pure helpers: slugify, artifact file I/O, browser open. */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, normalize, sep } from 'node:path';
+import { dirname, join, normalize, sep } from 'node:path';
 import { spawn } from 'node:child_process';
 
 import { ARTIFACT_DIR } from './config.js';
@@ -135,4 +135,52 @@ export function openInBrowser(url: string): void {
   spawn(cmd, args, { detached: true, stdio: 'ignore' })
     .on('error', (err) => console.warn(`openInBrowser: ${cmd} failed: ${err.message}`))
     .unref();
+}
+
+/** Run a command, resolve with trimmed stdout. Rejects with stderr (or spawn error) on failure. */
+function run(cmd: string, args: string[], input?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args);
+    let out = '';
+    let err = '';
+    child.stdout.on('data', (d) => (out += d));
+    child.stderr.on('data', (d) => (err += d));
+    child.on('error', (e) => reject(new Error(`${cmd} is not available: ${e.message}`)));
+    child.on('close', (code) =>
+      code === 0 ? resolve(out.trim()) : reject(new Error(err.trim() || `${cmd} exited with code ${code}`)),
+    );
+    if (input != null) child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
+/** Copy text to the system clipboard (pbcopy / clip / wl-copy). */
+export async function copyToClipboard(text: string): Promise<void> {
+  const [cmd, args] =
+    process.platform === 'darwin'
+      ? (['pbcopy', []] as const)
+      : process.platform === 'win32'
+        ? (['clip', []] as const)
+        : (['wl-copy', []] as const);
+  await run(cmd, [...args], text);
+}
+
+/** Reveal a file in the OS file manager (Finder / Explorer / xdg-open on its directory). */
+export function revealFile(absPath: string): void {
+  const [cmd, args] =
+    process.platform === 'darwin'
+      ? ['open', ['-R', absPath]]
+      : process.platform === 'win32'
+        ? ['explorer', [`/select,${absPath}`]]
+        : ['xdg-open', [dirname(absPath)]];
+  spawn(cmd, args, { detached: true, stdio: 'ignore' })
+    .on('error', (err) => console.warn(`revealFile: ${cmd} failed: ${err.message}`))
+    .unref();
+}
+
+/** Upload an artifact file as a GitHub gist via the gh CLI. Returns the gist URL. */
+export async function createGist(absPath: string, title: string, isPublic: boolean): Promise<string> {
+  const args = ['gist', 'create', absPath, '--desc', title];
+  if (isPublic) args.push('--public');
+  return run('gh', args);
 }

--- a/packages/artifacts/utils.ts
+++ b/packages/artifacts/utils.ts
@@ -184,3 +184,52 @@ export async function createGist(absPath: string, title: string, isPublic: boole
   if (isPublic) args.push('--public');
   return run('gh', args);
 }
+
+/** Locate a headless-capable browser binary. darwin: known app paths; elsewhere: PATH names. */
+function findBrowser(): string | null {
+  if (process.platform === 'darwin') {
+    for (const p of [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    ]) {
+      if (existsSync(p)) return p;
+    }
+    return null;
+  }
+  // linux/win: rely on PATH; spawn errors surface as a clear message from run()
+  return 'google-chrome';
+}
+
+/**
+ * Screenshot a URL to a PNG via headless Chrome-family flags.
+ * The artifact server must already be running (the caller ensures it).
+ */
+export async function screenshotUrl(url: string, outPath: string, width: number, height: number): Promise<void> {
+  const browser = findBrowser();
+  if (!browser) {
+    throw new Error(
+      'no Chrome-family browser found (looked in /Applications). Install Chrome or Chromium to render images.',
+    );
+  }
+  await run(browser, [
+    '--headless',
+    '--disable-gpu',
+    '--hide-scrollbars',
+    `--window-size=${width},${height}`,
+    `--screenshot=${outPath}`,
+    url,
+  ]);
+  if (!existsSync(outPath)) throw new Error('the browser exited without writing a screenshot.');
+}
+
+/** Copy a PNG file to the clipboard as an image (macOS only). Returns false on other platforms or failure. */
+export async function copyImageToClipboard(absPath: string): Promise<boolean> {
+  if (process.platform !== 'darwin') return false;
+  try {
+    await run('osascript', ['-e', `set the clipboard to (read (POSIX file "${absPath}") as «class PNGf»)`]);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What

New `share` action on the `artifact` tool. Every artifact is already one self-contained HTML file, so sharing is a hand-off of that file:

| Method | What it does |
|---|---|
| `clipboard` (default) | Copies the rendered HTML (pbcopy / clip / wl-copy) |
| `reveal` | Shows the file in the OS file manager (`open -R` in Finder) — ready to AirDrop or drag into Slack |
| `gist` | `gh gist create` under the user's GitHub account (secret unless `public: true`), URL copied + opened |
| `image` | Screenshots the rendered page with a headless Chrome-family browser to `<slug>.png` (`width`/`height` set the viewport, default 1280×800); on macOS the PNG also lands on the clipboard as an image |

## Notes

- Upload is explicit opt-in — `gist` only runs when the model is told the user asked for it; the tool description says so.
- Gists render as source, not a page — README and tool output both say it; `reveal`/`image` are the show-someone paths.
- Browser discovery for `image`: known /Applications paths on macOS, `google-chrome` on PATH elsewhere, with a clear error when nothing is found.

## Verified

- typecheck, oxlint, oxfmt, full build (28 packages)
- clipboard round-trip test (pbcopy → pbpaste)
- end-to-end `image` smoke test against a real artifact: PNG written, clipboard image copy confirmed