### PR TITLE
fix(recap): use theme customMessageBg token for recap card background

### DIFF
--- a/.changeset/recap-theme-bg.md
+++ b/.changeset/recap-theme-bg.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-recap': patch
+---
+
+Use the theme's `customMessageBg` token for the recap card background instead of a hardcoded truecolor, so the card fits every theme while staying distinct from messages.

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -172,10 +172,9 @@ export default function (pi: ExtensionAPI) {
     pi.registerEntryRenderer(ENTRY_TYPE, (entry, _opts, theme) => {
       const data = entry.data as { summary: string; ts: number };
       const dim = (s: string) => theme.fg('dim', s);
-      // Hardcoded bg darker than both base bg (#1a1b26) and message bg (#1e1f2b)
-      // so it's clearly distinct from user/assistant messages. theme.bg only
-      // accepts named tokens, so emit a truecolor escape directly.
-      const bg = (s: string) => `\x1b[48;2;19;19;32m${s}\x1b[49m`;
+      // Theme-aware bg: same token pi's own summary cards (compaction, branch)
+      // use, so the card stands out appropriately in every theme.
+      const bg = (s: string) => theme.bg('customMessageBg', s);
       const box = new Box(1, 0, (s) => bg(dim(s)));
       box.addChild(new Text(dim(theme.bold('Recap')) + dim(` · ${new Date(data.ts).toLocaleTimeString()}`), 0, 0));
       box.addChild(new Markdown(capLines(data.summary, MAX_CARD_LINES), 0, 0, getMarkdownTheme()));


### PR DESCRIPTION
The recap card background was a hardcoded truecolor escape (`48;2;19;19;32`) tuned for one dark theme, so it clashed with other themes.

Switch to the theme's `customMessageBg` token — the same background pi's built-in compaction/branch summary cards use — so the card follows the active theme while staying visually distinct from user/assistant messages.

Includes a patch changeset.