### PR TITLE
fix(stash): avoid built-in shortcut conflict

### DIFF
--- a/.changeset/six-animals-deny.md
+++ b/.changeset/six-animals-deny.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-stash': patch
+---
+
+Move the stash/restore shortcut from Ctrl+S to Ctrl+Shift+S to avoid Pi's built-in shortcut conflict warning. Update the widget hint to match.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Local paths are added to pi's settings without copying — edits in the repo are
 | [fast](packages/fast/)                   | Toggle premium faster inference for supported Anthropic Claude and OpenAI Codex models                                       | `/fast`, footer status                                    |
 | [model-switch](packages/model-switch/)   | Cycle or fuzzy-pick from a machine-local, sectioned model list, skipping missing or unauthenticated entries                  | `/model-cycle`, configurable shortcuts                    |
 | [session-name](packages/session-name/)   | Auto-name sessions (heuristic or LLM), mirror to terminal title, name-focused session picker                                 | `/sn`, `/sessions`                                        |
-| [stash](packages/stash/)                 | `ctrl+s` parks the prompt draft on a LIFO stack; pop or auto-restore                                                         | `ctrl+s`, stash widget                                    |
+| [stash](packages/stash/)                 | `ctrl+shift+s` parks the prompt draft on a LIFO stack; pop or auto-restore                                                   | `ctrl+shift+s`, stash widget                              |
 
 ### Library
 

--- a/packages/stash/README.md
+++ b/packages/stash/README.md
@@ -1,17 +1,17 @@
 # @nicknisi/pi-stash
 
-Replicates Claude Code's `ctrl+s` message stash. Press `ctrl+s` to stash whatever you've typed in the input editor, go do something else (run a command, answer another prompt), then press `ctrl+s` again with an empty editor to pop the most recent stash back. Stashes live on a stack, so multiple drafts can be parked and restored LIFO.
+Replicates Claude Code's message stash using `ctrl+shift+s` to avoid conflicts with Pi's built-in `ctrl+s` shortcuts. Press `ctrl+shift+s` to stash whatever you've typed in the input editor, go do something else, then press `ctrl+shift+s` again with an empty editor to pop the most recent stash back. Stashes live on a stack, so multiple drafts can be parked and restored LIFO.
 
 ## What it adds
 
-- **Keybinding:** `ctrl+s` — stash/restore toggle (see behavior table below)
-- **Widget:** a single-line widget above the editor, visible whenever the stash stack is non-empty, showing a 60-char preview of the most recent stash, the count of additional stashes (`(+N more)`), and a `ctrl+s to restore` hint
+- **Keybinding:** `ctrl+shift+s` toggles stash/restore. See the behavior table below.
+- **Widget:** a single-line widget above the editor, visible whenever the stash stack is non-empty, showing a 60-char preview of the most recent stash, the count of additional stashes (`(+N more)`), and a `ctrl+shift+s to restore` hint
 - **Events hooked:** `before_agent_start` — after a message is submitted and the agent starts, the most recent stash is auto-restored into the now-empty editor (mirrors Claude Code)
 - No slash commands, no tools, no custom entry types.
 
 ### Keybinding behavior
 
-| Editor state on `ctrl+s`                  | Action                                     |
+| Editor state on `ctrl+shift+s`            | Action                                     |
 | ----------------------------------------- | ------------------------------------------ |
 | Contains text                             | Push text onto the stack, clear the editor |
 | Empty (or whitespace) and stack non-empty | Pop the most recent stash into the editor  |
@@ -21,9 +21,9 @@ Replicates Claude Code's `ctrl+s` message stash. Press `ctrl+s` to stash whateve
 
 ```text
 (type a long prompt, then need to ask something else first)
-ctrl+s            "⧉ stashed: Refactor the auth module to..." · editor cleared
+ctrl+shift+s      "⧉ stashed: Refactor the auth module to..." · editor cleared
 (ask the other question; on submit, the stashed draft is restored automatically)
-ctrl+s            (with empty editor) pops the stash back manually
+ctrl+shift+s      (with empty editor) pops the stash back manually
 ```
 
 The stash is in-memory only (per session, per process). It is not persisted across restarts.
@@ -41,9 +41,9 @@ None. No config files, no options, no environment variables.
 
 - UI-gated: every handler checks `ctx.hasUI`; the extension is a no-op in headless/non-TUI mode.
 - Depends on the editor text APIs (`ctx.ui.getEditorText` / `setEditorText`) and the widget system (`ctx.ui.setWidget`) — these are stable pi extension APIs, but a pi version that changes editor or widget semantics could affect it.
-- The `before_agent_start` auto-restore pops a stash whenever a message is sent with an empty editor. If you intentionally sent a quick command and wanted the stash to stay parked, it will still be restored into the editor (you can `ctrl+s` it back). This matches Claude Code's behavior.
+- The `before_agent_start` auto-restore pops a stash whenever a message is sent with an empty editor. If you intentionally sent a quick command and wanted the stash to stay parked, it will still be restored into the editor (you can `ctrl+shift+s` it back). This matches Claude Code's behavior.
 - Stash stack is module-local state; it does not survive session reload or extension reload.
-- No platform-specific behavior (works on any OS/terminal pi runs in). The widget preview uses the Unicode glyphs `⧉` and `…`.
+- The terminal must distinguish `ctrl+shift+s` from `ctrl+s`, for example through the Kitty keyboard protocol. Legacy terminals may need a key mapping. The widget preview uses the Unicode glyphs `⧉` and `…`.
 
 ## Install
 

--- a/packages/stash/index.test.ts
+++ b/packages/stash/index.test.ts
@@ -1,0 +1,40 @@
+import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { expect, it, vi } from 'vitest';
+import stash from './index.js';
+
+it('stashes and restores drafts with Ctrl+Shift+S and shows the matching hint', async () => {
+  const registerShortcut = vi.fn<ExtensionAPI['registerShortcut']>();
+  stash({ registerShortcut, on: vi.fn() } as unknown as ExtensionAPI);
+
+  expect(registerShortcut).toHaveBeenCalledOnce();
+  const [key, { handler }] = registerShortcut.mock.calls[0]!;
+  expect(key).toBe('ctrl+shift+s');
+
+  let text = 'first draft';
+  const setWidget = vi.fn();
+  const ctx = {
+    hasUI: true,
+    ui: {
+      getEditorText: () => text,
+      setEditorText: (value: string) => {
+        text = value;
+      },
+      setWidget,
+      theme: { fg: (_color: string, value: string) => value },
+    },
+  } as unknown as ExtensionContext;
+
+  await handler(ctx);
+  expect(text).toBe('');
+  expect(setWidget).toHaveBeenLastCalledWith('message-stash', [expect.stringContaining('ctrl+shift+s to restore')]);
+
+  text = 'second draft';
+  await handler(ctx);
+  expect(text).toBe('');
+  await handler(ctx);
+  expect(text).toBe('second draft');
+  text = '';
+  await handler(ctx);
+  expect(text).toBe('first draft');
+  expect(setWidget).toHaveBeenLastCalledWith('message-stash', undefined);
+});

--- a/packages/stash/index.ts
+++ b/packages/stash/index.ts
@@ -1,12 +1,12 @@
 /**
  * Message Stash Extension
  *
- * Replicates Claude Code's ctrl+s message stash: press ctrl+s to stash
+ * Replicates Claude Code's message stash: press ctrl+shift+s to stash
  * whatever you've typed in the input box, do something else, then press
- * ctrl+s again (with an empty input) to restore it.
+ * ctrl+shift+s again (with an empty input) to restore it.
  *
- * - ctrl+s with text in the editor → pushes it onto a stack and clears
- * - ctrl+s with an empty editor    → pops the most recent stash back
+ * - ctrl+shift+s with text in the editor → pushes it onto a stack and clears
+ * - ctrl+shift+s with an empty editor    → pops the most recent stash back
  * - sending another message        → auto-restores the most recent stash
  *
  * A widget above the editor shows how many messages are stashed with a
@@ -32,11 +32,11 @@ export default function stash(pi: ExtensionAPI) {
     const preview = firstLine.length > 60 ? `${firstLine.slice(0, 60)}…` : firstLine;
     const count = stack.length > 1 ? theme.fg('dim', ` (+${stack.length - 1} more)`) : '';
     ctx.ui.setWidget(WIDGET_KEY, [
-      `${theme.fg('accent', '⧉ stashed:')} ${theme.fg('muted', preview)}${count} ${theme.fg('dim', '· ctrl+s to restore')}`,
+      `${theme.fg('accent', '⧉ stashed:')} ${theme.fg('muted', preview)}${count} ${theme.fg('dim', '· ctrl+shift+s to restore')}`,
     ]);
   };
 
-  pi.registerShortcut('ctrl+s', {
+  pi.registerShortcut('ctrl+shift+s', {
     description: 'Stash / restore the typed message',
     handler: async (ctx) => {
       if (!ctx.hasUI) return;


### PR DESCRIPTION
## Summary

Move stash/restore from Ctrl+S to Ctrl+Shift+S so installation no longer produces a built-in shortcut conflict warning with Pi defaults.

Update the widget hint and documentation, document terminal support requirements, and include a patch changeset and a stash/restore regression test.

## Verification

Passed the stash regression test, pnpm typecheck, pnpm lint, targeted formatting checks, and git diff --check.

Verified that Pi 0.84.0 and 0.85.1 accept the new shortcut with zero diagnostics. Auto-restore after submission still works.