### PR TITLE
fix(recap): support extension-registered providers

### DIFF
--- a/.changeset/calm-recaps-handle-providers.md
+++ b/.changeset/calm-recaps-handle-providers.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-recap': patch
+---
+
+Route recap completion through Pi's model registry so extension-registered providers work, and report background generation failures without terminating Pi.

--- a/packages/recap/README.md
+++ b/packages/recap/README.md
@@ -61,8 +61,7 @@ No environment variables are read.
 Peer deps (all `@earendil-works/*`, provided by the pi host):
 
 - `@earendil-works/pi-ai` — `uuidv7` (session id for the completion call)
-- `@earendil-works/pi-ai/compat` — `complete` (one-shot summarization)
-- `@earendil-works/pi-coding-agent` — `ExtensionAPI`, `getMarkdownTheme`; uses `pi.registerCommand`, `pi.registerEntryRenderer`, `pi.appendEntry`, `pi.on`, `ctx.sessionManager.getBranch`, `ctx.modelRegistry.getApiKeyAndHeaders`, `ctx.isIdle`, `ctx.ui.notify`
+- `@earendil-works/pi-coding-agent` — `ExtensionAPI`, `getMarkdownTheme`; uses `pi.registerCommand`, `pi.registerEntryRenderer`, `pi.appendEntry`, `pi.on`, `ctx.sessionManager.getBranch`, `ctx.modelRegistry.complete`, `ctx.isIdle`, `ctx.ui.notify`
 - `@earendil-works/pi-tui` — `Box`, `Text`, `Markdown` for the card renderer
 
 No npm runtime deps, no workspace deps.
@@ -70,8 +69,9 @@ No npm runtime deps, no workspace deps.
 ## Caveats
 
 - TUI only: the timer and renderer are installed in `session_start` only when `ctx.mode === "tui"`. `/recap` technically works in other modes but nothing renders the entry there.
-- Depends on several pi internals that could change across versions: `sessionManager.getBranch()`, `modelRegistry.getApiKeyAndHeaders()`, `ctx.isIdle()`, and the `session_start`/`before_agent_start`/`agent_settled` event names.
-- A configured model is resolved through `ctx.modelRegistry`, so registered custom providers work. An omitted or unresolved override falls back to the current session model.
+- Depends on several pi internals that could change across versions: `sessionManager.getBranch()`, `modelRegistry.complete()`, `ctx.isIdle()`, and the `session_start`/`before_agent_start`/`agent_settled` event names.
+- A configured model is resolved and completed through `ctx.modelRegistry`, so registered custom providers work. An omitted or unresolved override falls back to the current session model.
+- Background recap failures are reported as warnings and never terminate the pi process.
 - The card background is a hardcoded truecolor escape (`#131320`) chosen to sit darker than the tokyonight base/message backgrounds (`theme.bg` only accepts named tokens). With other themes it may clash.
 - Entry content extraction is structural (filters blocks by `type === "text"` / `type === "toolCall"`), so changes to pi's message block shape would silently empty the transcript it summarizes.
 - The timer is cleared on `session_shutdown`; if a session never shuts down cleanly the interval lives until process exit.

--- a/packages/recap/index.test.ts
+++ b/packages/recap/index.test.ts
@@ -1,0 +1,82 @@
+import type { Api, AssistantMessage, Model } from '@earendil-works/pi-ai';
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import recap from './index.js';
+
+type EventHandler = (event: unknown, ctx: ExtensionContext) => Promise<unknown> | unknown;
+type CommandHandler = (args: string, ctx: ExtensionContext) => Promise<void> | void;
+
+function harness() {
+  const handlers = new Map<string, EventHandler>();
+  const commands = new Map<string, CommandHandler>();
+  const appendEntry = vi.fn();
+  const notify = vi.fn();
+  const model = {
+    provider: 'custom-provider',
+    id: 'custom-model',
+    api: 'custom-stream-api',
+  } as Model<Api>;
+  const complete = vi.fn<ExtensionContext['modelRegistry']['complete']>();
+  const branch = Array.from({ length: 4 }, (_, index) => ({
+    type: 'message',
+    message: {
+      role: index % 2 === 0 ? 'user' : 'assistant',
+      content: [{ type: 'text', text: `message ${index}` }],
+    },
+  }));
+  const pi = {
+    appendEntry,
+    on(name: string, handler: EventHandler) {
+      handlers.set(name, handler);
+    },
+    registerCommand(name: string, command: { handler: CommandHandler }) {
+      commands.set(name, command.handler);
+    },
+    registerEntryRenderer() {},
+  } as unknown as ExtensionAPI;
+  const ctx = {
+    mode: 'tui',
+    model,
+    isIdle: () => true,
+    modelRegistry: { complete, find: () => undefined },
+    sessionManager: { getBranch: () => branch },
+    ui: { notify },
+  } as unknown as ExtensionContext;
+
+  recap(pi);
+  return { appendEntry, commands, complete, ctx, handlers, model, notify };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('recap extension', () => {
+  it('completes custom-provider models through the model registry', async () => {
+    const { appendEntry, commands, complete, ctx, model } = harness();
+    complete.mockResolvedValue({
+      content: [{ type: 'text', text: 'Current recap' }],
+    } as AssistantMessage);
+
+    await commands.get('recap')!('', ctx);
+
+    expect(complete).toHaveBeenCalledWith(model, expect.any(Object), expect.any(Object));
+    expect(appendEntry).toHaveBeenCalledWith('recap', expect.objectContaining({ summary: 'Current recap' }));
+  });
+
+  it('reports background recap failures without an unhandled rejection', async () => {
+    const { complete, ctx, handlers, notify } = harness();
+    complete.mockRejectedValue(new Error('provider unavailable'));
+
+    await handlers.get('session_start')!({}, ctx);
+    await vi.advanceTimersByTimeAsync(180_000);
+
+    expect(notify).toHaveBeenCalledWith('recap: provider unavailable', 'warning');
+    await handlers.get('session_shutdown')!({}, ctx);
+  });
+});

--- a/packages/recap/index.ts
+++ b/packages/recap/index.ts
@@ -1,6 +1,10 @@
 import { uuidv7 } from '@earendil-works/pi-ai';
-import { complete } from '@earendil-works/pi-ai/compat';
-import { getAgentDir, getMarkdownTheme, type ExtensionAPI } from '@earendil-works/pi-coding-agent';
+import {
+  getAgentDir,
+  getMarkdownTheme,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from '@earendil-works/pi-coding-agent';
 import { Box, Markdown, Text } from '@earendil-works/pi-tui';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -26,7 +30,7 @@ let lastActivity = Date.now();
 let firedThisIdle = false;
 let timer: ReturnType<typeof setInterval> | null = null;
 let piRef: ExtensionAPI | null = null;
-let lastModel: import('@earendil-works/pi-coding-agent').ExtensionContext['model'] = undefined;
+let lastModel: ExtensionContext['model'] = undefined;
 
 function readConfig(): Config {
   try {
@@ -100,7 +104,7 @@ function capLines(text: string, max: number): string {
   return lines.slice(0, max).join('\n') + ' …';
 }
 
-async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').ExtensionContext): Promise<string> {
+async function generateSummary(ctx: ExtensionContext): Promise<string> {
   const cfg = readConfig();
   const configuredModel =
     cfg.model && typeof cfg.model.provider === 'string' && typeof cfg.model.id === 'string'
@@ -111,14 +115,9 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
     ctx.ui.notify('recap: no model available', 'warning');
     return '';
   }
-  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
-  if (!auth?.ok) {
-    ctx.ui.notify(`recap: ${auth.error ?? 'no API key for model'}`, 'warning');
-    return '';
-  }
   const conversation = buildConversation(ctx.sessionManager.getBranch());
   if (!conversation.trim()) return '';
-  const response = await complete(
+  const response = await ctx.modelRegistry.complete(
     model,
     {
       messages: [
@@ -130,11 +129,6 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
       ],
     },
     {
-      // Spread conditionally: optional in ProviderStreamOptions, and
-      // exactOptionalPropertyTypes rejects an explicit undefined.
-      ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
-      ...(auth.headers !== undefined && { headers: auth.headers }),
-      ...(auth.env !== undefined && { env: auth.env }),
       reasoningEffort: 'low',
       cacheRetention: 'none',
       sessionId: uuidv7(),
@@ -146,13 +140,13 @@ async function generateSummary(ctx: import('@earendil-works/pi-coding-agent').Ex
     .join('\n');
 }
 
-async function injectRecap(ctx: import('@earendil-works/pi-coding-agent').ExtensionContext) {
+async function injectRecap(ctx: ExtensionContext) {
   const summary = await generateSummary(ctx);
   if (!summary) return;
   piRef?.appendEntry(ENTRY_TYPE, { summary, ts: Date.now() });
 }
 
-async function maybeFire(ctx: import('@earendil-works/pi-coding-agent').ExtensionContext) {
+async function maybeFire(ctx: ExtensionContext) {
   if (!ctx.isIdle() || firedThisIdle) return;
   const cfg = readConfig();
   if (Date.now() - lastActivity < cfg.idleMinutes * 60_000) return;
@@ -182,7 +176,10 @@ export default function (pi: ExtensionAPI) {
     });
 
     timer = setInterval(() => {
-      void maybeFire(ctx);
+      void maybeFire(ctx).catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`recap: ${message}`, 'warning');
+      });
     }, TICK_MS);
   });
 


### PR DESCRIPTION
## Summary

- route recap generation through `ctx.modelRegistry.complete()` so extension-registered providers use their composed runtime provider
- catch idle-timer generation failures and surface a warning instead of allowing an unhandled rejection to terminate Pi
- add regression coverage for custom-provider completion and background failures

## Motivation

This fixes a recurring Pi termination reported from real usage. After a session became idle, the recap timer attempted to summarize with an extension-registered model and Pi exited with an uncaught exception:

```text
Error: No API provider registered for api: pi-claude-code-provider-headless
    at resolveApiProvider (...)
    at generateSummary (.../@nicknisi/pi-recap/index.ts)
    at injectRecap (.../@nicknisi/pi-recap/index.ts)
    at maybeFire (.../@nicknisi/pi-recap/index.ts)
```

The stack and reproduction point to recap's provider dispatch and unhandled timer rejection.

## Root cause

The recap resolved models through `ctx.modelRegistry` but sent them through the global `@earendil-works/pi-ai/compat` dispatcher. Models whose API is registered only through `pi.registerProvider()` therefore failed with `No API provider registered`. The idle timer discarded the rejected promise, allowing that failure to terminate the process.

## Verification

- `pnpm vitest run packages/recap/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- scratch-agent `pi -p` extension-load smoke test

