### PR TITLE
fix(orchestrate): /goal stop now stops a running /loop and aborts the in-flight turn

### DIFF
--- a/.changeset/orchestrate-goal-stop.md
+++ b/.changeset/orchestrate-goal-stop.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-orchestrate': patch
+---
+
+`/goal stop` (and clear aliases) now stops a running `/loop` too — previously it replied "No goal set" while a loop kept re-firing, which read as a goal that couldn't be stopped. Clearing also aborts the in-flight turn so the stop is immediate.

--- a/packages/orchestrate/README.md
+++ b/packages/orchestrate/README.md
@@ -20,7 +20,7 @@ Claude Code-style `/goal` and `/loop` for pi. `/goal <condition>` makes the sess
 /goal clear          remove the active goal
 ```
 
-Clear aliases: `clear`, `stop`, `off`, `reset`, `none`, `cancel`. Tab completion is provided for `clear` and `stop`.
+Clear aliases: `clear`, `stop`, `off`, `reset`, `none`, `cancel`. Tab completion is provided for `clear` and `stop`. Stop means stop: clearing also stops a running `/loop` (a runaway "goal" is usually a loop, which `/goal` subcommands otherwise can't see) and aborts the in-flight turn so the stop is immediate.
 
 Setting a goal immediately sends the condition as a user message (`deliverAs: "followUp"` when idle, `"steer"` mid-turn). After each `agent_end`, the evaluator reads the transcript tail (last ~20000 chars, text content only) and returns `YES`/`NO` plus a one-sentence reason. On `NO`, the reason is fed back as guidance for the next turn. On `YES`, the goal clears automatically. If the evaluator itself errors, the session keeps working toward the condition (the failure is treated as transient, not as a goal verdict).
 

--- a/packages/orchestrate/index.ts
+++ b/packages/orchestrate/index.ts
@@ -6,6 +6,9 @@
  *                       met, then clears the goal automatically.
  * /goal                 show status (condition, duration, turns, last reason).
  * /goal clear           remove the active goal (stop|off|reset|none|cancel ok).
+ *                       Stop means stop: also stops a running /loop and aborts
+ *                       the in-flight turn, since a runaway "goal" report is
+ *                       usually a loop the user can't see from /goal.
  *
  * /loop [interval] <prompt>   re-run a prompt while the session stays open.
  *   /loop 5m check if the deploy finished
@@ -371,16 +374,32 @@ function setGoal(ctx: ExtensionContext, condition: string): void {
 }
 
 function clearGoal(ctx: ExtensionContext, silent = false): void {
-  if (!goal) {
-    if (!silent) notify(ctx, 'No goal set');
-    return;
-  }
-  const cond = goal.condition;
+  const cond = goal?.condition;
   goal = null;
+  // Stop means stop. A runaway "goal" report is usually a running /loop the
+  // user can't see from /goal subcommands — take it down too, and abort the
+  // in-flight turn so the stop is immediate instead of letting the current
+  // turn (and one queued continuation) play out after the clear.
+  const stoppedLoop = loop ? { prompt: loop.prompt, iterations: loop.iterations } : null;
+  if (loop) stopLoop(ctx, true);
   persist(ctx);
   if (!goal && !loop) clearStateFile(ctx.cwd);
   refreshStatus(ctx);
-  if (!silent) notify(ctx, `Goal cleared: ${short(cond)}`);
+  if (cond !== undefined || stoppedLoop) {
+    try {
+      ctx.abort();
+    } catch {
+      /* best effort — cleared state already guarantees no new continuations */
+    }
+  }
+  if (silent) return;
+  const parts: string[] = [];
+  if (cond !== undefined) parts.push(`Goal cleared: ${short(cond)}`);
+  if (stoppedLoop)
+    parts.push(
+      `Loop stopped (${stoppedLoop.iterations} run${stoppedLoop.iterations === 1 ? '' : 's'}): ${short(stoppedLoop.prompt)}`,
+    );
+  notify(ctx, parts.length > 0 ? parts.join('\n') : 'No goal set');
 }
 
 function goalStatus(ctx: ExtensionContext): void {
@@ -593,14 +612,14 @@ export default function (pi: ExtensionAPI): void {
 
   pi.registerCommand('goal', {
     description:
-      "Set a completion condition and pi keeps working until a model confirms it's met. /goal <condition> | /goal (status) | /goal clear",
+      "Set a completion condition and pi keeps working until a model confirms it's met. /goal <condition> | /goal (status) | /goal clear — clear also stops a running /loop and aborts the in-flight turn",
     getArgumentCompletions: (prefix: string) =>
       ['clear', 'stop']
         .filter((v) => v.startsWith(prefix))
         .map((v) => ({
           value: v + ' ',
           label: v,
-          description: v === 'clear' ? 'remove the active goal' : 'alias of clear',
+          description: v === 'clear' ? 'stop the goal (and any running loop)' : 'alias of clear',
         })),
     handler: async (args: string, ctx: ExtensionContext) => cmdGoal(args, ctx),
   });

--- a/packages/orchestrate/orchestrate.test.ts
+++ b/packages/orchestrate/orchestrate.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the "/goal stop doesn't work" report.
+ *
+ * The runaway state file showed `goal: null` with a 326-iteration /loop —
+ * clearGoal() returned "No goal set" and never touched the loop. The fix:
+ * /goal stop|clear stops a running loop too and aborts the in-flight turn.
+ *
+ * The extension module holds goal/loop in module-level state, so the tests
+ * drive it through the captured command handlers with a stub ctx, the same
+ * way pi would.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import factory from './index.js';
+
+let cwd: string;
+
+function makeHarness() {
+  const commands = new Map<string, (args: string, ctx: unknown) => Promise<void> | void>();
+  const sent: string[] = [];
+  const api = {
+    registerCommand: (name: string, def: { handler: (args: string, ctx: unknown) => void }) =>
+      commands.set(name, def.handler),
+    on: () => {},
+    sendUserMessage: (text: string) => {
+      sent.push(text);
+    },
+  };
+  const notifications: string[] = [];
+  const abort = vi.fn();
+  const ctx = {
+    cwd,
+    hasUI: true,
+    ui: {
+      notify: (msg: string) => notifications.push(msg),
+      setStatus: () => {},
+    },
+    sessionManager: { getSessionFile: () => path.join(cwd, 'session.jsonl') },
+    isIdle: () => true,
+    abort,
+  };
+  factory(api as never);
+  return { commands, sent, notifications, abort, ctx };
+}
+
+beforeEach(() => {
+  cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'pi-orchestrate-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(cwd, { recursive: true, force: true });
+});
+
+describe('/goal stop', () => {
+  it('stops a running loop even when no goal is set', async () => {
+    const h = makeHarness();
+    await h.commands.get('loop')!('run greptile review --agent until 5/5', h.ctx);
+    // Loop is live: it sent its first tick continuation.
+    expect(h.sent.some((m) => m.includes('greptile'))).toBe(true);
+
+    await h.commands.get('goal')!('stop', h.ctx);
+    expect(h.notifications.some((n) => n.includes('Loop stopped'))).toBe(true);
+    expect(h.abort).toHaveBeenCalled();
+
+    // The loop must stay dead across an agent_end (this is what fired 326 times).
+    h.sent.length = 0;
+    await h.commands.get('goal')!('', h.ctx); // status — also proves no goal adopted
+    expect(h.notifications.some((n) => n.includes('No goal set'))).toBe(true);
+    expect(h.sent).toEqual([]);
+  });
+
+  it('clears an active goal and aborts the in-flight turn', async () => {
+    const h = makeHarness();
+    await h.commands.get('goal')!('all tests pass', h.ctx);
+    expect(h.sent).toEqual(['all tests pass']);
+
+    await h.commands.get('goal')!('stop', h.ctx);
+    expect(h.notifications.some((n) => n.includes('Goal cleared: all tests pass'))).toBe(true);
+    expect(h.abort).toHaveBeenCalled();
+  });
+
+  it('with nothing running, says so and does NOT abort an unrelated turn', async () => {
+    const h = makeHarness();
+    await h.commands.get('goal')!('stop', h.ctx);
+    expect(h.notifications).toEqual(['No goal set']);
+    expect(h.abort).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Confirm

The user's runaway `/goal` was this package (orchestrate), not the third-party `@narumitw/pi-goal` (installed in the npm store but absent from settings.json). Evidence: `cli/graphql-client/.pi-goal/state.json` matches orchestrate's `SavedState` shape exactly and shows `goal: null` with a **326-iteration self-paced loop** (`run greptile review --agent until the score is 5/5`).

Two real defects:

1. **`/goal stop` never touches a running loop.** `clearGoal()` returned early with "No goal set" when `goal` was null — but the thing running was a `/loop`, which only `/loop stop` stops. From the user's side: the goal machine won't stop.
2. **Clearing didn't abort the in-flight turn.** Even a successful clear let the current turn run to completion (and one already-queued continuation fire), so a working stop still looked like it didn't.

## Fix

- `clearGoal` (covering `stop|clear|off|reset|none|cancel`) now also stops a running loop and reports both actions: `Goal cleared: …` / `Loop stopped (N runs): …`.
- When it actually stopped something, it calls `ctx.abort()` (typed on `ExtensionContext`) so the in-flight turn dies immediately. With nothing running it does NOT abort, so `/goal stop` can't kill an unrelated turn mid-flight.
- Regression test drives the captured command handlers: stop-with-loop-only, stop-with-goal, stop-with-nothing.

## Verification

- `packages/orchestrate/orchestrate.test.ts`: 3/3 pass.
- `pnpm typecheck && pnpm lint && pnpm format:check` clean.
- Full suite: 233/234; the one failure is `packages/relay/core.test.ts` (pnpm offline pack/install), which fails identically on main.