### PR TITLE
feat(subagents): add profiles — persona files with skill baskets

### DIFF
--- a/.changeset/spotty-pugs-repeat.md
+++ b/.changeset/spotty-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-subagents': minor
+---
+
+Add profiles (personas): named agent-definition markdown files that bundle a skill basket, tool allowlist, model, and system prompt. Dispatch tasks select one with the new strict `profile` field, and the `&` prefix resolves `&<name>` against profiles before falling back to a plain label. Profiles are discovered first-wins from `.pi/agents/` (project), `<agentDir>/agents/` (user), and embedder-provided `SubagentsOptions.profileDirs`; bare skill names resolve through the parent session's skill catalog, and unresolved skills warn without failing the dispatch.

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -11,6 +11,7 @@ First-party subagent dispatch and fleet for pi — fan out parallel child agents
 - **`/patches` command** — staging area for worktree-subagent `.patch` handoffs. Opens a keyboard-driven overlay over every pending patch with diffstat and a pre-flight stamp (`clean` / `conflicts` / `stale`, checked via `git apply --check` **without** applying). `Enter` applies the whole patch (`git apply --3way`); `e` expands the full diff with per-hunk navigation (`n`/`p`); `s` applies the focused hunk; `d` discards. Apply/discard decisions persist to `~/.pi/agent/subagent-patches/state.json` so `/patches` survives restart.
 - **`&` dispatch prefix** — `&scout how does auth work` at position zero dispatches a single subagent inline (reusing the same spawn/cancel path as the `dispatch` tool). Live progress shows in a widget above the editor; the final result lands as a collapsible `subagents:inline` transcript block rendered with the same vocabulary as a dispatch tool result, and the answer reaches the model's context. Each dispatch is captured as a session custom entry so it survives restart.
 - **`/again [amendment]` command** — re-fires the last `&` dispatch verbatim, or with the amendment appended.
+- **Profiles (personas)** — named agent-definition markdown files bundling a skill basket, tool allowlist, model, and system prompt. A dispatch task passes `profile: "reviewer"` (or the editor uses `&reviewer …`) instead of hand-assembling those per task. See **Profiles** below.
 
 ## Usage
 
@@ -123,9 +124,59 @@ Children are **hermetic by construction**: no user extensions, skills, prompt te
 
 `spawn()` never rejects; results are a discriminated union (`ok | crashed | empty | schema_invalid | aborted`). See `packages/shared/README.md` for the full runtime API.
 
+## Profiles
+
+A profile is a markdown file — frontmatter on top, persona system prompt below — that names a reusable child persona: which skills it carries, which tools it may use, optionally which model it runs, and how it should behave. Hermetic children get **no** skills by default; a profile is the curated basket that opts specific ones in.
+
+```markdown
+---
+name: reviewer
+description: Code review — correctness, tests, simplicity
+skills: pr, review-checklist
+tools: read, grep, find, ls
+model: anthropic/claude-sonnet-4-5
+---
+
+Review the change against the task. Prefer the smallest correct fix.
+```
+
+| Field         | Meaning                                                                                                                                                                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`        | Profile name (defaults to the file stem).                                                                                                                                                                                                                    |
+| `description` | Required — shown in the dispatch tool's profile catalog.                                                                                                                                                                                                     |
+| `skills`      | Skill basket: bare names resolve against the parent session's skill catalog (wherever pi discovered them — user dir, project, packages, `--skill` flags); entries with a `/` or `.md` resolve relative to the profile file. Missing skills warn, never fail. |
+| `tools`       | Tool allowlist. Omitted = dispatch's read-only default.                                                                                                                                                                                                      |
+| `model`       | Optional model spec.                                                                                                                                                                                                                                         |
+| `worktree`    | Default the task to worktree isolation — set this on builder personas so their `edit`/`write`/`bash` tools stay parallel and need no `allowTreeMutation`.                                                                                                    |
+| `replace`     | Replace pi's system prompt with the persona prompt instead of appending.                                                                                                                                                                                     |
+
+Lists accept comma-separated scalars or `- item` block lists. Unknown keys are ignored, so agent files shared with other harnesses load. The parser is deliberately small — flat `key: value` frontmatter, not full YAML.
+
+**Discovery** (first-wins by name, highest precedence first):
+
+1. `<cwd>/.pi/agents/*.md` — project profiles
+2. `~/.pi/agent/agents/*.md` — user profiles
+3. Host-provided extra dirs (`SubagentsOptions.profileDirs`) — e.g. a distribution's bundled defaults
+
+Dirs are rescanned on each dispatch, so edits apply without a restart (the tool _description_'s profile catalog refreshes on session start).
+
+**Merge semantics:** explicit task fields win — call beats persona, persona beats defaults. `profile` on a dispatch task is strict: an unknown name refuses that task and lists the known profiles. The `&` prefix resolves softly: `&reviewer fix this` applies the `reviewer` profile when it exists and otherwise keeps the old plain-label behavior. `replace` applies only when the persona's own prompt is used.
+
+```json
+{ "tasks": [{ "task": "Review this diff for correctness", "profile": "reviewer" }] }
+```
+
 ## Configuration
 
-None. No config files, no environment variables.
+None required. Embedders can pass options through the factory:
+
+```ts
+import subagents from '@nicknisi/pi-subagents';
+
+export default (pi: ExtensionAPI) => subagents(pi, { profileDirs: ['/path/to/bundled/profiles'] });
+```
+
+`profileDirs` appends lowest-precedence profile directories — the hook for a distribution (e.g. arc) to ship default personas that user and project files can shadow.
 
 ## Caveats
 

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -60,6 +60,25 @@ import {
 } from '@nicknisi/pi-shared';
 import { Type } from 'typebox';
 import { scopeFleetRuns, type FleetScope } from './fleet.js';
+import {
+  applyProfile,
+  discoverProfiles,
+  profileSearchDirs,
+  resolveProfileSkills,
+  type AgentProfile,
+  type DiscoveredProfiles,
+} from './profiles.js';
+
+export type { AgentProfile } from './profiles.js';
+
+export interface SubagentsOptions {
+  /**
+   * Extra profile directories, searched after the project (`.pi/agents/`) and
+   * user (`<agentDir>/agents/`) dirs — the hook for a distribution's bundled
+   * default personas.
+   */
+  profileDirs?: string[];
+}
 
 const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
 const PATCHES_STATE_DIR = path.join(getAgentDir(), 'subagent-patches');
@@ -88,12 +107,16 @@ const BG_WIDGET_KEY = 'subagents-bg';
 interface TaskSpec {
   task: string;
   agent?: string | undefined;
+  profile?: string | undefined;
   model?: string | undefined;
   tools?: string[] | undefined;
   systemPrompt?: string | undefined;
   background?: boolean | undefined;
   allowTreeMutation?: boolean | undefined;
   worktree?: boolean | undefined;
+  /** Resolved by profile merging — not part of the tool schema. */
+  skillPaths?: string[] | undefined;
+  replaceSystemPrompt?: boolean | undefined;
 }
 
 type TaskStatus = 'pending' | 'working' | 'done' | 'error' | 'background';
@@ -131,9 +154,54 @@ function toSpawnOptions(spec: TaskSpec, cwd: string, parentSession: string | und
   if (spec.agent) opts.agent = spec.agent;
   if (spec.model) opts.model = spec.model;
   if (spec.systemPrompt) opts.systemPrompt = spec.systemPrompt;
+  if (spec.replaceSystemPrompt) opts.replaceSystemPrompt = true;
+  if (spec.skillPaths && spec.skillPaths.length > 0) opts.skillPaths = spec.skillPaths;
   if (spec.worktree) opts.worktree = true;
   if (parentSession) opts.parentSession = parentSession;
   return opts;
+}
+
+// ── Profiles ─────────────────────────────────────────────────────────────────
+
+/** Skill name -> SKILL.md path, from the parent session's discovered catalog. */
+function skillRegistry(pi: ExtensionAPI): Map<string, string> {
+  const registry = new Map<string, string>();
+  for (const cmd of pi.getCommands()) {
+    if (cmd.source !== 'skill') continue;
+    const name = cmd.name.startsWith('skill:') ? cmd.name.slice('skill:'.length) : cmd.name;
+    const skillPath = cmd.sourceInfo?.path;
+    if (skillPath && !registry.has(name)) registry.set(name, skillPath);
+  }
+  return registry;
+}
+
+/** Rescan profile dirs (cheap: a few readdirs) so edits apply without a restart. */
+function loadProfiles(cwd: string, extraDirs: string[]): DiscoveredProfiles {
+  return discoverProfiles(profileSearchDirs(cwd, getAgentDir(), extraDirs));
+}
+
+type ProfileMerge =
+  | { ok: true; spec: TaskSpec; missingSkills: string[]; profile: AgentProfile }
+  | { ok: false; error: string };
+
+/** Strict profile resolution + merge: unknown profile names fail loudly. */
+function mergeProfile(spec: TaskSpec, discovered: DiscoveredProfiles, registry: Map<string, string>): ProfileMerge {
+  const profile = discovered.profiles.get(spec.profile!);
+  if (!profile) {
+    const known = [...discovered.profiles.keys()];
+    const knownText = known.length > 0 ? `Known profiles: ${known.join(', ')}.` : 'No profiles are defined.';
+    const parseErrors =
+      discovered.errors.length > 0 ? ` Unloadable profile files: ${discovered.errors.join('; ')}` : '';
+    return { ok: false, error: `unknown profile '${spec.profile}'. ${knownText}${parseErrors}` };
+  }
+  const { skillPaths, missing } = resolveProfileSkills(profile, registry);
+  return { ok: true, spec: applyProfile(spec, profile, skillPaths), missingSkills: missing, profile };
+}
+
+function profileCatalogLine(profiles: Map<string, AgentProfile>): string {
+  if (profiles.size === 0) return '';
+  const items = [...profiles.values()].map((p) => `${p.name} (${short(p.description, 60)})`);
+  return ` Available profiles: ${items.join('; ')}.`;
 }
 
 function short(text: string, max: number): string {
@@ -1294,8 +1362,31 @@ async function dispatchInline(
   }
 }
 
-export default function subagents(pi: ExtensionAPI) {
+export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = {}) {
   const runtime = createSubagentRuntime({ namespace: 'subagents', artifactsDir: ARTIFACTS_ROOT });
+  const extraProfileDirs = options.profileDirs ?? [];
+  // Registration-time snapshot for the tool description; execution rescans.
+  const initialProfiles = loadProfiles(process.cwd(), extraProfileDirs);
+
+  // Soft profile resolution for `&<name>` / `/again`: a matching profile is
+  // applied; a non-matching name stays a plain label (back-compat with
+  // `&scout`-style ad-hoc labels).
+  const resolveInlineSpec = (ctx: ExtensionContext, spec: TaskSpec): TaskSpec => {
+    if (!spec.agent) return spec;
+    const discovered = loadProfiles(ctx.cwd, extraProfileDirs);
+    if (!discovered.profiles.has(spec.agent)) {
+      if (discovered.profiles.size > 0 && ctx.hasUI) {
+        ctx.ui.notify(`No profile '${spec.agent}' — running as a plain label`, 'info');
+      }
+      return spec;
+    }
+    const merged = mergeProfile({ ...spec, profile: spec.agent }, discovered, skillRegistry(pi));
+    if (!merged.ok) return spec; // unreachable after the has() check; stay safe
+    if (merged.missingSkills.length > 0 && ctx.hasUI) {
+      ctx.ui.notify(`Profile '${spec.agent}': skipped unresolved skills ${merged.missingSkills.join(', ')}`, 'warning');
+    }
+    return merged.spec;
+  };
   // GC old artifacts (7d retention, incl. worktrees + patches) and reap
   // ghost 'running' records left by dead host processes. Once per process.
   sweepRunArtifactsOnce(ARTIFACTS_ROOT);
@@ -1351,11 +1442,17 @@ export default function subagents(pi: ExtensionAPI) {
       'Tasks whose tools include edit, write, or bash mutate the shared working tree: they require',
       'allowTreeMutation: true and run sequentially after the parallel batch. Prefer worktree: true',
       'for builders instead — isolated worktrees stay parallel and hand off a patch for central integration.',
-    ].join(' '),
+      'A task may name a profile — a persona file bundling a skill basket, tool allowlist, model, and',
+      'system prompt — instead of assembling those per task; explicit task fields override profile values.',
+      profileCatalogLine(initialProfiles.profiles),
+    ]
+      .filter(Boolean)
+      .join(' '),
     promptSnippet: 'Fan out parallel child agents for independent subtasks',
     promptGuidelines: [
       `Use dispatch for independent parallel subtasks (max ${MAX_TASKS}); never for sequential work or trivial questions.`,
       'Children default to read-only tools (read, grep, find, ls). Pass tools explicitly for builders.',
+      'Prefer profile: "<name>" when a defined profile matches the work — it attaches the persona\'s skills, tools, and prompt.',
       'Set background: true for long-running tasks; results surface via the fleet tool.',
       'Tasks with edit/write/bash tools need allowTreeMutation: true and serialize after the parallel batch — or set worktree: true to isolate them and keep them parallel.',
     ],
@@ -1364,6 +1461,12 @@ export default function subagents(pi: ExtensionAPI) {
         Type.Object({
           task: Type.String({ description: 'The full prompt for this child agent' }),
           agent: Type.Optional(Type.String({ description: 'Label, e.g. "reviewer"' })),
+          profile: Type.Optional(
+            Type.String({
+              description:
+                'Profile (persona) name to launch as — attaches its skill basket, tools, model, and system prompt. Unknown names fail the task. Explicit task fields override profile values.',
+            }),
+          ),
           model: Type.Optional(Type.String({ description: 'Model spec, e.g. "anthropic/claude-haiku-4-5"' })),
           tools: Type.Optional(
             Type.Array(Type.String(), { description: 'Tool allowlist; default read-only (read, grep, find, ls)' }),
@@ -1387,12 +1490,40 @@ export default function subagents(pi: ExtensionAPI) {
     }),
 
     async execute(toolCallId, params, signal, onUpdate, ctx) {
-      const specs = params.tasks as TaskSpec[];
-      if (specs.length === 0) {
+      const rawSpecs = params.tasks as TaskSpec[];
+      if (rawSpecs.length === 0) {
         return toolResult('dispatch requires at least one task.');
       }
-      if (specs.length > MAX_TASKS) {
-        return toolResult(`Too many tasks (${specs.length}); max is ${MAX_TASKS}. Split into multiple dispatch calls.`);
+      if (rawSpecs.length > MAX_TASKS) {
+        return toolResult(
+          `Too many tasks (${rawSpecs.length}); max is ${MAX_TASKS}. Split into multiple dispatch calls.`,
+        );
+      }
+
+      // Strict profile resolution first, so progress rows, labels, and the
+      // mutation rules all see the merged spec. Unknown profile → that task
+      // is refused (like an undeclared mutating task); unresolved skills
+      // warn but never fail.
+      const profileFailures = new Map<TaskSpec, string>();
+      const profileWarnings: string[] = [];
+      let specs = rawSpecs;
+      if (rawSpecs.some((spec) => spec.profile)) {
+        const discovered = loadProfiles(ctx.cwd, extraProfileDirs);
+        const registry = skillRegistry(pi);
+        specs = rawSpecs.map((raw) => {
+          if (!raw.profile) return raw;
+          const merged = mergeProfile(raw, discovered, registry);
+          if (!merged.ok) {
+            profileFailures.set(raw, merged.error);
+            return raw;
+          }
+          if (merged.missingSkills.length > 0) {
+            profileWarnings.push(
+              `profile '${merged.profile.name}': skipped unresolved skills ${merged.missingSkills.join(', ')}`,
+            );
+          }
+          return merged.spec;
+        });
       }
 
       if (ctx.hasUI) widgetUi = ctx.ui;
@@ -1435,11 +1566,23 @@ export default function subagents(pi: ExtensionAPI) {
       };
 
       const lines: string[] = [];
+      if (profileWarnings.length > 0) {
+        lines.push(profileWarnings.map((w) => `> ⚠ ${w}`).join('\n'));
+      }
 
       // Refuse undeclared tree-mutating tasks outright; declared ones serialize after the parallel batch.
       const runnable: TaskSpec[] = [];
       const mutating: TaskSpec[] = [];
       for (const spec of specs) {
+        const profileFailure = profileFailures.get(spec);
+        if (profileFailure) {
+          const task = progress.get(spec)!;
+          task.status = 'error';
+          task.error = profileFailure;
+          task.doneAt = Date.now();
+          lines.push(`## ✗ ${task.label} — refused\n\n${profileFailure}`);
+          continue;
+        }
         if (wantsTreeMutation(spec)) {
           if (spec.allowTreeMutation === true) {
             mutating.push(spec);
@@ -1821,7 +1964,7 @@ export default function subagents(pi: ExtensionAPI) {
       ctx.ui.notify('Usage: &<agent> <prompt> (e.g. &scout how does auth work)', 'warning');
       return { action: 'handled' };
     }
-    const spec: TaskSpec = { task: parsed.prompt, agent: parsed.agentType };
+    const spec = resolveInlineSpec(ctx, { task: parsed.prompt, agent: parsed.agentType });
     void dispatchInline(pi, ctx, runtime, spec);
     return { action: 'handled' };
   });
@@ -1872,11 +2015,11 @@ export default function subagents(pi: ExtensionAPI) {
       }
       const amendment = args.trim();
       const prompt = amendment ? `${last.data.prompt}\n\n${amendment}` : last.data.prompt;
-      const spec: TaskSpec = {
+      const spec = resolveInlineSpec(ctx, {
         task: prompt,
         agent: last.data.agentType,
         worktree: last.data.worktree ? true : undefined,
-      };
+      });
       void dispatchInline(pi, ctx, runtime, spec);
     },
   });

--- a/packages/subagents/package.json
+++ b/packages/subagents/package.json
@@ -17,7 +17,8 @@
   "files": [
     "dist",
     "index.ts",
-    "fleet.ts"
+    "fleet.ts",
+    "profiles.ts"
   ],
   "type": "module",
   "exports": {

--- a/packages/subagents/profiles.test.ts
+++ b/packages/subagents/profiles.test.ts
@@ -1,0 +1,232 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  applyProfile,
+  discoverProfiles,
+  parseAgentProfile,
+  profileSearchDirs,
+  resolveProfileSkills,
+  type AgentProfile,
+  type ProfileTaskFields,
+} from './profiles.js';
+
+type Spec = ProfileTaskFields & { task: string };
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'profiles-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+function profile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    name: 'reviewer',
+    description: 'Code review',
+    skills: [],
+    prompt: '',
+    path: '/profiles/reviewer.md',
+    scope: 'user',
+    ...overrides,
+  };
+}
+
+describe('parseAgentProfile', () => {
+  it('parses frontmatter scalars, comma lists, and the prompt body', () => {
+    const content = [
+      '---',
+      'name: reviewer',
+      'description: Code review — correctness, tests, simplicity',
+      'skills: pr, review-checklist',
+      'tools: read, grep, find, ls',
+      'model: anthropic/claude-sonnet-4-5',
+      'worktree: true',
+      'replace: true',
+      '---',
+      '',
+      'Review the change against the task.',
+    ].join('\n');
+    const result = parseAgentProfile(content, '/x/reviewer.md', 'user');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile).toMatchObject({
+      name: 'reviewer',
+      description: 'Code review — correctness, tests, simplicity',
+      skills: ['pr', 'review-checklist'],
+      tools: ['read', 'grep', 'find', 'ls'],
+      model: 'anthropic/claude-sonnet-4-5',
+      worktree: true,
+      replace: true,
+      prompt: 'Review the change against the task.',
+      scope: 'user',
+    });
+  });
+
+  it('parses block lists and quoted scalars', () => {
+    const content = [
+      '---',
+      'description: "UI work"',
+      'skills:',
+      '  - claymorphism',
+      '  - web-perf',
+      'tools:',
+      "  - 'read'",
+      '  - edit',
+      '---',
+      'Persona.',
+    ].join('\n');
+    const result = parseAgentProfile(content, '/x/ui-engineer.md', 'project');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile.name).toBe('ui-engineer'); // falls back to file stem
+    expect(result.profile.description).toBe('UI work');
+    expect(result.profile.skills).toEqual(['claymorphism', 'web-perf']);
+    expect(result.profile.tools).toEqual(['read', 'edit']);
+  });
+
+  it('ignores unknown keys, comments, and blank lines', () => {
+    const content = [
+      '---',
+      '# a comment',
+      'description: Minimal',
+      'inheritSkills: false', // another harness's field
+      '',
+      'aliases: rev, r',
+      '---',
+    ].join('\n');
+    const result = parseAgentProfile(content, '/x/min.md', 'extra');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.profile.prompt).toBe('');
+    expect(result.profile.tools).toBeUndefined();
+    expect(result.profile.worktree).toBeUndefined();
+  });
+
+  it('rejects files without frontmatter, unterminated frontmatter, or missing description', () => {
+    expect(parseAgentProfile('just text', '/x/a.md', 'user').ok).toBe(false);
+    expect(parseAgentProfile('---\ndescription: x', '/x/b.md', 'user').ok).toBe(false);
+    const missing = parseAgentProfile('---\nname: a\n---\nbody', '/x/c.md', 'user');
+    expect(missing.ok).toBe(false);
+    if (missing.ok) return;
+    expect(missing.error).toContain('description');
+  });
+});
+
+describe('discoverProfiles', () => {
+  it('applies first-wins precedence across dirs and collects parse errors', () => {
+    const projectDir = tempDir();
+    const userDir = tempDir();
+    writeFileSync(join(projectDir, 'reviewer.md'), '---\ndescription: project reviewer\n---\n');
+    writeFileSync(join(userDir, 'reviewer.md'), '---\ndescription: user reviewer\n---\n');
+    writeFileSync(join(userDir, 'scout.md'), '---\ndescription: user scout\n---\n');
+    writeFileSync(join(userDir, 'broken.md'), 'no frontmatter');
+    writeFileSync(join(userDir, 'notes.txt'), 'ignored');
+
+    const { profiles, errors } = discoverProfiles([
+      { dir: projectDir, scope: 'project' },
+      { dir: userDir, scope: 'user' },
+      { dir: join(userDir, 'does-not-exist'), scope: 'extra' },
+    ]);
+
+    expect(profiles.get('reviewer')?.description).toBe('project reviewer');
+    expect(profiles.get('reviewer')?.scope).toBe('project');
+    expect(profiles.get('scout')?.scope).toBe('user');
+    expect(profiles.size).toBe(2);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('broken.md');
+  });
+});
+
+describe('profileSearchDirs', () => {
+  it('orders project, user, then extra dirs', () => {
+    const dirs = profileSearchDirs('/repo', '/home/agent', ['/bundled/profiles']);
+    expect(dirs.map((d) => d.dir)).toEqual([
+      join('/repo', '.pi', 'agents'),
+      join('/home/agent', 'agents'),
+      '/bundled/profiles',
+    ]);
+    expect(dirs.map((d) => d.scope)).toEqual(['project', 'user', 'extra']);
+  });
+});
+
+describe('resolveProfileSkills', () => {
+  it('resolves bare names via the registry and path entries relative to the profile', () => {
+    const dir = tempDir();
+    mkdirSync(join(dir, 'local-skill'));
+    writeFileSync(join(dir, 'local-skill', 'SKILL.md'), '---\nname: local\ndescription: x\n---\n');
+    const p = profile({
+      path: join(dir, 'reviewer.md'),
+      skills: ['pr', 'local-skill/SKILL.md', 'pr', 'ghost'],
+    });
+    const registry = new Map([['pr', '/skills/pr/SKILL.md']]);
+
+    const { skillPaths, missing } = resolveProfileSkills(p, registry);
+    expect(skillPaths).toEqual(['/skills/pr/SKILL.md', join(dir, 'local-skill', 'SKILL.md')]);
+    expect(missing).toEqual(['ghost']);
+  });
+
+  it('reports path entries that do not exist', () => {
+    const p = profile({ path: '/nowhere/reviewer.md', skills: ['sub/SKILL.md'] });
+    const { skillPaths, missing } = resolveProfileSkills(p, new Map());
+    expect(skillPaths).toEqual([]);
+    expect(missing).toEqual(['sub/SKILL.md']);
+  });
+});
+
+describe('applyProfile', () => {
+  const full = profile({
+    tools: ['read', 'edit'],
+    model: 'anthropic/claude-sonnet-4-5',
+    worktree: true,
+    prompt: 'Persona prompt.',
+  });
+
+  it('fills defaults from the profile', () => {
+    const spec: Spec = { task: 'do it' };
+    const merged = applyProfile(spec, full, ['/s/SKILL.md']);
+    expect(merged).toMatchObject({
+      agent: 'reviewer',
+      model: 'anthropic/claude-sonnet-4-5',
+      tools: ['read', 'edit'],
+      worktree: true,
+      skillPaths: ['/s/SKILL.md'],
+      systemPrompt: 'Persona prompt.',
+    });
+    expect(merged.replaceSystemPrompt).toBeUndefined();
+  });
+
+  it('lets explicit spec fields win', () => {
+    const spec: Spec = {
+      task: 'do it',
+      agent: 'label',
+      model: 'openai/gpt-5-mini',
+      tools: ['read'],
+      systemPrompt: 'custom',
+      worktree: false,
+    };
+    const merged = applyProfile(spec, full, []);
+    expect(merged).toMatchObject({
+      agent: 'label',
+      model: 'openai/gpt-5-mini',
+      tools: ['read'],
+      systemPrompt: 'custom',
+      worktree: false,
+    });
+    expect(merged.skillPaths).toBeUndefined();
+  });
+
+  it('applies replace only when the persona prompt is used', () => {
+    const replacing = profile({ prompt: 'Persona.', replace: true });
+    const bare: Spec = { task: 't' };
+    const custom: Spec = { task: 't', systemPrompt: 'mine' };
+    expect(applyProfile(bare, replacing, []).replaceSystemPrompt).toBe(true);
+    expect(applyProfile(custom, replacing, []).replaceSystemPrompt).toBeUndefined();
+  });
+});

--- a/packages/subagents/profiles.ts
+++ b/packages/subagents/profiles.ts
@@ -212,7 +212,9 @@ export function discoverProfiles(dirs: ProfileDir[]): DiscoveredProfiles {
     } catch {
       continue; // dir absent — normal
     }
-    for (const entry of entries.filter((e) => e.isFile() && e.name.toLowerCase().endsWith('.md')).sort()) {
+    for (const entry of entries
+      .filter((e) => e.isFile() && e.name.toLowerCase().endsWith('.md'))
+      .sort((a, b) => a.name.localeCompare(b.name))) {
       const filePath = path.join(dir, entry.name);
       let content: string;
       try {

--- a/packages/subagents/profiles.ts
+++ b/packages/subagents/profiles.ts
@@ -1,0 +1,289 @@
+/**
+ * Agent profiles — named personas for dispatch.
+ *
+ * A profile is a markdown file: YAML-ish frontmatter on top, a persona system
+ * prompt below. It bundles a skill basket, a tool allowlist, and an optional
+ * model so `dispatch` (and the `&` prefix) can launch a child as a named
+ * specialist instead of hand-assembling tools/skills/prompt per task:
+ *
+ *     ---
+ *     name: reviewer
+ *     description: Code review — correctness, tests, simplicity
+ *     skills: pr, review-checklist
+ *     tools: read, grep, find, ls
+ *     model: anthropic/claude-sonnet-4-5
+ *     ---
+ *     Review the change against the task. Prefer the smallest correct fix.
+ *
+ * Discovery (first-wins by name, highest precedence first):
+ *   1. `<cwd>/.pi/agents/*.md`        — project profiles
+ *   2. `<agentDir>/agents/*.md`       — user profiles
+ *   3. host-provided extra dirs       — e.g. a distribution's bundled defaults
+ *
+ * The frontmatter parser is deliberately small, not a YAML implementation:
+ * `key: value` scalars, `key:` followed by `- item` block lists, and
+ * comma-separated scalars for list fields. Unknown keys are ignored so files
+ * shared with other agent-file consumers (Claude Code, pi-subagents) load.
+ *
+ * Skills resolve at dispatch time against the parent session's registered
+ * skill catalog (bare names) or relative to the profile file (path entries).
+ * Missing skills warn; they never fail the dispatch.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export interface AgentProfile {
+  name: string;
+  description: string;
+  /** Skill names (resolved via the session skill registry) or `.md` paths relative to the profile file. */
+  skills: string[];
+  /** Tool allowlist. Omitted = dispatch's read-only default. */
+  tools?: string[] | undefined;
+  model?: string | undefined;
+  /** Default the task to worktree isolation (the natural home for builder personas). */
+  worktree?: boolean | undefined;
+  /** Replace pi's system prompt with the persona prompt instead of appending. */
+  replace?: boolean | undefined;
+  /** Persona system prompt (frontmatter body). Empty string when absent. */
+  prompt: string;
+  /** Source file, for diagnostics and relative skill resolution. */
+  path: string;
+  scope: 'project' | 'user' | 'extra';
+}
+
+/** The task fields a profile can default. Structural so index.ts's TaskSpec satisfies it. */
+export interface ProfileTaskFields {
+  agent?: string | undefined;
+  model?: string | undefined;
+  tools?: string[] | undefined;
+  systemPrompt?: string | undefined;
+  worktree?: boolean | undefined;
+  skillPaths?: string[] | undefined;
+  replaceSystemPrompt?: boolean | undefined;
+}
+
+export type ParseResult = { ok: true; profile: AgentProfile } | { ok: false; error: string };
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length >= 2) {
+    const first = trimmed[0];
+    if ((first === '"' || first === "'") && trimmed.endsWith(first!)) {
+      return trimmed.slice(1, -1);
+    }
+  }
+  return trimmed;
+}
+
+function splitList(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => stripQuotes(item))
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Parse one profile file. Returns a typed error (never throws) so discovery
+ * can collect diagnostics and a strict `profile:` lookup can explain itself.
+ */
+export function parseAgentProfile(content: string, filePath: string, scope: AgentProfile['scope']): ParseResult {
+  const lines = content.split(/\r?\n/);
+  if (lines[0]?.trim() !== '---') {
+    return { ok: false, error: `${filePath}: missing frontmatter (file must start with ---)` };
+  }
+  let close = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i]!.trim() === '---') {
+      close = i;
+      break;
+    }
+  }
+  if (close === -1) {
+    return { ok: false, error: `${filePath}: unterminated frontmatter (no closing ---)` };
+  }
+
+  const scalars = new Map<string, string>();
+  const lists = new Map<string, string[]>();
+  let currentList: string[] | null = null;
+
+  for (let i = 1; i < close; i++) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+    if (trimmed === '' || trimmed.startsWith('#')) continue;
+
+    if (trimmed.startsWith('- ') || trimmed === '-') {
+      if (currentList) {
+        const item = stripQuotes(trimmed.slice(1));
+        if (item) currentList.push(item);
+      }
+      // A stray `- item` with no preceding `key:` is ignored.
+      continue;
+    }
+
+    const colon = trimmed.indexOf(':');
+    if (colon === -1) continue; // not key: value — ignore, stay lenient
+    const key = trimmed.slice(0, colon).trim().toLowerCase();
+    const value = trimmed.slice(colon + 1).trim();
+    if (value === '') {
+      // `key:` opens a block list (only meaningful for list fields).
+      currentList = [];
+      lists.set(key, currentList);
+    } else {
+      currentList = null;
+      scalars.set(key, stripQuotes(value));
+    }
+  }
+
+  const listField = (key: string): string[] | undefined => {
+    const block = lists.get(key);
+    if (block && block.length > 0) return block;
+    const scalar = scalars.get(key);
+    if (scalar) return splitList(scalar);
+    if (block) return []; // explicit empty block
+    return undefined;
+  };
+
+  const boolField = (key: string): boolean | undefined => {
+    const value = scalars.get(key);
+    if (value === undefined) return undefined;
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return undefined; // unrecognized — ignore rather than guess
+  };
+
+  const stem = path.basename(filePath).replace(/\.md$/i, '');
+  const name = scalars.get('name') ?? stem;
+  const description = scalars.get('description');
+  if (!description) {
+    return { ok: false, error: `${filePath}: missing required 'description' frontmatter field` };
+  }
+
+  const profile: AgentProfile = {
+    name,
+    description,
+    skills: listField('skills') ?? [],
+    prompt: lines
+      .slice(close + 1)
+      .join('\n')
+      .trim(),
+    path: filePath,
+    scope,
+  };
+  const tools = listField('tools');
+  if (tools) profile.tools = tools;
+  const model = scalars.get('model');
+  if (model) profile.model = model;
+  const worktree = boolField('worktree');
+  if (worktree !== undefined) profile.worktree = worktree;
+  const replace = boolField('replace');
+  if (replace !== undefined) profile.replace = replace;
+  return { ok: true, profile };
+}
+
+export interface ProfileDir {
+  dir: string;
+  scope: AgentProfile['scope'];
+}
+
+/** Ordered search dirs, highest precedence first. Missing dirs are fine. */
+export function profileSearchDirs(cwd: string, agentDir: string, extraDirs: string[]): ProfileDir[] {
+  return [
+    { dir: path.join(cwd, '.pi', 'agents'), scope: 'project' as const },
+    { dir: path.join(agentDir, 'agents'), scope: 'user' as const },
+    ...extraDirs.map((dir) => ({ dir, scope: 'extra' as const })),
+  ];
+}
+
+export interface DiscoveredProfiles {
+  /** name -> profile, first-wins across dirs in the given order. */
+  profiles: Map<string, AgentProfile>;
+  /** Parse failures, for strict-lookup diagnostics. */
+  errors: string[];
+}
+
+export function discoverProfiles(dirs: ProfileDir[]): DiscoveredProfiles {
+  const profiles = new Map<string, AgentProfile>();
+  const errors: string[] = [];
+  for (const { dir, scope } of dirs) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue; // dir absent — normal
+    }
+    for (const entry of entries.filter((e) => e.isFile() && e.name.toLowerCase().endsWith('.md')).sort()) {
+      const filePath = path.join(dir, entry.name);
+      let content: string;
+      try {
+        content = fs.readFileSync(filePath, 'utf-8');
+      } catch (err) {
+        errors.push(`${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+      const result = parseAgentProfile(content, filePath, scope);
+      if (!result.ok) {
+        errors.push(result.error);
+        continue;
+      }
+      if (!profiles.has(result.profile.name)) {
+        profiles.set(result.profile.name, result.profile);
+      }
+    }
+  }
+  return { profiles, errors };
+}
+
+export interface ResolvedSkills {
+  skillPaths: string[];
+  missing: string[];
+}
+
+/**
+ * Resolve a profile's skill entries to SKILL.md paths. Bare names look up in
+ * `skillRegistry` (skill name -> SKILL.md path, from the parent session's
+ * catalog); entries containing a path separator or ending in `.md` resolve
+ * relative to the profile file. Missing entries are reported, not fatal.
+ */
+export function resolveProfileSkills(profile: AgentProfile, skillRegistry: Map<string, string>): ResolvedSkills {
+  const skillPaths: string[] = [];
+  const missing: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of profile.skills) {
+    let resolved: string | undefined;
+    if (entry.includes('/') || entry.toLowerCase().endsWith('.md')) {
+      const candidate = path.resolve(path.dirname(profile.path), entry);
+      if (fs.existsSync(candidate)) resolved = candidate;
+    } else {
+      resolved = skillRegistry.get(entry);
+    }
+    if (!resolved) {
+      missing.push(entry);
+      continue;
+    }
+    if (!seen.has(resolved)) {
+      seen.add(resolved);
+      skillPaths.push(resolved);
+    }
+  }
+  return { skillPaths, missing };
+}
+
+/**
+ * Merge a profile into a task spec. Explicit spec fields win — call beats
+ * persona, persona beats defaults. `replace` applies only when the persona's
+ * own prompt is used (an explicit systemPrompt keeps append semantics).
+ */
+export function applyProfile<T extends ProfileTaskFields>(spec: T, profile: AgentProfile, skillPaths: string[]): T {
+  const merged: T = { ...spec };
+  if (merged.agent === undefined) merged.agent = profile.name;
+  if (merged.model === undefined && profile.model !== undefined) merged.model = profile.model;
+  if (merged.tools === undefined && profile.tools !== undefined) merged.tools = profile.tools;
+  if (merged.worktree === undefined && profile.worktree !== undefined) merged.worktree = profile.worktree;
+  if (skillPaths.length > 0) merged.skillPaths = skillPaths;
+  if (merged.systemPrompt === undefined && profile.prompt !== '') {
+    merged.systemPrompt = profile.prompt;
+    if (profile.replace) merged.replaceSystemPrompt = true;
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

- Adds **profiles (personas)** to `@nicknisi/pi-subagents`: agent-definition markdown files (frontmatter + persona system prompt) that bundle a skill basket, tool allowlist, optional model, and prompt — so a dispatch task can launch as a named specialist instead of hand-assembling those per task.
- New strict `profile` field on `dispatch` tasks: unknown names refuse that task and list the known profiles. The `&` prefix resolves `&<name>` against profiles before falling back to the existing plain-label behavior, and `/again` re-resolves on re-fire.
- Children stay **hermetic**: the skill basket is resolved at dispatch time — bare names through the parent session's skill catalog (`pi.getCommands()`, so user/project/package/`--skill` skills all resolve), path entries relative to the profile file — and passed as explicit `skillPaths`. Unresolved skills warn; they never fail the dispatch.
- Discovery is first-wins: `<cwd>/.pi/agents/*.md` (project) → `<agentDir>/agents/*.md` (user) → new `SubagentsOptions.profileDirs` (embedder hook, e.g. a distribution shipping bundled default personas that user/project files can shadow).
- Merge semantics: explicit task fields win — call beats persona, persona beats defaults. `worktree: true` on a builder persona keeps its `edit`/`write`/`bash` tasks parallel with no `allowTreeMutation`; `replace: true` swaps pi's system prompt for the persona prompt, and only when the persona's own prompt is used.
