### PR TITLE
fix(adr): exclude only 0000-* templates from the veto list

### DIFF
--- a/.changeset/adr-template-prefix.md
+++ b/.changeset/adr-template-prefix.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-adr': patch
+---
+
+Only `0000-*` files are treated as templates now. Previously any ADR with "template" in its title (e.g. `0007-template-rendering.md`) was silently dropped from the injected veto list.

--- a/packages/adr/README.md
+++ b/packages/adr/README.md
@@ -14,7 +14,7 @@ Pairs with a user-level prompt template (`~/.pi/agent/prompts/adr.md`, not part 
 
 - ADRs are `NNNN-kebab-title.md` directly in `docs/decisions/`. The filename is the veto — make titles descriptive ("no package service primitive", not "refactor approach").
 - Superseded ADRs move to `docs/decisions/superseded/`, which drops them out of the injected list (the readdir is non-recursive; no status parsing).
-- Template files (`0000-*`, anything matching `template`) are excluded.
+- Template files (`0000-*`) are excluded.
 
 ## Install
 

--- a/packages/adr/index.test.ts
+++ b/packages/adr/index.test.ts
@@ -27,8 +27,9 @@ describe('listAdrs', () => {
     writeFileSync(join(dir, '0002-second.md'), '');
     writeFileSync(join(dir, '0001-first.md'), '');
     writeFileSync(join(dir, '0000-template.md'), '');
+    writeFileSync(join(dir, '0003-template-rendering.md'), '');
     writeFileSync(join(dir, 'README.md'), '');
     writeFileSync(join(dir, 'superseded', '0009-old.md'), '');
-    expect(listAdrs(dir)).toEqual(['0001-first.md', '0002-second.md']);
+    expect(listAdrs(dir)).toEqual(['0001-first.md', '0002-second.md', '0003-template-rendering.md']);
   });
 });

--- a/packages/adr/index.ts
+++ b/packages/adr/index.ts
@@ -9,7 +9,7 @@
  *  - ADRs are NNNN-kebab-title.md directly in docs/decisions/
  *  - superseded ADRs move to docs/decisions/superseded/ (excluded by the
  *    non-recursive readdir — no status parsing)
- *  - template files (0000-*, *template*) are excluded
+ *  - template files (0000-*) are excluded
  *
  * Recomputed per prompt, so the index is never stale within a session.
  * No-ops when no docs/decisions/ exists.
@@ -36,7 +36,7 @@ export function findAdrDir(start: string): string | null {
 /** Active ADR filenames, sorted by number. Templates excluded. */
 export function listAdrs(dir: string): string[] {
   return readdirSync(dir)
-    .filter((f) => ADR_FILE.test(f) && !/template/i.test(f))
+    .filter((f) => ADR_FILE.test(f) && !f.startsWith('0000-'))
     .sort();
 }
 


### PR DESCRIPTION
Fixes F3 from the thermo-nuclear review of #106.

`listAdrs` excluded any filename matching `/template/i`, so a settled ADR with "template" in its title (e.g. `0007-template-rendering.md`) vanished from the system-prompt veto list without a trace — the opposite of the feature's purpose.

Now only `0000-*` files are treated as templates. Test updated to cover an ADR with "template" in the title; patch changeset included.