### PR TITLE
feat(artifacts): persistent artifact access — footer status link + /artifacts picker

### DIFF
--- a/.changeset/artifact-footer-status.md
+++ b/.changeset/artifact-footer-status.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-artifacts': minor
+---
+
+Persistent artifact access in the TUI. After `create`/`update`/`open`, the artifact's title appears in the footer as an OSC 8 hyperlink to its localhost URL (replacing the previous one). `/artifacts` is now an in-TUI picker over all generated artifacts — Enter opens the pick in the browser and pins it as the footer status; the browser index page remains the no-UI/empty fallback.

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -181,7 +181,7 @@ Peer deps: `@earendil-works/pi-coding-agent` (provides `ExtensionAPI` — only `
 
 ## Caveats
 
-- **Uses only the public extension API** (`registerTool` / `registerCommand` / `on("session_shutdown")`) — no pi internals. Should be stable across pi versions modulo API changes in those three calls.
+- **Uses only the public extension API** (`registerTool` / `registerCommand` / `on("session_shutdown")` / `ctx.ui.setStatus` / `ctx.ui.select`) — no pi internals. Should be stable across pi versions modulo API changes in those calls.
 - **Config is loaded once at extension load** (pi extensions load at session start) — edit `artifacts.json`, then restart pi.
 - **Mermaid artifacts need network** on first view (CDN script). Everything else is rendered at write time and viewable offline.
 - **Server lifetime = process lifetime.** Port is held in module state; the server stops on `session_shutdown`. Artifacts persist on disk and can be re-served by a later session.

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -186,6 +186,7 @@ Peer deps: `@earendil-works/pi-coding-agent` (provides `ExtensionAPI` — only `
 - **Mermaid artifacts need network** on first view (CDN script). Everything else is rendered at write time and viewable offline.
 - **Server lifetime = process lifetime.** Port is held in module state; the server stops on `session_shutdown`. Artifacts persist on disk and can be re-served by a later session.
 - **Server is per-process and cwd-keyed.** Two pi sessions in different projects each run their own server on different ports; artifact URLs from one session don't resolve in the other.
+- **Footer status uses a nerd-font glyph** (`\u{F0C5}`) — terminals without a nerd font show tofu for the icon; the link itself is unaffected.
 - **Browser open is platform-specific**: `open` (macOS), `rundll32 url.dll,FileProtocolHandler` (Windows — `start` is a cmd.exe builtin and can't be spawned), `xdg-open` (Linux). Failures only warn.
 - **`path` param is capped at 2 MB** — excerpt large files into `content` instead.
 - **Index-page metadata is regex-parsed** from each file's `<title>`/`<meta>` tags. Foreign `.html` files dropped into `.pi/artifacts/` are listed with kind inferred from the presence of the shell's `<style data-base>` marker.

--- a/packages/artifacts/README.md
+++ b/packages/artifacts/README.md
@@ -13,7 +13,8 @@ pi install /Users/nicknisi/Developer/pi-extensions/packages/artifacts
 ## What it adds
 
 - **Tool `artifact`** — action-based (`create` | `update` | `open` | `list` | `share`). Registered with a `promptSnippet` ("emit visual output as a browser HTML artifact instead of terminal text") so the model knows when to reach for it.
-- **Command `/artifacts`** — starts the lazy server and opens the index page (`/`) in the browser.
+- **Command `/artifacts`** — in-TUI picker over every generated artifact (newest first, with relative age); Enter opens it in the browser and pins it as the footer status. Without a UI (print/RPC) or with no artifacts yet, falls back to opening the index page (`/`) in the browser.
+- **Footer status** — after `create`/`update`/`open`, the artifact's title appears in the footer as a persistent OSC 8 hyperlink to its localhost URL (`setStatus('artifacts', …)`), replacing the previous one. Rendered by pi's built-in footer or any custom footer that surfaces extension statuses (e.g. `@nicknisi/pi-statusline`).
 - **Event hook** — `session_shutdown`: stops the HTTP server.
 - **Browser UI** — styled artifact pages plus an index page at `/`; live reload via an `/events` SSE endpoint. Every served artifact page carries a **Share** button (bottom-right): _Copy image_ renders a PNG with the comments panel open (when comments exist), _Copy PDF_ prints to a selectable-text PDF with a Review comments section, _Copy file_ puts the self-contained HTML on your clipboard (comments baked in), _Create gist link_ uploads via `gh` and copies the URL — no agent round-trip needed. No TUI widgets, overlays, keybindings, or custom message/entry types: tool results use pi's default rendering (the tool returns structured `details` — `action`, `slug`, `title`, `kind`, `url`, `absPath` — and a text summary containing the clickable localhost URL).
 - **Annotation layer** — every served artifact page carries an inert comment layer (see [Annotations](#annotations)): select text, comment, and send the comments back to the running agent as a follow-up message.
@@ -130,7 +131,7 @@ Artifact: sprint-report (http://127.0.0.1:PORT/sprint-report.html)
 /artifacts
 ```
 
-User-facing front door: starts the lazy server if needed and opens the index page in the browser. No args, no subcommands — the index page is the listing and the picker.
+User-facing front door. With a UI, shows a select list of all generated artifacts (title, kind, relative age — newest first); picking one starts the lazy server if needed, opens it in the browser, and pins it as the footer status. Esc cancels. With no UI (print/RPC) or no artifacts yet, opens the browser index page instead. No args, no subcommands.
 
 ## Configuration
 

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -1,6 +1,7 @@
 /** Artifacts extension — registers the `artifact` tool (create/update/open/list) and a TUI result card. */
 
-import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { hyperlink } from '@earendil-works/pi-tui';
 import { Type } from 'typebox';
 import { readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
@@ -60,6 +61,23 @@ function resolveContent(params: { content?: string; path?: string }): { content:
   return { error: 'provide `content` or `path` for create/update.' };
 }
 
+/** "5m ago" style label for the artifact picker. */
+function ago(mtime: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - mtime) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+/** Show the latest artifact as a persistent, clickable footer status. */
+function setArtifactStatus(ctx: ExtensionContext, title: string, url: string | undefined) {
+  if (!url) return;
+  ctx.ui.setStatus('artifacts', `📄 ${hyperlink(ctx.ui.theme.fg('accent', title), url)}`);
+}
+
 export default function artifacts(pi: ExtensionAPI) {
   // Deliver composed feedback to the live session as a follow-up message.
   const sender: FeedbackSender = (markdown) => {
@@ -74,10 +92,22 @@ export default function artifacts(pi: ExtensionAPI) {
     stopServer();
   });
 
-  // ─── /artifacts command — open the index page (starts the server lazily) ──
+  // ─── /artifacts command — pick an artifact to open (falls back to the index page) ──
   pi.registerCommand('artifacts', {
-    description: 'Open the artifacts index page in the browser (starts the localhost server if not running)',
+    description: 'Pick a generated artifact to open in the browser (starts the localhost server if not running)',
     handler: async (_args, ctx) => {
+      const entries = listArtifacts();
+      if (ctx.hasUI && entries.length > 0) {
+        const labels = entries.map((e) => `${e.title}  (${e.kind}, ${ago(e.mtime)})`);
+        const picked = await ctx.ui.select('Open artifact', labels);
+        if (picked === undefined) return; // Esc — cancelled
+        const entry = entries[labels.indexOf(picked)]!;
+        const url = await artifactUrl(entry.slug);
+        openInBrowser(url);
+        setArtifactStatus(ctx, entry.title, url);
+        return;
+      }
+      // No UI (print/RPC) or nothing to pick — open the index page.
       const url = await artifactUrl(); // no slug → index; ensureServer starts lazily
       openInBrowser(url);
       if (ctx.hasUI) ctx.ui.notify(`Artifacts: ${url}`, 'info');
@@ -160,7 +190,7 @@ export default function artifacts(pi: ExtensionAPI) {
         }),
       ),
     }),
-    async execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const action = params.action;
 
       // ── list ──────────────────────────────────────────────────────────────
@@ -201,6 +231,7 @@ export default function artifacts(pi: ExtensionAPI) {
         }
         const url = await artifactUrl(slug);
         openInBrowser(url);
+        setArtifactStatus(ctx, title, url);
         const details: ArtifactDetails = {
           action,
           slug,
@@ -319,6 +350,7 @@ export default function artifacts(pi: ExtensionAPI) {
         url = await artifactUrl(slug);
       }
 
+      setArtifactStatus(ctx, title, url);
       const details: ArtifactDetails = { action, slug, title, kind, url, absPath };
       const verb = action === 'create' ? 'Created' : 'Updated';
       const text = `${verb} ${title} [${kind}]\n${url ?? '(server not running — use action: open to view)'}\n${absPath}`;

--- a/packages/artifacts/index.ts
+++ b/packages/artifacts/index.ts
@@ -75,7 +75,8 @@ function ago(mtime: number): string {
 /** Show the latest artifact as a persistent, clickable footer status. */
 function setArtifactStatus(ctx: ExtensionContext, title: string, url: string | undefined) {
   if (!url) return;
-  ctx.ui.setStatus('artifacts', `📄 ${hyperlink(ctx.ui.theme.fg('accent', title), url)}`);
+  // \u{F0C5} =  copy — nerd-font glyph matching the statusline's icon convention
+  ctx.ui.setStatus('artifacts', `\u{F0C5} ${hyperlink(ctx.ui.theme.fg('accent', title), url)}`);
 }
 
 export default function artifacts(pi: ExtensionAPI) {


### PR DESCRIPTION
## What

Two small additions to `@nicknisi/pi-artifacts` so generated artifacts stop feeling ephemeral:

1. **Footer status link** — after `create`/`update`/`open`, the artifact's title appears in the footer as a clickable OSC 8 hyperlink to its localhost URL (`ctx.ui.setStatus('artifacts', …)`). Latest artifact wins; rendered by pi's built-in footer or any custom footer that surfaces extension statuses (e.g. `@nicknisi/pi-statusline`, which passes OSC 8 through untouched).
2. **`/artifacts` picker** — the command now opens an in-TUI `select` list over all generated artifacts (title, kind, relative age — newest first). Enter opens the pick in the browser and pins it as the footer status; Esc cancels. The browser index page stays as the fallback for print/RPC mode or an empty artifact dir.

## Notes

- ~40 lines total, no new dependencies (`hyperlink` comes from peer dep `@earendil-works/pi-tui`, already used the same way in the statusline package).
- Built-in `ctx.ui.select` over the shared `SearchableSelectList` — the searchable variant needs `ctx.ui.custom` plumbing; upgrade path if artifact lists get long.
- Verified: `pnpm typecheck`, `pnpm lint`, `pnpm format`, extension load + tool execution smoke test in `pi -p`.
- Changeset: minor.