### PR TITLE
feat(subagents): Add task cwd and childExtensionPaths

### DIFF
--- a/.changeset/subagents-task-cwd-child-extensions.md
+++ b/.changeset/subagents-task-cwd-child-extensions.md
@@ -1,0 +1,7 @@
+---
+'@nicknisi/pi-subagents': minor
+---
+
+Add a per-task `cwd` (dispatch schema and profile frontmatter) and host-configured `childExtensionPaths` (factory option or `<agentDir>/subagents.json`).
+
+`cwd` is relative to the session cwd and jailed inside it, so a host whose session cwd is a workspace root holding several repository checkouts can point a worktree task at one checkout instead of failing with "not inside a git repository". `childExtensionPaths` names extension files every child loads, so a host whose model routing lives in an extension (a provider registered with `pi.registerProvider`) gets working children instead of ones with no usable model. Both are host configuration or explicit task fields; children stay hermetic otherwise.

--- a/packages/subagents/README.md
+++ b/packages/subagents/README.md
@@ -4,7 +4,7 @@ First-party subagent dispatch and fleet for pi — fan out parallel child agents
 
 ## What it adds
 
-- **`dispatch` tool** (model-facing) — fan out up to 8 child agents in parallel. Each task gets its own prompt, optional label/model/system-prompt, and a tool allowlist (default read-only: `read`, `grep`, `find`, `ls`). Running rows show cumulative token usage after each completed model response. Typed per-task results aggregate into one tool result. `background: true` runs detached and surfaces completion via a transcript message. Tasks whose allowlist includes `edit`, `write`, or `bash` mutate the shared working tree: they must declare `allowTreeMutation: true` (otherwise that task is refused) and always run **sequentially**, one at a time, after the parallel read-only batch completes — never concurrently with each other or the read-only batch.
+- **`dispatch` tool** (model-facing) — fan out up to 8 child agents in parallel. Each task gets its own prompt, optional label/model/system-prompt, and a tool allowlist (default read-only: `read`, `grep`, `find`, `ls`). Running rows show cumulative token usage after each completed model response. Typed per-task results aggregate into one tool result. `background: true` runs detached and surfaces completion via a transcript message. Tasks whose allowlist includes `edit`, `write`, or `bash` mutate the shared working tree: they must declare `allowTreeMutation: true` (otherwise that task is refused) and always run **sequentially**, one at a time, after the parallel read-only batch completes — never concurrently with each other or the read-only batch. A task may set `cwd` — relative to the session cwd and jailed inside it — to run a child (and its worktree) inside a subdirectory such as a repository checkout.
 - **`fleet` tool** (model-facing) — `list` shows queued/running runs owned by the current Pi session. Pass `scope: "all"` for persisted machine-wide history, or fetch a `result` directly by runId. This is how the model checks on background dispatches without mixing in unrelated sessions.
 - **`/fleet` command** — user-facing active-run table. `/fleet all` opens persisted machine-wide history; `/fleet <runId-prefix>` jumps to a historical result.
 - **Fleet radar overlay + statusline** — `Alt+Ctrl+F` (rebind via `~/.pi/agent/keybindings.json`) opens a tmux-choose-tree-style overlay listing active runs owned by the current Pi session as per-child lanes: status, model, current tool, token burn, last activity. `Enter` inspects the live run transcript; `c` cancels the focused run (wired into the cascading-cancellation registry); `Esc` closes. The ambient footer segment (`ctx.ui.setStatus`) exists only while this session owns queued/running subagents; runs from other sessions never make it appear.
@@ -55,7 +55,23 @@ Live progress shows in a widget above the editor; when the child settles, the re
 
 ### Worktree isolation
 
-Builder tasks should prefer `worktree: true` over `allowTreeMutation: true`:
+Builder tasks should prefer `worktree: true` over `allowTreeMutation: true`. The worktree is created from the git repository that contains the child's cwd — the session cwd by default. When the session cwd is not itself a repository (a workspace root holding several checkouts under `repos/`, say), set `cwd` on the task or its profile so the child runs inside the checkout:
+
+```json
+{
+  "tasks": [
+    {
+      "task": "Implement the parser in packages/foo",
+      "profile": "builder",
+      "cwd": "repos/acme__widgets"
+    }
+  ]
+}
+```
+
+`cwd` is relative to the session cwd, must exist, and must stay inside it (checked on real paths, so a symlink cannot escape). A task with a bad `cwd` is refused, like a task naming an unknown profile; the rest of the dispatch proceeds.
+
+A plain worktree task:
 
 ```json
 {
@@ -120,7 +136,7 @@ Compat caveats:
 - The mirror reflects the child's messages as pi sees them (user prompt → assistant turns → tool results). It does **not** carry the subagent-specific metadata (runId, namespace, transcript summary, worktree/patch paths) — that lives only on the bespoke `.json` artifact, which is why both are kept.
 - Worktree-isolated runs mirror with the **worktree's** cwd (where the child actually ran), not the caller's cwd. The session header's `cwd` is honest about where the work happened.
 
-Children are **hermetic by construction**: no user extensions, skills, prompt templates, themes, or `AGENTS.md` context load unless explicitly requested. Tool scoping is likewise by construction — a child receives exactly its allowlist, and no spawn capability exists as a tool, so children cannot recurse. The ecosystem recursion guard (`PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_CHILD`) is honored: inside a pi-subagents child, spawns are refused.
+Children are **hermetic by construction**: no user extensions, skills, prompt templates, themes, or `AGENTS.md` context load unless explicitly requested — the one host-level exception is `childExtensionPaths` (see **Configuration**), which names extension files every child loads and is never model input. Tool scoping is likewise by construction — a child receives exactly its allowlist, and no spawn capability exists as a tool, so children cannot recurse. The ecosystem recursion guard (`PI_SUBAGENT_DEPTH` / `PI_SUBAGENT_CHILD`) is honored: inside a pi-subagents child, spawns are refused.
 
 `spawn()` never rejects; results are a discriminated union (`ok | crashed | empty | schema_invalid | aborted`). See `packages/shared/README.md` for the full runtime API.
 
@@ -148,6 +164,7 @@ Review the change against the task. Prefer the smallest correct fix.
 | `tools`       | Tool allowlist. Omitted = dispatch's read-only default.                                                                                                                                                                                                      |
 | `model`       | Optional model spec.                                                                                                                                                                                                                                         |
 | `worktree`    | Default the task to worktree isolation — set this on builder personas so their `edit`/`write`/`bash` tools stay parallel and need no `allowTreeMutation`.                                                                                                    |
+| `cwd`         | Default working directory for the task, relative to the session cwd and jailed inside it (e.g. `repos/acme__widgets`). An explicit task `cwd` wins. Worktree tasks branch from the repository containing it.                                                 |
 | `replace`     | Replace pi's system prompt with the persona prompt instead of appending.                                                                                                                                                                                     |
 
 Lists accept comma-separated scalars or `- item` block lists. Unknown keys are ignored, so agent files shared with other harnesses load. The parser is deliberately small — flat `key: value` frontmatter, not full YAML.
@@ -175,10 +192,24 @@ None required. Embedders can pass options through the factory:
 ```ts
 import subagents from '@nicknisi/pi-subagents';
 
-export default (pi: ExtensionAPI) => subagents(pi, { profileDirs: ['/path/to/bundled/profiles'] });
+export default (pi: ExtensionAPI) =>
+  subagents(pi, {
+    profileDirs: ['/path/to/bundled/profiles'],
+    childExtensionPaths: ['/app/inference-broker.ts'],
+  });
 ```
 
 `profileDirs` appends lowest-precedence profile directories — the hook for a distribution (e.g. arc) to ship default personas that user and project files can shadow.
+
+`childExtensionPaths` names extension files **every child loads**. Children get a fresh model runtime and load no user extensions, so a host whose model routing lives in an extension — a provider registered with `pi.registerProvider` that streams through a broker, for example — has no working model in a child unless that extension loads there too. The same goes for any per-turn context an extension injects. Entries are absolute or relative to the agent dir; missing files are skipped with a warning at load (and a notification on `session_start` when there is a UI). Children stay hermetic otherwise.
+
+Hosts that install this package with `pi install` rather than wrapping the factory set the same list in **`<agentDir>/subagents.json`**:
+
+```json
+{ "childExtensionPaths": ["/app/inference-broker.ts", "/app/repo-context.ts"] }
+```
+
+Factory-option entries come first, then the file's, deduplicated. The file is read once at load; restart pi after editing it. It is host configuration, never model input — the `dispatch` schema has no way to name extensions.
 
 ## Caveats
 

--- a/packages/subagents/host-config.test.ts
+++ b/packages/subagents/host-config.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { HOST_CONFIG_FILE, readHostConfigFile, resolveChildExtensionPaths, resolveTaskCwd } from './host-config.js';
+import { applyProfile, parseAgentProfile, type ProfileTaskFields } from './profiles.js';
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'host-config-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe('resolveTaskCwd', () => {
+  it('returns the session cwd when the task sets none', () => {
+    const root = tempDir();
+    expect(resolveTaskCwd(root, undefined)).toEqual({ ok: true, cwd: root });
+    expect(resolveTaskCwd(root, '  ')).toEqual({ ok: true, cwd: root });
+  });
+
+  it('resolves a nested directory inside the session cwd', () => {
+    const root = tempDir();
+    mkdirSync(join(root, 'repos', 'acme__widgets'), { recursive: true });
+    const result = resolveTaskCwd(root, 'repos/acme__widgets');
+    expect(result).toEqual({ ok: true, cwd: join(root, 'repos', 'acme__widgets') });
+  });
+
+  it('refuses absolute paths', () => {
+    const root = tempDir();
+    const result = resolveTaskCwd(root, root);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/must be relative/);
+  });
+
+  it('refuses paths that climb out of the session cwd', () => {
+    const root = tempDir();
+    const result = resolveTaskCwd(root, '../elsewhere');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/does not exist|escapes/);
+  });
+
+  it('refuses a directory that does not exist', () => {
+    const root = tempDir();
+    const result = resolveTaskCwd(root, 'repos/missing');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/does not exist/);
+  });
+
+  it('refuses a symlink that points outside the session cwd', () => {
+    const root = tempDir();
+    const outside = tempDir();
+    symlinkSync(outside, join(root, 'escape'));
+    const result = resolveTaskCwd(root, 'escape');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/escapes/);
+  });
+});
+
+describe('readHostConfigFile', () => {
+  it('treats a missing file as an empty config', () => {
+    const agentDir = tempDir();
+    expect(readHostConfigFile(agentDir)).toEqual({ config: {}, warnings: [] });
+  });
+
+  it('reads childExtensionPaths', () => {
+    const agentDir = tempDir();
+    writeFileSync(join(agentDir, HOST_CONFIG_FILE), JSON.stringify({ childExtensionPaths: ['/app/broker.ts'] }));
+    expect(readHostConfigFile(agentDir)).toEqual({ config: { childExtensionPaths: ['/app/broker.ts'] }, warnings: [] });
+  });
+
+  it('warns and ignores invalid JSON', () => {
+    const agentDir = tempDir();
+    writeFileSync(join(agentDir, HOST_CONFIG_FILE), '{ not json');
+    const result = readHostConfigFile(agentDir);
+    expect(result.config).toEqual({});
+    expect(result.warnings[0]).toMatch(/invalid JSON/);
+  });
+
+  it('warns when childExtensionPaths is not an array of strings', () => {
+    const agentDir = tempDir();
+    writeFileSync(join(agentDir, HOST_CONFIG_FILE), JSON.stringify({ childExtensionPaths: 'broker.ts' }));
+    const result = readHostConfigFile(agentDir);
+    expect(result.config).toEqual({});
+    expect(result.warnings[0]).toMatch(/must be an array of strings/);
+  });
+
+  it('keeps the string entries and warns about the rest', () => {
+    const agentDir = tempDir();
+    writeFileSync(join(agentDir, HOST_CONFIG_FILE), JSON.stringify({ childExtensionPaths: ['a.ts', 42, ''] }));
+    const result = readHostConfigFile(agentDir);
+    expect(result.config).toEqual({ childExtensionPaths: ['a.ts'] });
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe('resolveChildExtensionPaths', () => {
+  it('resolves relative entries against the agent dir, dedupes, and separates missing files', () => {
+    const agentDir = tempDir();
+    mkdirSync(join(agentDir, 'ext'));
+    writeFileSync(join(agentDir, 'ext', 'broker.ts'), 'export default () => {};');
+    const absolute = join(agentDir, 'ext', 'broker.ts');
+    const result = resolveChildExtensionPaths(agentDir, ['ext/broker.ts', absolute], ['ext/missing.ts']);
+    expect(result.paths).toEqual([absolute]);
+    expect(result.missing).toEqual([join(agentDir, 'ext', 'missing.ts')]);
+  });
+
+  it('keeps factory-option order ahead of the config file', () => {
+    const agentDir = tempDir();
+    writeFileSync(join(agentDir, 'a.ts'), '');
+    writeFileSync(join(agentDir, 'b.ts'), '');
+    const result = resolveChildExtensionPaths(agentDir, ['b.ts'], ['a.ts', 'b.ts']);
+    expect(result.paths).toEqual([join(agentDir, 'b.ts'), join(agentDir, 'a.ts')]);
+  });
+
+  it('returns nothing when no source is given', () => {
+    expect(resolveChildExtensionPaths(tempDir(), undefined, undefined)).toEqual({ paths: [], missing: [] });
+  });
+});
+
+describe('profile cwd', () => {
+  type Spec = ProfileTaskFields & { task: string };
+
+  it('parses a cwd frontmatter field', () => {
+    const parsed = parseAgentProfile(
+      ['---', 'description: Builder', 'cwd: repos/acme__widgets', 'worktree: true', '---', 'Build it.'].join('\n'),
+      '/profiles/builder.md',
+      'user',
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.profile.cwd).toBe('repos/acme__widgets');
+  });
+
+  it('applies the profile cwd only when the task sets none', () => {
+    const profile = {
+      name: 'builder',
+      description: 'Builder',
+      skills: [],
+      prompt: '',
+      path: '/profiles/builder.md',
+      scope: 'user' as const,
+      cwd: 'repos/acme__widgets',
+    };
+    const defaulted = applyProfile<Spec>({ task: 'x' }, profile, []);
+    expect(defaulted.cwd).toBe('repos/acme__widgets');
+    const explicit = applyProfile<Spec>({ task: 'x', cwd: 'repos/other' }, profile, []);
+    expect(explicit.cwd).toBe('repos/other');
+  });
+});

--- a/packages/subagents/host-config.ts
+++ b/packages/subagents/host-config.ts
@@ -1,0 +1,161 @@
+/**
+ * Host-level configuration for subagent children, plus the per-task `cwd`
+ * resolver.
+ *
+ * Children are hermetic: a fresh model runtime, no user extensions, and the
+ * parent's cwd. Two kinds of host need to widen that without giving the model
+ * any new authority:
+ *
+ * - A harness whose session cwd is a *workspace root* holding several
+ *   repository checkouts (e.g. `repos/<owner>__<name>`). Worktree isolation
+ *   resolves the repository from the child's cwd, so such a host needs a
+ *   per-task `cwd` that stays inside the session cwd.
+ * - A harness whose model routing lives in an extension — a brokered provider
+ *   registered with `pi.registerProvider` — has no working model in a child
+ *   unless that extension loads there too. `childExtensionPaths` names the
+ *   extension files every child loads. It is host configuration (factory
+ *   option or `<agentDir>/subagents.json`), never model input.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** File name under the agent dir, e.g. `~/.pi/agent/subagents.json`. */
+export const HOST_CONFIG_FILE = 'subagents.json';
+
+export interface SubagentsHostConfig {
+  /** Extension files every child loads. Absolute, or relative to the agent dir. */
+  childExtensionPaths?: string[] | undefined;
+}
+
+export interface HostConfigFileResult {
+  config: SubagentsHostConfig;
+  /** Human-readable problems with the file; the config is still usable. */
+  warnings: string[];
+}
+
+/**
+ * Read `<agentDir>/subagents.json`. A missing file is not an error. A file
+ * that is unparseable or has the wrong shape yields an empty config plus a
+ * warning — misconfiguration must never take the whole extension down.
+ */
+export function readHostConfigFile(agentDir: string): HostConfigFileResult {
+  const file = path.join(agentDir, HOST_CONFIG_FILE);
+  let text: string;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { config: {}, warnings: [] };
+    return { config: {}, warnings: [`${file}: unreadable (${(err as Error).message})`] };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    return { config: {}, warnings: [`${file}: invalid JSON (${(err as Error).message})`] };
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { config: {}, warnings: [`${file}: expected a JSON object`] };
+  }
+
+  const warnings: string[] = [];
+  const config: SubagentsHostConfig = {};
+  const raw = (parsed as Record<string, unknown>).childExtensionPaths;
+  if (raw !== undefined) {
+    if (!Array.isArray(raw)) {
+      warnings.push(`${file}: childExtensionPaths must be an array of strings`);
+    } else {
+      const strings = raw.filter((entry): entry is string => typeof entry === 'string' && entry.trim() !== '');
+      if (strings.length !== raw.length) {
+        warnings.push(`${file}: childExtensionPaths entries must be non-empty strings; ignored the rest`);
+      }
+      config.childExtensionPaths = strings;
+    }
+  }
+  return { config, warnings };
+}
+
+export interface ChildExtensionPaths {
+  /** Absolute paths to existing files, deduplicated, in source order. */
+  paths: string[];
+  /** Configured entries that do not resolve to a file; skipped, not fatal. */
+  missing: string[];
+}
+
+/**
+ * Merge child extension path lists (factory option first, then the config
+ * file), resolve relative entries against the agent dir, drop duplicates, and
+ * separate entries that do not exist so the host can warn about them.
+ */
+export function resolveChildExtensionPaths(
+  agentDir: string,
+  ...sources: Array<readonly string[] | undefined>
+): ChildExtensionPaths {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  const missing: string[] = [];
+  for (const source of sources) {
+    for (const entry of source ?? []) {
+      const resolved = path.isAbsolute(entry) ? path.normalize(entry) : path.resolve(agentDir, entry);
+      if (seen.has(resolved)) continue;
+      seen.add(resolved);
+      if (isFile(resolved)) paths.push(resolved);
+      else missing.push(resolved);
+    }
+  }
+  return { paths, missing };
+}
+
+export type TaskCwdResolution = { ok: true; cwd: string } | { ok: false; error: string };
+
+/**
+ * Resolve a task's `cwd` against the session cwd. The result must be an
+ * existing directory inside the session cwd — checked on real paths, so a
+ * symlink cannot escape the jail. Absent or empty means the session cwd.
+ */
+export function resolveTaskCwd(sessionCwd: string, taskCwd: string | undefined): TaskCwdResolution {
+  if (taskCwd === undefined || taskCwd.trim() === '') return { ok: true, cwd: sessionCwd };
+  if (path.isAbsolute(taskCwd)) {
+    return { ok: false, error: `cwd must be relative to the session cwd, got absolute path ${taskCwd}` };
+  }
+  const candidate = path.resolve(sessionCwd, taskCwd);
+  if (!isDirectory(candidate)) {
+    return { ok: false, error: `cwd ${taskCwd} does not exist or is not a directory under ${sessionCwd}` };
+  }
+  const realRoot = realpath(sessionCwd);
+  const realCandidate = realpath(candidate);
+  if (realRoot === null || realCandidate === null) {
+    return { ok: false, error: `cwd ${taskCwd} could not be resolved` };
+  }
+  const relative = path.relative(realRoot, realCandidate);
+  if (relative === '') return { ok: true, cwd: candidate };
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return { ok: false, error: `cwd ${taskCwd} escapes the session cwd ${sessionCwd}` };
+  }
+  return { ok: true, cwd: candidate };
+}
+
+function isFile(file: string): boolean {
+  try {
+    return fs.statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function isDirectory(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function realpath(target: string): string | null {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return null;
+  }
+}

--- a/packages/subagents/index.ts
+++ b/packages/subagents/index.ts
@@ -60,6 +60,7 @@ import {
 } from '@nicknisi/pi-shared';
 import { Type } from 'typebox';
 import { scopeFleetRuns, type FleetScope } from './fleet.js';
+import { readHostConfigFile, resolveChildExtensionPaths, resolveTaskCwd } from './host-config.js';
 import {
   applyProfile,
   discoverProfiles,
@@ -70,6 +71,7 @@ import {
 } from './profiles.js';
 
 export type { AgentProfile } from './profiles.js';
+export { HOST_CONFIG_FILE, resolveTaskCwd, type SubagentsHostConfig } from './host-config.js';
 
 export interface SubagentsOptions {
   /**
@@ -78,7 +80,18 @@ export interface SubagentsOptions {
    * default personas.
    */
   profileDirs?: string[];
+  /**
+   * Extension files every child loads (absolute, or relative to the agent
+   * dir). Merged ahead of `<agentDir>/subagents.json`. The hook for a host
+   * whose model routing lives in an extension — a provider registered with
+   * `pi.registerProvider` does not exist in a child's fresh model runtime
+   * unless the extension loads there too. Children stay hermetic otherwise.
+   */
+  childExtensionPaths?: string[];
 }
+
+/** Resolved once at load; every spawn copies it into `SpawnOptions.extensionPaths`. */
+let hostChildExtensionPaths: string[] = [];
 
 const ARTIFACTS_ROOT = path.join(getAgentDir(), 'subagent-runs');
 const PATCHES_STATE_DIR = path.join(getAgentDir(), 'subagent-patches');
@@ -114,6 +127,8 @@ interface TaskSpec {
   background?: boolean | undefined;
   allowTreeMutation?: boolean | undefined;
   worktree?: boolean | undefined;
+  /** Relative to the session cwd and jailed inside it; validated before spawn. */
+  cwd?: string | undefined;
   /** Resolved by profile merging — not part of the tool schema. */
   skillPaths?: string[] | undefined;
   replaceSystemPrompt?: boolean | undefined;
@@ -149,8 +164,10 @@ function toSpawnOptions(spec: TaskSpec, cwd: string, parentSession: string | und
   const opts: SpawnOptions = {
     prompt: spec.task,
     tools: spec.tools ?? DEFAULT_TOOLS,
-    cwd,
+    // Callers validate spec.cwd with resolveTaskCwd before reaching here.
+    cwd: spec.cwd ? path.resolve(cwd, spec.cwd) : cwd,
   };
+  if (hostChildExtensionPaths.length > 0) opts.extensionPaths = [...hostChildExtensionPaths];
   if (spec.agent) opts.agent = spec.agent;
   if (spec.model) opts.model = spec.model;
   if (spec.systemPrompt) opts.systemPrompt = spec.systemPrompt;
@@ -1281,6 +1298,13 @@ async function dispatchInline(
   spec: TaskSpec,
 ): Promise<void> {
   const parentSession = ctx.sessionManager?.getSessionFile();
+  if (spec.cwd) {
+    const resolved = resolveTaskCwd(ctx.cwd, spec.cwd);
+    if (!resolved.ok) {
+      if (ctx.hasUI) ctx.ui.notify(`dispatch refused: ${resolved.error}`, 'error');
+      return;
+    }
+  }
   const task: TaskProgress = { label: spec.agent ?? short(spec.task, 40), status: 'pending' };
   if (spec.model) task.model = spec.model;
   const details: DispatchDetails = { tasks: [task], settled: false };
@@ -1365,6 +1389,20 @@ async function dispatchInline(
 export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = {}) {
   const runtime = createSubagentRuntime({ namespace: 'subagents', artifactsDir: ARTIFACTS_ROOT });
   const extraProfileDirs = options.profileDirs ?? [];
+  // Host config: factory option first, then <agentDir>/subagents.json. Missing
+  // files are skipped with a warning; a broken config file never blocks load.
+  const hostConfig = readHostConfigFile(getAgentDir());
+  const childExtensions = resolveChildExtensionPaths(
+    getAgentDir(),
+    options.childExtensionPaths,
+    hostConfig.config.childExtensionPaths,
+  );
+  hostChildExtensionPaths = childExtensions.paths;
+  const hostWarnings = [
+    ...hostConfig.warnings,
+    ...childExtensions.missing.map((file) => `childExtensionPaths: ${file} does not exist — skipped`),
+  ];
+  for (const warning of hostWarnings) console.error(`[subagents] ${warning}`);
   // Registration-time snapshot for the tool description; execution rescans.
   const initialProfiles = loadProfiles(process.cwd(), extraProfileDirs);
 
@@ -1393,6 +1431,7 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
 
   pi.on('session_start', (_event, ctx) => {
     if (!ctx.hasUI) return;
+    for (const warning of hostWarnings) ctx.ui.notify(`[subagents] ${warning}`, 'warning');
     statusUi = ctx.ui;
     statusTheme = (ctx.ui as ExtensionUIContext).theme ?? null;
     statusParentSession = ctx.sessionManager.getSessionFile();
@@ -1444,6 +1483,8 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
       'for builders instead — isolated worktrees stay parallel and hand off a patch for central integration.',
       'A task may name a profile — a persona file bundling a skill basket, tool allowlist, model, and',
       'system prompt — instead of assembling those per task; explicit task fields override profile values.',
+      'A task may set cwd (relative to the session cwd, jailed inside it) to run inside a subdirectory such',
+      'as a repository checkout; worktree isolation uses the repository containing that cwd.',
       profileCatalogLine(initialProfiles.profiles),
     ]
       .filter(Boolean)
@@ -1455,6 +1496,7 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
       'Prefer profile: "<name>" when a defined profile matches the work — it attaches the persona\'s skills, tools, and prompt.',
       'Set background: true for long-running tasks; results surface via the fleet tool.',
       'Tasks with edit/write/bash tools need allowTreeMutation: true and serialize after the parallel batch — or set worktree: true to isolate them and keep them parallel.',
+      'Set cwd: "<relative dir>" when the child should run inside a subdirectory (a repository checkout, for worktree tasks); it must stay inside the session cwd.',
     ],
     parameters: Type.Object({
       tasks: Type.Array(
@@ -1483,6 +1525,12 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
             Type.Boolean({
               description:
                 'Run in an isolated git worktree; writes never touch your tree. The full change set (incl. new files) lands as a .patch next to the run artifact — integrate centrally. Mutating tools stay parallel and need no allowTreeMutation.',
+            }),
+          ),
+          cwd: Type.Optional(
+            Type.String({
+              description:
+                'Working directory for the child, relative to the session cwd and jailed inside it (e.g. "repos/acme__widgets"). Worktree tasks branch from the repository containing this directory. Must exist; escaping paths are refused.',
             }),
           ),
         }),
@@ -1524,6 +1572,16 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
           }
           return merged.spec;
         });
+      }
+
+      // A task cwd must be an existing directory inside the session cwd
+      // (checked on real paths). A bad cwd refuses that task, like an
+      // unknown profile — never the whole dispatch.
+      const cwdFailures = new Map<TaskSpec, string>();
+      for (const spec of specs) {
+        if (!spec.cwd) continue;
+        const resolved = resolveTaskCwd(ctx.cwd, spec.cwd);
+        if (!resolved.ok) cwdFailures.set(spec, resolved.error);
       }
 
       if (ctx.hasUI) widgetUi = ctx.ui;
@@ -1574,13 +1632,13 @@ export default function subagents(pi: ExtensionAPI, options: SubagentsOptions = 
       const runnable: TaskSpec[] = [];
       const mutating: TaskSpec[] = [];
       for (const spec of specs) {
-        const profileFailure = profileFailures.get(spec);
-        if (profileFailure) {
+        const refusal = profileFailures.get(spec) ?? cwdFailures.get(spec);
+        if (refusal) {
           const task = progress.get(spec)!;
           task.status = 'error';
-          task.error = profileFailure;
+          task.error = refusal;
           task.doneAt = Date.now();
-          lines.push(`## ✗ ${task.label} — refused\n\n${profileFailure}`);
+          lines.push(`## ✗ ${task.label} — refused\n\n${refusal}`);
           continue;
         }
         if (wantsTreeMutation(spec)) {

--- a/packages/subagents/profiles.ts
+++ b/packages/subagents/profiles.ts
@@ -43,6 +43,11 @@ export interface AgentProfile {
   model?: string | undefined;
   /** Default the task to worktree isolation (the natural home for builder personas). */
   worktree?: boolean | undefined;
+  /**
+   * Default working directory for the task, relative to the session cwd and
+   * jailed inside it — e.g. a repository checkout under a workspace root.
+   */
+  cwd?: string | undefined;
   /** Replace pi's system prompt with the persona prompt instead of appending. */
   replace?: boolean | undefined;
   /** Persona system prompt (frontmatter body). Empty string when absent. */
@@ -60,6 +65,7 @@ export interface ProfileTaskFields {
   systemPrompt?: string | undefined;
   allowTreeMutation?: boolean | undefined;
   worktree?: boolean | undefined;
+  cwd?: string | undefined;
   skillPaths?: string[] | undefined;
   replaceSystemPrompt?: boolean | undefined;
 }
@@ -177,6 +183,8 @@ export function parseAgentProfile(content: string, filePath: string, scope: Agen
   if (model) profile.model = model;
   const worktree = boolField('worktree');
   if (worktree !== undefined) profile.worktree = worktree;
+  const cwd = scalars.get('cwd');
+  if (cwd) profile.cwd = cwd;
   const replace = boolField('replace');
   if (replace !== undefined) profile.replace = replace;
   return { ok: true, profile };
@@ -294,6 +302,7 @@ export function applyProfile<T extends ProfileTaskFields>(spec: T, profile: Agen
         : profile.tools;
     if (tools.length > 0) merged.tools = tools;
   }
+  if (merged.cwd === undefined && profile.cwd !== undefined) merged.cwd = profile.cwd;
   if (skillPaths.length > 0) merged.skillPaths = skillPaths;
   if (merged.systemPrompt === undefined && profile.prompt !== '') {
     merged.systemPrompt = profile.prompt;


### PR DESCRIPTION
## Summary

- **Why:** hosted harnesses break two assumptions children make. TARS (WorkOS's cloud agent, which installs this package as a pinned extension) runs pi at a *workspace root* that holds several checkouts under `repos/<owner>__<name>`, and routes every model call through a broker that an extension registers with `pi.registerProvider`. As shipped, `worktree: true` fails fast because the child's cwd is the session cwd and that is not a git repo, and a child has no usable model because it gets a fresh `ModelRuntime` with no extensions, so the parent's registered providers do not exist there.
- **`cwd` on dispatch tasks and profiles.** Relative to the session cwd, must exist, and must stay inside it. The check runs on real paths, so a symlink cannot escape. A bad `cwd` refuses only that task, the same way an unknown profile does; the rest of the dispatch proceeds. Worktree tasks branch from the repository containing the resolved cwd.
- **`childExtensionPaths`, host configuration only.** A factory option (`subagents(pi, { childExtensionPaths: [...] })`) merged ahead of `<agentDir>/subagents.json`, for hosts that install with `pi install` and cannot wrap the factory. Entries are absolute or relative to the agent dir; missing files are skipped with a warning at load and a `session_start` notification when there is a UI. The `dispatch` schema has no way to name extensions, so children stay hermetic apart from what the host lists.
- **Exposure, not new machinery.** `SpawnOptions` already carried `cwd` and `extensionPaths`; `toSpawnOptions` now fills them. `runChild` and the worktree helper are unchanged.
- **Tests and release.** `host-config.test.ts` adds 16 vitest cases (cwd jail incl. symlink escape, config file parsing, path merging, profile `cwd` precedence); changeset bumps `@nicknisi/pi-subagents` minor. `pnpm typecheck`, `pnpm lint`, `pnpm format`, and `pnpm vitest run packages/subagents` pass.

## What it looks like for a host

```json
// <agentDir>/subagents.json
{ "childExtensionPaths": ["/app/inference-broker.ts", "/app/repo-context.ts"] }
```

```markdown
---
name: builder
description: Implements one scoped change in an isolated worktree and returns a patch
tools: read, edit, write, bash, grep, find, ls
worktree: true
cwd: repos/acme__widgets
---
```

A dispatch task can also set `cwd` directly; an explicit task value wins over the profile default.

## Notes for review

- The README documents both fields (Worktree isolation, Profiles table, Configuration) and updates the hermetic-children paragraph to name the one host-level exception.
- Relative `childExtensionPaths` resolve against the agent dir, matching how the rest of this package treats `getAgentDir()`.
- No behavior changes for callers that set neither field.
