### PR TITLE
fix(workflows): never silently decide at the autoplan gate

### DIFF
--- a/.changeset/autoplan-gate-fallback.md
+++ b/.changeset/autoplan-gate-fallback.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-workflows': patch
+---
+
+`autoplan.js`: an off-list answer at the decision gate no longer silently resolves to the advisor's recommendation. The run returns `decided: false` with the custom text so it can be re-mined, matching the "the human is the gate" design.

--- a/packages/workflows/examples/autoplan.js
+++ b/packages/workflows/examples/autoplan.js
@@ -100,16 +100,19 @@ const choice = await ask(`Recommended: ${advice.recommended} — ${advice.why}\n
   ...ordered.map((o) => `${o.id}: ${o.title} — ${o.gist}`),
   REJECT,
 ]);
-if (!choice || choice === REJECT) {
+const picked = choice && choice !== REJECT ? ordered.find((o) => choice.startsWith(`${o.id}:`)) : undefined;
+if (!picked) {
+  // Dismissed, reject-all, or off-list custom text — never silently decide
+  // for the human; hand the outcome (and any custom answer) back to re-mine.
   return {
     decided: false,
+    ...(choice && choice !== REJECT ? { custom: choice } : {}),
     options: advice.options,
     recommended: advice.recommended,
     why: advice.why,
     rejections: advice.rejections,
   };
 }
-const picked = ordered.find((o) => choice.startsWith(`${o.id}:`)) ?? ordered[0];
 log(`human picked: ${picked.id} ${picked.title}`);
 
 phase('plan');

--- a/packages/workflows/skills/autoplan/SKILL.md
+++ b/packages/workflows/skills/autoplan/SKILL.md
@@ -25,5 +25,6 @@ If `workflow` `list` shows no `autoplan`, install it first: copy `examples/autop
 
 - `decided: false` — the user rejected every option or dismissed the gate. Present the options and
   the advisor's recommendation; offer to re-mine with new constraints or a proposed new option.
-  Never write a plan for an undecided run.
+  When the result carries `custom`, the user typed an off-list answer — treat it as their proposed
+  direction and offer to re-mine around it. Never write a plan for an undecided run.
 - `decided: true` — present `choice` and the `plan`. Elaborate sections on request.


### PR DESCRIPTION
Fixes F1 from the thermo-nuclear review.

The autoplan decision gate had `?? ordered[0]` on the option lookup, so any `ask()` result that wasn't exactly an option label — custom typed text, a host quirk — silently became the advisor's recommendation and got a full plan written for it. The file's own header says the human is the gate, "including rejecting everything."

Now an unmatched answer returns `decided: false` with a `custom` field carrying the off-list text, and the skill doc tells the model to treat `custom` as a proposed direction for re-mining. Patch changeset included.