### PR TITLE
feat(adr): inject docs/decisions index into system prompt as veto list

### DIFF
--- a/.changeset/adr-veto-list.md
+++ b/.changeset/adr-veto-list.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-adr': minor
+---
+
+New package: `@nicknisi/pi-adr` injects the repo's `docs/decisions/` index into the system prompt as a steering veto list, so the agent sees which directions are already settled. Walks up from cwd, filenames only, superseded ADRs (in `superseded/`) excluded, no-ops when the directory doesn't exist.

--- a/packages/adr/README.md
+++ b/packages/adr/README.md
@@ -1,0 +1,29 @@
+# @nicknisi/pi-adr
+
+Injects the repo's ADR index (`docs/decisions/`) into the system prompt as a steering veto list, so the agent knows which directions are already settled before it proposes anything.
+
+Inspired by Kent C. Dodds' [Turn your agent on auto-pilot with ADRs](https://www.youtube.com/watch?v=vRoqBBI51Vo): decisions die in chat transcripts; numbered records in the repo keep agents from re-litigating them.
+
+## What it adds
+
+- `before_agent_start` hook — walks up from cwd to the nearest ancestor with `docs/decisions/` and appends a framing sentence plus the sorted filename list to the system prompt. Filenames only (~10 tokens per ADR); full files are read on demand by the agent. Recomputed per prompt, so it's never stale. No-ops when no `docs/decisions/` exists.
+
+No slash commands, tools, keybindings, widgets, or config.
+
+Pairs with a user-level prompt template (`~/.pi/agent/prompts/adr.md`, not part of this package) that writes the next numbered ADR from the current conversation on `/adr`.
+
+## Conventions
+
+- ADRs are `NNNN-kebab-title.md` directly in `docs/decisions/`. The filename is the veto — make titles descriptive ("no package service primitive", not "refactor approach").
+- Superseded ADRs move to `docs/decisions/superseded/`, which drops them out of the injected list (the readdir is non-recursive; no status parsing).
+- Template files (`0000-*`, anything matching `template`) are excluded.
+
+## Install
+
+```bash
+pi install /Users/nicknisi/Developer/pi-extensions/packages/adr
+```
+
+## Dependencies
+
+Peer dep on `@earendil-works/pi-coding-agent` (provided by the pi runtime). No runtime dependencies.

--- a/packages/adr/README.md
+++ b/packages/adr/README.md
@@ -19,7 +19,7 @@ Pairs with a user-level prompt template (`~/.pi/agent/prompts/adr.md`, not part 
 ## Install
 
 ```bash
-pi install /Users/nicknisi/Developer/pi-extensions/packages/adr
+pi install npm:@nicknisi/pi-adr
 ```
 
 ## Dependencies

--- a/packages/adr/README.md
+++ b/packages/adr/README.md
@@ -2,8 +2,6 @@
 
 Injects the repo's ADR index (`docs/decisions/`) into the system prompt as a steering veto list, so the agent knows which directions are already settled before it proposes anything.
 
-Inspired by Kent C. Dodds' [Turn your agent on auto-pilot with ADRs](https://www.youtube.com/watch?v=vRoqBBI51Vo): decisions die in chat transcripts; numbered records in the repo keep agents from re-litigating them.
-
 ## What it adds
 
 - `before_agent_start` hook — walks up from cwd to the nearest ancestor with `docs/decisions/` and appends a framing sentence plus the sorted filename list to the system prompt. Filenames only (~10 tokens per ADR); full files are read on demand by the agent. Recomputed per prompt, so it's never stale. No-ops when no `docs/decisions/` exists.

--- a/packages/adr/index.test.ts
+++ b/packages/adr/index.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, it } from 'vitest';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { findAdrDir, listAdrs } from './index.ts';
+import { findAdrDir, listAdrs } from './index.js';
 
 describe('findAdrDir', () => {
-  test('finds docs/decisions in an ancestor of cwd', () => {
+  it('finds docs/decisions in an ancestor of cwd', () => {
     const root = mkdtempSync(join(tmpdir(), 'adr-'));
     mkdirSync(join(root, 'docs', 'decisions'), { recursive: true });
     const nested = join(root, 'src', 'deep');
@@ -13,14 +13,14 @@ describe('findAdrDir', () => {
     expect(findAdrDir(nested)).toBe(join(root, 'docs', 'decisions'));
   });
 
-  test('returns null when nothing exists', () => {
+  it('returns null when nothing exists', () => {
     const root = mkdtempSync(join(tmpdir(), 'adr-'));
     expect(findAdrDir(root)).toBeNull();
   });
 });
 
 describe('listAdrs', () => {
-  test('returns numbered files sorted, skipping templates and superseded/', () => {
+  it('returns numbered files sorted, skipping templates and superseded/', () => {
     const root = mkdtempSync(join(tmpdir(), 'adr-'));
     const dir = join(root, 'docs', 'decisions');
     mkdirSync(join(dir, 'superseded'), { recursive: true });

--- a/packages/adr/index.test.ts
+++ b/packages/adr/index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findAdrDir, listAdrs } from './index.ts';
+
+describe('findAdrDir', () => {
+  test('finds docs/decisions in an ancestor of cwd', () => {
+    const root = mkdtempSync(join(tmpdir(), 'adr-'));
+    mkdirSync(join(root, 'docs', 'decisions'), { recursive: true });
+    const nested = join(root, 'src', 'deep');
+    mkdirSync(nested, { recursive: true });
+    expect(findAdrDir(nested)).toBe(join(root, 'docs', 'decisions'));
+  });
+
+  test('returns null when nothing exists', () => {
+    const root = mkdtempSync(join(tmpdir(), 'adr-'));
+    expect(findAdrDir(root)).toBeNull();
+  });
+});
+
+describe('listAdrs', () => {
+  test('returns numbered files sorted, skipping templates and superseded/', () => {
+    const root = mkdtempSync(join(tmpdir(), 'adr-'));
+    const dir = join(root, 'docs', 'decisions');
+    mkdirSync(join(dir, 'superseded'), { recursive: true });
+    writeFileSync(join(dir, '0002-second.md'), '');
+    writeFileSync(join(dir, '0001-first.md'), '');
+    writeFileSync(join(dir, '0000-template.md'), '');
+    writeFileSync(join(dir, 'README.md'), '');
+    writeFileSync(join(dir, 'superseded', '0009-old.md'), '');
+    expect(listAdrs(dir)).toEqual(['0001-first.md', '0002-second.md']);
+  });
+});

--- a/packages/adr/index.ts
+++ b/packages/adr/index.ts
@@ -1,0 +1,56 @@
+/**
+ * adr — inject the repo's ADR index into the system prompt.
+ *
+ * When any ancestor of cwd contains docs/decisions/, its numbered filenames
+ * (the "veto list") are appended to the system prompt on before_agent_start.
+ * Full ADRs are read on demand by the agent; only paths ride the prompt.
+ *
+ * Conventions:
+ *  - ADRs are NNNN-kebab-title.md directly in docs/decisions/
+ *  - superseded ADRs move to docs/decisions/superseded/ (excluded by the
+ *    non-recursive readdir — no status parsing)
+ *  - template files (0000-*, *template*) are excluded
+ *
+ * Recomputed per prompt, so the index is never stale within a session.
+ * No-ops when no docs/decisions/ exists.
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+
+const ADR_DIR = join('docs', 'decisions');
+const ADR_FILE = /^\d{4}-.+\.md$/;
+
+/** Walk up from `start` to the filesystem root; first docs/decisions/ wins. */
+export function findAdrDir(start: string): string | null {
+  let dir = start;
+  for (;;) {
+    const candidate = join(dir, ADR_DIR);
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** Active ADR filenames, sorted by number. Templates excluded. */
+export function listAdrs(dir: string): string[] {
+  return readdirSync(dir)
+    .filter(f => ADR_FILE.test(f) && !/template/i.test(f))
+    .sort();
+}
+
+const FRAMING = `## Decision records
+
+This repo has ADRs in docs/decisions/. These are settled decisions: read the relevant file before proposing or changing anything it touches, and do not contravene one without asking, unless the user explicitly overrides.`;
+
+export default function (pi: ExtensionAPI) {
+  pi.on('before_agent_start', (event, ctx) => {
+    const dir = findAdrDir(ctx.cwd);
+    if (!dir) return;
+    const adrs = listAdrs(dir);
+    if (adrs.length === 0) return;
+    const list = adrs.map(f => `- docs/decisions/${f}`).join('\n');
+    return { systemPrompt: `${event.systemPrompt}\n\n${FRAMING}\n\n${list}` };
+  });
+}

--- a/packages/adr/index.ts
+++ b/packages/adr/index.ts
@@ -36,7 +36,7 @@ export function findAdrDir(start: string): string | null {
 /** Active ADR filenames, sorted by number. Templates excluded. */
 export function listAdrs(dir: string): string[] {
   return readdirSync(dir)
-    .filter(f => ADR_FILE.test(f) && !/template/i.test(f))
+    .filter((f) => ADR_FILE.test(f) && !/template/i.test(f))
     .sort();
 }
 
@@ -50,7 +50,7 @@ export default function (pi: ExtensionAPI) {
     if (!dir) return;
     const adrs = listAdrs(dir);
     if (adrs.length === 0) return;
-    const list = adrs.map(f => `- docs/decisions/${f}`).join('\n');
+    const list = adrs.map((f) => `- docs/decisions/${f}`).join('\n');
     return { systemPrompt: `${event.systemPrompt}\n\n${FRAMING}\n\n${list}` };
   });
 }

--- a/packages/adr/package.json
+++ b/packages/adr/package.json
@@ -15,12 +15,14 @@
     "directory": "packages/adr"
   },
   "files": [
+    "dist",
     "index.ts"
   ],
   "type": "module",
   "exports": {
     ".": {
-      "default": "./index.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "peerDependencies": {

--- a/packages/adr/package.json
+++ b/packages/adr/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@nicknisi/pi-adr",
+  "version": "0.1.0",
+  "description": "Injects the repo's ADR index (docs/decisions/) into the system prompt as a steering veto list",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/adr#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/adr"
+  },
+  "files": [
+    "index.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "default": "./index.ts"
+    }
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,8 @@ importers:
         specifier: ^3.2.4
         version: 3.2.7(@types/node@24.13.3)(jiti@2.7.0)(yaml@2.9.0)
 
+  packages/adr: {}
+
   packages/agent-urls: {}
 
   packages/answer:


### PR DESCRIPTION
New package `@nicknisi/pi-adr`. When any ancestor of cwd contains `docs/decisions/`, a `before_agent_start` hook appends a framing sentence plus the sorted ADR filename list to the system prompt — the "steering veto list" from Kent C. Dodds' ADR video, so the agent knows which directions are settled before proposing anything.

- Filenames only (~10 tokens/ADR); full files read on demand
- Recomputed per prompt — never stale
- Superseded ADRs (`docs/decisions/superseded/`) and templates excluded via non-recursive readdir, no status parsing
- No-ops when no `docs/decisions/` exists
- No runtime deps, no commands/tools/widgets

Pairs with a user-level `~/.pi/agent/prompts/adr.md` template (not in this PR) that writes the next numbered ADR on `/adr`.

Tests: 3 passing over the walk-up and filename filtering (`bun test packages/adr`).
