### PR TITLE
fix: keep read-only profiles dispatchable

### DIFF
--- a/.changeset/calm-explorers-search.md
+++ b/.changeset/calm-explorers-search.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-subagents': patch
+---
+
+Keep otherwise read-only profiles runnable by dropping inherited `bash` access unless the task opts into mutation or worktree isolation.

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -152,6 +152,8 @@ Review the change against the task. Prefer the smallest correct fix.
 
 Lists accept comma-separated scalars or `- item` block lists. Unknown keys are ignored, so agent files shared with other harnesses load. The parser is deliberately small — flat `key: value` frontmatter, not full YAML.
 
+For compatibility with legacy read-only profiles, inherited `bash` is omitted when the profile has no `edit` or `write` tools and the task does not set `worktree: true` or `allowTreeMutation: true`. An explicit task `tools` list is never changed.
+
 **Discovery** (first-wins by name, highest precedence first):
 
 1. `<cwd>/.pi/agents/*.md` — project profiles

--- a/packages/subagents/profiles.test.ts
+++ b/packages/subagents/profiles.test.ts
@@ -202,12 +202,27 @@ describe('applyProfile', () => {
     expect(merged.replaceSystemPrompt).toBeUndefined();
   });
 
+  it('drops inherited bash from otherwise read-only profiles', () => {
+    const explorer = profile({ tools: ['read', 'bash', 'grep', 'find', 'ls'] });
+    const spec: Spec = { task: 'search' };
+    const merged = applyProfile(spec, explorer, []);
+    expect(merged.tools).toEqual(['read', 'grep', 'find', 'ls']);
+  });
+
+  it('keeps inherited bash when mutation is isolated or allowed', () => {
+    const explorer = profile({ tools: ['read', 'bash', 'grep', 'find', 'ls'] });
+    const isolated: Spec = { task: 'search', worktree: true };
+    const allowed: Spec = { task: 'search', allowTreeMutation: true };
+    expect(applyProfile(isolated, explorer, []).tools).toContain('bash');
+    expect(applyProfile(allowed, explorer, []).tools).toContain('bash');
+  });
+
   it('lets explicit spec fields win', () => {
     const spec: Spec = {
       task: 'do it',
       agent: 'label',
       model: 'openai/gpt-5-mini',
-      tools: ['read'],
+      tools: ['read', 'bash'],
       systemPrompt: 'custom',
       worktree: false,
     };
@@ -215,7 +230,7 @@ describe('applyProfile', () => {
     expect(merged).toMatchObject({
       agent: 'label',
       model: 'openai/gpt-5-mini',
-      tools: ['read'],
+      tools: ['read', 'bash'],
       systemPrompt: 'custom',
       worktree: false,
     });

--- a/packages/subagents/profiles.ts
+++ b/packages/subagents/profiles.ts
@@ -58,6 +58,7 @@ export interface ProfileTaskFields {
   model?: string | undefined;
   tools?: string[] | undefined;
   systemPrompt?: string | undefined;
+  allowTreeMutation?: boolean | undefined;
   worktree?: boolean | undefined;
   skillPaths?: string[] | undefined;
   replaceSystemPrompt?: boolean | undefined;
@@ -280,8 +281,19 @@ export function applyProfile<T extends ProfileTaskFields>(spec: T, profile: Agen
   const merged: T = { ...spec };
   if (merged.agent === undefined) merged.agent = profile.name;
   if (merged.model === undefined && profile.model !== undefined) merged.model = profile.model;
-  if (merged.tools === undefined && profile.tools !== undefined) merged.tools = profile.tools;
   if (merged.worktree === undefined && profile.worktree !== undefined) merged.worktree = profile.worktree;
+  if (merged.tools === undefined && profile.tools !== undefined) {
+    // Legacy read-only profiles often include bash for git inspection. Omit
+    // inherited bash rather than refusing the task when no mutation is allowed.
+    const tools =
+      merged.worktree !== true &&
+      merged.allowTreeMutation !== true &&
+      profile.tools.includes('bash') &&
+      !profile.tools.some((tool) => tool === 'edit' || tool === 'write')
+        ? profile.tools.filter((tool) => tool !== 'bash')
+        : profile.tools;
+    if (tools.length > 0) merged.tools = tools;
+  }
   if (skillPaths.length > 0) merged.skillPaths = skillPaths;
   if (merged.systemPrompt === undefined && profile.prompt !== '') {
     merged.systemPrompt = profile.prompt;


### PR DESCRIPTION
## Summary

- drop profile-inherited `bash` when the profile is otherwise read-only and the task has no mutation opt-in
- preserve explicit task tools and profile `bash` when worktree isolation or shared-tree mutation is enabled
- document the compatibility behavior and add a patch changeset

## Verification

- `pnpm exec vitest run packages/subagents/profiles.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check packages/subagents/profiles.ts packages/subagents/profiles.test.ts packages/subagents/README.md .changeset/calm-explorers-search.md`
