### PR TITLE
feat(compact-tools): add compact expandable tool displays

### DIFF
--- a/.changeset/free-clouds-read.md
+++ b/.changeset/free-clouds-read.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-compact-tools': minor
+---
+
+Add compact tool displays with human-readable headers, one preview line, and native success/error backgrounds for all tools. Preserve original expanded rendering through Ctrl+O and fullscreen clicks without changing tool results or model context.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Local paths are added to pi's settings without copying — edits in the repo are
 
 | Package                                      | What it does                                                                                                 | Adds                                        |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| [compact-tools](packages/compact-tools/)     | Two-line tool displays with original rendering on Ctrl+O or fullscreen click                                 | compact tool display                        |
 | [composer](packages/composer/)               | Config-driven boxed input editor; paste-again-to-expand for collapsed paste markers; tmux focus-aware border | custom editor component                     |
 | [header](packages/header/)                   | Animated dashboard header (GIF-compiled truecolor frames or ASCII art) with session info, on fresh sessions  | `/nicknisi-header`, custom header           |
 | [mg](packages/mg/)                           | Severance-style "100% File Completion" animation starring a pixelated Michael Grinich, with macOS audio      | `/mg [name]`                                |

--- a/packages/compact-tools/README.md
+++ b/packages/compact-tools/README.md
@@ -1,0 +1,67 @@
+# pi-compact-tools
+
+Collapse every tool display to a header and one preview line. Press **Ctrl+O** to expand all tools, or click a tool in Pi's fullscreen mode to expand just that tool.
+
+```text
+▸ $ pnpm test
+  Test run started … [ctrl+o]
+```
+
+Only the display changes. Tool execution, saved results, images, details, and model context stay untouched. Expanding restores the tool's original renderer, including syntax highlighting, diffs, and custom extension displays.
+
+## Install
+
+From a local checkout:
+
+```bash
+pi install /absolute/path/to/pi-extensions/packages/compact-tools
+```
+
+After publication:
+
+```bash
+pi install npm:@nicknisi/pi-compact-tools
+```
+
+Restart Pi or run `/reload` after installation.
+
+## Behavior
+
+| Action or state               | Display                                                                             |
+| ----------------------------- | ----------------------------------------------------------------------------------- |
+| Before a result arrives       | One line using the tool's normal human-readable header                              |
+| Streaming or completed result | Header plus one readable preview line                                               |
+| Multiline output              | An ellipsis after the preview                                                       |
+| Success                       | Both lines use Pi's green `toolSuccessBg` background                                |
+| Running                       | Both lines use Pi's `toolPendingBg` background                                      |
+| Error                         | Both lines use Pi's red `toolErrorBg` background, with an explicit `Error:` preview |
+| Images                        | An image count instead of inline images                                             |
+| Ctrl+O                        | Pi's existing expand/collapse toggle for all tools                                  |
+| Fullscreen left click         | Expand one collapsed tool. Click its original header or result to collapse it again |
+
+There is one blank separator before each tool. Long lines truncate to the terminal width rather than wrapping. Built-in, extension, MCP, dynamically registered, and restored tool rows all use the same compact display. Headers reuse the tool's existing renderer, such as `read src/index.ts` or `$ pnpm test`. Tools without a custom header show their name and a path, command, query, action, or URL when available. The fallback never dumps JSON arguments or file contents.
+
+Tools start collapsed on session start and reload. The key hint follows your `app.tools.expand` binding in `~/.pi/agent/keybindings.json`. No new tools, commands, shortcuts, widgets, or session entry types are registered.
+
+## Configuration
+
+None. The default is two content lines. Use Pi's existing expansion controls when you need more detail.
+
+## Dependencies and caveats
+
+- Pi supplies `@earendil-works/pi-coding-agent` and `@earendil-works/pi-tui` as peer dependencies. `@nicknisi/pi-shared` supplies terminal-label sanitization.
+- Keyboard compaction works with Pi 0.84 and 0.85. Fullscreen click expansion needs Pi 0.85.1 or newer. Regular terminal mode leaves mouse input to terminal scrollback, so use Ctrl+O there.
+- Pi has no public global tool-rendering hook. This extension wraps `ToolExecutionComponent.render` and its mouse handler, reading the component's private display state. A Pi update can break this integration. Missing required methods produce a warning and leave the original display in place.
+- The wrapper is installed only in TUI sessions and removed on session shutdown, including reload. Print, JSON, and RPC sessions are unchanged.
+- Previews use the tool's existing result renderer when available, falling back to the first nonempty output line. JSON-only output shows an item or field count instead of serialized data. No model call is made. Custom controls and detailed progress displays are available when expanded.
+- Expanded displays retain each tool's own limits. This extension cannot recover output already truncated by a tool.
+- Other extensions that replace the same component methods can conflict. This extension does not overwrite a later wrapper during cleanup.
+- User shell commands entered with `!` or `!!` use a separate Pi component and are unchanged.
+
+## Development
+
+```bash
+pnpm test -- packages/compact-tools/index.test.ts
+pnpm typecheck
+pnpm lint
+```

--- a/packages/compact-tools/index.test.ts
+++ b/packages/compact-tools/index.test.ts
@@ -1,0 +1,217 @@
+import {
+  createBashToolDefinition,
+  initTheme,
+  ToolExecutionComponent,
+  type ExtensionAPI,
+  type ExtensionContext,
+} from '@earendil-works/pi-coding-agent';
+import {
+  getKeybindings,
+  KeybindingsManager,
+  setKeybindings,
+  Text,
+  visibleWidth,
+  type TUI,
+} from '@earendil-works/pi-tui';
+import { stripVTControlCharacters } from 'node:util';
+import { afterEach, expect, it, vi } from 'vitest';
+import compactTools from './index.js';
+
+type Handler = (event: unknown, ctx: ExtensionContext) => void;
+const shutdowns: Array<() => void> = [];
+const originalKeybindings = getKeybindings();
+initTheme('dark', false);
+afterEach(() => {
+  for (const shutdown of shutdowns.reverse()) shutdown();
+  shutdowns.length = 0;
+  setKeybindings(originalKeybindings);
+});
+
+function install(mode: ExtensionContext['mode'] = 'tui') {
+  setKeybindings(new KeybindingsManager({ 'app.tools.expand': { defaultKeys: 'ctrl+o' } }));
+  const handlers = new Map<string, Handler>();
+  const ctx = {
+    mode,
+    ui: {
+      theme: {
+        fg: (_color: string, text: string) => text,
+        bg: vi.fn((_color: string, text: string) => text),
+      },
+      notify: vi.fn(),
+      setToolsExpanded: vi.fn(),
+      setStatus: vi.fn(),
+    },
+  } as unknown as ExtensionContext;
+  compactTools({ on: (name: string, handler: Handler) => handlers.set(name, handler) } as unknown as ExtensionAPI);
+  const start = () => handlers.get('session_start')!({}, ctx);
+  const shutdown = () => handlers.get('session_shutdown')!({}, ctx);
+  shutdowns.push(shutdown);
+  start();
+  return { start, shutdown, handlers, ctx };
+}
+
+type Definition = NonNullable<ConstructorParameters<typeof ToolExecutionComponent>[4]>;
+
+function row(name = 'bash', definition?: Definition) {
+  return new ToolExecutionComponent(
+    name,
+    'call-1',
+    { command: 'printf "first\\nsecond\\nthird"' },
+    {},
+    definition,
+    { requestRender: vi.fn() } as unknown as TUI,
+    process.cwd(),
+  );
+}
+
+const result = {
+  content: [{ type: 'text', text: '\nfirst\nsecond\nthird' }],
+  details: { untouched: true },
+  isError: false,
+};
+const plain = (component: ToolExecutionComponent, width = 80) =>
+  component.render(width).map((line) => stripVTControlCharacters(line).trimEnd());
+const click = (component: ToolExecutionComponent, type = 'click', button = 'left', y = 1) =>
+  (component as unknown as { handleMouse(event: { type: string; button: string; y: number }): unknown }).handleMouse({
+    type,
+    button,
+    y,
+  });
+
+it('compacts existing and future rows, preserves results, and restores native expanded rendering', () => {
+  const existing = row('bash', createBashToolDefinition(process.cwd()));
+  existing.updateResult(result);
+  existing.setExpanded(true);
+  const expanded = existing.render(80);
+  existing.setExpanded(false);
+  const { ctx, handlers } = install();
+
+  expect([...handlers.keys()]).toEqual(['session_start', 'session_shutdown']);
+  expect(ctx.ui.setToolsExpanded).toHaveBeenCalledWith(false);
+  expect(ctx.ui.setStatus).toHaveBeenCalledWith('compact-tools', undefined);
+  const before = structuredClone(result);
+  for (const component of [existing, row('mcp__test__query')]) {
+    component.updateResult(result);
+    expect(plain(component)).toEqual(['', expect.stringContaining('▸ '), '  first … [ctrl+o]']);
+    component.setExpanded(true);
+    expect(plain(component).join('\n')).toContain('third');
+    component.setExpanded(false);
+    expect(plain(component)).toHaveLength(3);
+  }
+  existing.setExpanded(true);
+  expect(existing.render(80)).toEqual(expanded);
+  expect(result).toEqual(before);
+});
+
+it('restores custom self-shell renderers and allows per-row clicks without sending input to hidden children', () => {
+  const definition: Definition = {
+    ...createBashToolDefinition(process.cwd()),
+    name: 'custom',
+    renderShell: 'self',
+    renderCall: () => new Text('Original header\nExtra header', 0, 0),
+    renderResult: () => new Text('Original result\nOriginal detail', 0, 0),
+  };
+  const component = row('custom', definition);
+  component.updateResult(result);
+  component.setExpanded(true);
+  const expanded = component.render(80);
+  component.setExpanded(false);
+  install();
+  expect(plain(component)).toHaveLength(3);
+  expect(plain(component)[1]).toBe('▸ Original header');
+  expect(plain(component)[2]).toBe('  Original result … [ctrl+o]');
+  expect(click(component, 'click', 'right')).toBeUndefined();
+  expect(click(component, 'wheel')).toBeUndefined();
+  expect(click(component, 'drag')).toBeUndefined();
+  expect(click(component, 'click', 'left', 0)).toBeUndefined();
+  expect(plain(component)).toHaveLength(3);
+  expect(click(component)).toEqual({ handled: true });
+  expect(component.render(80)).toEqual(expanded);
+  component.setExpanded(false);
+  expect(plain(component)).toHaveLength(3);
+});
+
+it('bounds pending, streaming, error, empty, and image displays, including narrow Unicode output', () => {
+  install();
+  const component = row('custom');
+  expect(plain(component)).toHaveLength(2);
+  expect(click(component)).toBeUndefined();
+  component.updateResult({ content: [], isError: false }, true);
+  expect(plain(component)[2]).toContain('Running');
+  component.updateResult({ content: [], isError: false });
+  expect(plain(component)[2]).toContain('Done');
+  component.updateResult({
+    content: [
+      { type: 'text', text: '\x1b]52;c;ZXZpbA==\x07\x1b[31m失敗\x1b[0m\tmessage\nMore detail' },
+      { type: 'image' },
+    ],
+    isError: true,
+  });
+  expect(plain(component)[2]).toContain('Error: 失敗 message … [1 image]');
+  expect(plain(component).join('\n')).not.toContain('52;c;');
+  for (const width of [0, 1, 2, 5, 12, 40, 80]) {
+    expect(component.render(width)).toHaveLength(3);
+    expect(component.render(width).every((line) => visibleWidth(line) <= width)).toBe(true);
+  }
+});
+
+it('fills both compact lines with the native outcome background and never dumps JSON arguments', () => {
+  const { ctx } = install();
+  const component = row('custom');
+  component.updateArgs({ path: 'src/index.ts', content: 'private payload', extra: { nested: true } });
+  expect(plain(component)[1]).toBe('▸ custom src/index.ts');
+  for (const [isPartial, isError, background] of [
+    [true, false, 'toolPendingBg'],
+    [false, false, 'toolSuccessBg'],
+    [false, true, 'toolErrorBg'],
+  ] as const) {
+    component.updateResult({ ...result, isError }, isPartial);
+    vi.mocked(ctx.ui.theme.bg).mockClear();
+    const lines = component.render(80);
+    expect(lines.slice(1).map(visibleWidth)).toEqual([80, 80]);
+    expect(ctx.ui.theme.bg).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(ctx.ui.theme.bg).mock.calls.every(([color]) => color === background)).toBe(true);
+    expect(lines.join('\n')).not.toContain('private payload');
+    expect(lines.join('\n')).not.toContain('{');
+  }
+});
+
+it('summarizes JSON-only results instead of showing braces or serialized payloads', () => {
+  install();
+  const component = row('mcp__query');
+  for (const [text, preview] of [
+    ['{"ok":true,"items":[1,2]}', 'Structured result with 2 fields'],
+    ['[{"id":1},{"id":2}]', '2 result items'],
+    ['{\n  "partial":', 'Structured output …'],
+  ]) {
+    component.updateResult({ content: [{ type: 'text', text: text! }], isError: false });
+    expect(plain(component)[2]).toBe(`  ${preview} [ctrl+o]`);
+    component.setExpanded(true);
+    expect(plain(component).join('\n')).toContain(text!.split('\n')[0]);
+    component.setExpanded(false);
+  }
+});
+
+it('restores prototype methods on shutdown and does not stack wrappers on repeated starts', () => {
+  const originalRender = ToolExecutionComponent.prototype.render;
+  const component = row();
+  component.updateResult(result);
+  const originalLines = component.render(80);
+  const extension = install();
+  extension.start();
+  expect(plain(component)).toHaveLength(3);
+  extension.shutdown();
+  expect(ToolExecutionComponent.prototype.render).toBe(originalRender);
+  expect(component.render(80)).toEqual(originalLines);
+  extension.start();
+  expect(plain(component)).toHaveLength(3);
+});
+
+it('leaves print, JSON, and RPC runtimes untouched', () => {
+  const originalRender = ToolExecutionComponent.prototype.render;
+  for (const mode of ['print', 'json', 'rpc'] as const) {
+    const { ctx } = install(mode);
+    expect(ToolExecutionComponent.prototype.render).toBe(originalRender);
+    expect(ctx.ui.setToolsExpanded).not.toHaveBeenCalled();
+  }
+});

--- a/packages/compact-tools/index.ts
+++ b/packages/compact-tools/index.ts
@@ -1,0 +1,137 @@
+import { keyText, ToolExecutionComponent, type ExtensionAPI, type Theme } from '@earendil-works/pi-coding-agent';
+import { stripTerminalSequences, truncateToWidth, type Component } from '@earendil-works/pi-tui';
+import { sanitizeTerminalLabel } from '@nicknisi/pi-shared';
+
+// Pi has no global tool-rendering hook. These TS-private fields are shared by
+// built-in, extension, MCP, and restored tool rows in Pi 0.84 and 0.85.
+interface ToolRow {
+  toolName: string;
+  args: unknown;
+  expanded: boolean;
+  isPartial: boolean;
+  callRendererComponent?: Component;
+  resultRendererComponent?: Component;
+  result?: { content: Array<{ type: string; text?: string }>; isError?: boolean };
+  render(width: number): string[];
+  setExpanded(expanded: boolean): void;
+  handleMouse?(event: MouseEvent): { handled?: boolean } | undefined;
+}
+
+interface MouseEvent {
+  type: string;
+  button: string;
+  y: number;
+}
+
+function renderedLines(component: Component | undefined, width: number): string[] {
+  try {
+    return (
+      component
+        ?.render(Math.max(1, width))
+        .map((line) => sanitizeTerminalLabel(stripTerminalSequences(line)).trim())
+        .filter(Boolean) ?? []
+    );
+  } catch {
+    // A custom renderer can fail. Fall back to the tool's text without losing expansion.
+    return [];
+  }
+}
+
+function callTitle(row: ToolRow, width: number): string {
+  const title = renderedLines(row.callRendererComponent, width).find((line) => /[\p{L}\p{N}]/u.test(line));
+  if (title) return title;
+  const args = row.args && typeof row.args === 'object' ? (row.args as Record<string, unknown>) : {};
+  const detail = args.path ?? args.command ?? args.query ?? args.action ?? args.url;
+  return sanitizeTerminalLabel(`${row.toolName}${typeof detail === 'string' ? ` ${detail.replace(/\s+/g, ' ')}` : ''}`);
+}
+
+function compactLines(row: ToolRow, width: number, theme: Theme): string[] {
+  const title = `▸ ${callTitle(row, width - 2)}`;
+  const color = row.result?.isError ? 'error' : row.isPartial ? 'warning' : 'toolOutput';
+  const background = row.isPartial ? 'toolPendingBg' : row.result?.isError ? 'toolErrorBg' : 'toolSuccessBg';
+  const paint = (line: string) => theme.bg(background, truncateToWidth(line, width, '…', true));
+  const lines = ['', paint(theme.fg('toolTitle', title))];
+  if (!row.result) return lines;
+
+  const text = row.result.content
+    .filter((part) => part.type === 'text')
+    .map((part) => part.text ?? '')
+    .join('\n')
+    .split('\n')
+    .map((line) => sanitizeTerminalLabel(line.replaceAll('\t', ' ')).trim())
+    .filter(Boolean);
+  const images = row.result.content.filter((part) => part.type === 'image').length;
+  const rendered = renderedLines(row.resultRendererComponent, width - 2);
+  const previewLines = rendered.length ? rendered : text;
+  let preview = previewLines[0] ?? (row.isPartial ? 'Running' : 'Done');
+  try {
+    const value: unknown = JSON.parse(previewLines.join('\n'));
+    if (Array.isArray(value)) preview = `${value.length} result items`;
+    else if (value && typeof value === 'object') preview = `Structured result with ${Object.keys(value).length} fields`;
+  } catch {
+    if (preview === '{' || preview === '[' || preview.startsWith('{"')) preview = 'Structured output';
+  }
+  if (previewLines.length > 1) preview += ' …';
+  if (images) preview += ` [${images} image${images === 1 ? '' : 's'}]`;
+  if (row.result.isError) preview = `Error: ${preview}`;
+  const hint = ` [${keyText('app.tools.expand')}]`;
+  const output = truncateToWidth(`  ${preview}`, Math.max(0, width - hint.length)) + hint;
+  lines.push(paint(theme.fg(color, output)));
+  return lines;
+}
+
+export default function compactTools(pi: ExtensionAPI) {
+  let dispose: (() => void) | undefined;
+
+  pi.on('session_start', (_event, ctx) => {
+    if (ctx.mode !== 'tui') return;
+    dispose?.();
+    const prototype = ToolExecutionComponent.prototype as unknown as ToolRow;
+    if (typeof prototype.render !== 'function' || typeof prototype.setExpanded !== 'function') {
+      ctx.ui.notify('compact-tools: unsupported Pi tool renderer. Keeping the original display.', 'warning');
+      return;
+    }
+
+    const originalRender = prototype.render;
+    const originalMouse = prototype.handleMouse;
+    let active = true;
+    const isCompact = (row: ToolRow) => active && row.expanded === false && typeof row.toolName === 'string';
+
+    function render(this: ToolRow, width: number): string[] {
+      return isCompact(this) ? compactLines(this, width, ctx.ui.theme) : originalRender.call(this, width);
+    }
+
+    function handleMouse(this: ToolRow, event: MouseEvent) {
+      if (!isCompact(this)) return originalMouse?.call(this, event);
+      // Hidden children must not receive input at their old, expanded positions.
+      // Unhandled wheel/drag events remain available to transcript scrolling/selection.
+      if (this.result && event.y > 0 && event.type === 'click' && event.button === 'left') {
+        this.setExpanded(true);
+        return { handled: true };
+      }
+      return undefined;
+    }
+
+    prototype.render = render;
+    prototype.handleMouse = handleMouse;
+    dispose = () => {
+      // A later extension may wrap us. In that case leave its wrapper intact,
+      // but make our captured functions pass through after this session ends.
+      active = false;
+      if (prototype.render === render) prototype.render = originalRender;
+      if (prototype.handleMouse === handleMouse) {
+        if (originalMouse) prototype.handleMouse = originalMouse;
+        else delete prototype.handleMouse;
+      }
+    };
+    ctx.ui.setToolsExpanded(false);
+    // setToolsExpanded is a no-op when already collapsed. Clear our unused status
+    // to request a redraw even then, without adding a visible widget or message.
+    ctx.ui.setStatus('compact-tools', undefined);
+  });
+
+  pi.on('session_shutdown', () => {
+    dispose?.();
+    dispose = undefined;
+  });
+}

--- a/packages/compact-tools/package.json
+++ b/packages/compact-tools/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@nicknisi/pi-compact-tools",
+  "version": "0.0.0",
+  "description": "Two-line tool displays with native click and Ctrl+O expansion",
+  "keywords": [
+    "pi",
+    "pi-coding-agent",
+    "pi-package"
+  ],
+  "homepage": "https://github.com/nicknisi/pi-extensions/tree/main/packages/compact-tools#readme",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nicknisi/pi-extensions.git",
+    "directory": "packages/compact-tools"
+  },
+  "files": [
+    "dist",
+    "index.ts"
+  ],
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@nicknisi/pi-shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,12 @@ importers:
         specifier: ^1.1.0
         version: 1.3.7
 
+  packages/compact-tools:
+    dependencies:
+      '@nicknisi/pi-shared':
+        specifier: workspace:*
+        version: link:../shared
+
   packages/composer: {}
 
   packages/fast: {}


### PR DESCRIPTION
## Summary

Add `@nicknisi/pi-compact-tools` to collapse built-in, extension, and MCP tool displays to a human-readable header and one preview line. Keep Pi's success, error, and pending backgrounds. JSON-only results show an item or field count instead of serialized data.

Ctrl+O expands all tools. Fullscreen clicks expand individual tools. Expanded rows use their original renderers. Tool execution, saved results, and model context do not change.

Includes a minor changeset, package README, and seven regression tests. The separate local Pi dependency upgrade is not included.

## Implementation caveat

Pi has no public global tool-rendering hook, so this wraps `ToolExecutionComponent` rendering and mouse handling. Shutdown and reload remove the wrapper. Keyboard behavior supports Pi 0.84 and 0.85. Fullscreen clicks require Pi 0.85.1 or newer.

## Verification

- The clean staged snapshot passes frozen-lockfile installation, all seven compact-tools tests, `pnpm build`, `pnpm typecheck`, `pnpm lint`, and `pnpm format:check`.
- The full suite has 269 passing tests and two failures outside this package: recap's background notification assertion, and relay's offline packaging test missing a cached `typebox` tarball.

Live Pi 0.85.1 checks confirmed compact startup, reload, Ctrl+O expansion, readable headers, and red/green backgrounds. Individual click expansion succeeded initially. A later mouse automation recheck after the window moved timed out, so mouse verification is not uniformly green. The native runtime render/click/collapse probe passed.
