### PR TITLE
feat(model-switch): add commands to save preferred models

### DIFF
--- a/.changeset/violet-keys-push.md
+++ b/.changeset/violet-keys-push.md
@@ -1,0 +1,5 @@
+---
+'@nicknisi/pi-model-switch': minor
+---
+
+Add `/model-switch add` and `/model-switch add-current` to save models to a chosen section without editing JSON. Preserve existing config data and skip duplicates within each section.

--- a/packages/model-switch/README.md
+++ b/packages/model-switch/README.md
@@ -34,6 +34,18 @@ These extension-owned action IDs are ignored by Pi's built-in keybinding manager
 
 ## Configure models
 
+### Add models from Pi
+
+Run `/model-switch add` to search Pi's available model catalog, pick a model, then choose an existing section to save it in. Run `/model-switch add-current` to save the model you're already using without opening the catalog picker. Both subcommands have argument completion.
+
+If the config file is missing, either command asks you to name the first section and creates the file. With an existing config, the section picker includes empty sections too. Add more sections by editing the config below.
+
+Adding a model does not switch the active model. Duplicate references in the chosen section are skipped, but the same model can belong to multiple sections. Escape cancels without writing. Saves preserve the legacy flat format, other sections, and extra config fields. Invalid configs produce a warning and are not overwritten.
+
+The catalog picker requires Pi's terminal UI. `add-current` also works with RPC clients that support Pi's selection and input dialogs. Neither command registers new providers or model definitions. The model must already be known to Pi.
+
+### Edit the config file
+
 Copy the example config:
 
 ```bash
@@ -125,7 +137,7 @@ The config may be missing, empty, malformed, or contain only missing/unauthentic
 - The picker uses a custom search + list component with `ctx.ui.custom()`; native `/model` and Ctrl+L remain available for the full catalog.
 - Terminal support for multi-modifier keys varies; configure simpler non-conflicting keys or use a terminal with the Kitty keyboard protocol when modified keys are not distinguishable.
 - Availability is checked on each interaction, which may resolve provider credentials before switching.
-- Duplicate references within a section are preserved as written; avoid them unless repeated cycle positions are intentional.
+- Duplicate references within a section are preserved as written; avoid them unless repeated cycle positions are intentional. The add commands never insert another copy of an existing reference.
 
 ## Development
 

--- a/packages/model-switch/config.test.ts
+++ b/packages/model-switch/config.test.ts
@@ -1,8 +1,16 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import { lstatSync, mkdtempSync, readFileSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DEFAULT_MODEL_CYCLE_KEYBINDINGS, loadModelSwitchConfig, loadModelSwitchKeybindings } from './config.js';
+import {
+  addModelToSection,
+  DEFAULT_MODEL_CYCLE_KEYBINDINGS,
+  loadModelSwitchConfig,
+  loadModelSwitchKeybindings,
+} from './config.js';
+
+vi.mock('node:fs', async (importOriginal) => ({ ...(await importOriginal<typeof import('node:fs')>()) }));
 
 const tempDirs: string[] = [];
 
@@ -15,6 +23,7 @@ function tempConfig(content?: string): string {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -132,6 +141,8 @@ describe('loadModelSwitchConfig', () => {
     ['missing sections and models', '{}'],
     ['non-object sections', JSON.stringify({ sections: 'nope' })],
     ['empty sections object', JSON.stringify({ sections: {} })],
+    ['array sections', JSON.stringify({ sections: [['provider/model']] })],
+    ['invalid sections with legacy models', JSON.stringify({ sections: null, models: ['provider/model'] })],
     ['non-array section models', JSON.stringify({ sections: { work: 'nope' } })],
     ['non-string model in section', JSON.stringify({ sections: { work: [42] } })],
     ['empty model in section', JSON.stringify({ sections: { work: ['  '] } })],
@@ -142,5 +153,120 @@ describe('loadModelSwitchConfig', () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain(path);
+  });
+});
+
+describe('addModelToSection', () => {
+  it('appends only to the selected section and preserves other config fields', () => {
+    const config = {
+      sections: { work: ['provider/old'], personal: ['provider/new'] },
+      models: ['legacy/ignored'],
+      note: 'keep me',
+    };
+    const path = tempConfig(JSON.stringify(config));
+
+    expect(addModelToSection('provider/new', 'work', path)).toEqual({ ok: true, added: true });
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({
+      ...config,
+      sections: { work: ['provider/old', 'provider/new'], personal: ['provider/new'] },
+    });
+  });
+
+  it('does not rewrite a duplicate, including a whitespace-padded reference', () => {
+    const content = '{ "sections": { "work": [" provider/model "] } }';
+    const path = tempConfig(content);
+
+    expect(addModelToSection('provider/model', 'work', path)).toEqual({ ok: true, added: false });
+    expect(readFileSync(path, 'utf8')).toBe(content);
+  });
+
+  it('keeps the legacy flat format', () => {
+    const path = tempConfig(JSON.stringify({ models: ['provider/old'], note: 'keep' }));
+
+    expect(addModelToSection('provider/new', 'models', path)).toEqual({ ok: true, added: true });
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({
+      models: ['provider/old', 'provider/new'],
+      note: 'keep',
+    });
+  });
+
+  it('creates missing config directories and preserves slashes in model IDs', () => {
+    const path = join(tempConfig(), 'configs', 'model-switch.json');
+
+    expect(addModelToSection('fireworks/accounts/fireworks/models/kimi-k3', 'personal', path)).toEqual({
+      ok: true,
+      added: true,
+    });
+    expect(loadModelSwitchConfig(path)).toEqual({
+      ok: true,
+      config: { sections: [{ name: 'personal', models: ['fireworks/accounts/fireworks/models/kimi-k3'] }] },
+    });
+  });
+
+  it('supports section names that match object prototype properties', () => {
+    const path = tempConfig();
+
+    expect(addModelToSection('provider/model', '__proto__', path)).toEqual({ ok: true, added: true });
+    expect(loadModelSwitchConfig(path)).toEqual({
+      ok: true,
+      config: { sections: [{ name: '__proto__', models: ['provider/model'] }] },
+    });
+  });
+
+  it.each(['{ nope', '{"sections":null,"models":[]}', '{"sections":[[]]}', '{"sections":{"work":[42]}}'])(
+    'does not overwrite malformed config: %s',
+    (content) => {
+      const path = tempConfig(content);
+      const result = addModelToSection('provider/new', 'work', path);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain(path);
+      expect(readFileSync(path, 'utf8')).toBe(content);
+    },
+  );
+
+  it('does not recreate a section removed while the picker was open', () => {
+    const content = '{"sections":{"personal":[]}}';
+    const path = tempConfig(content);
+
+    expect(addModelToSection('provider/new', 'work', path)).toEqual({
+      ok: false,
+      error: `Section "work" no longer exists in ${path}`,
+    });
+    expect(readFileSync(path, 'utf8')).toBe(content);
+  });
+
+  it('updates a symlink target without replacing the link', () => {
+    const path = tempConfig('{"sections":{"work":[]}}');
+    const link = `${path}.link`;
+    symlinkSync(path, link);
+
+    expect(addModelToSection('provider/new', 'work', link)).toEqual({ ok: true, added: true });
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({ sections: { work: ['provider/new'] } });
+  });
+
+  it('does not replace a dangling config symlink', () => {
+    const path = tempConfig();
+    const link = `${path}.link`;
+    symlinkSync(path, link);
+
+    expect(addModelToSection('provider/new', 'work', link).ok).toBe(false);
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+  });
+
+  it('preserves the original config and cleans up when replacing the file fails', () => {
+    const content = '{"sections":{"work":[]}}';
+    const path = tempConfig(content);
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      throw new Error('disk error');
+    });
+
+    expect(addModelToSection('provider/new', 'work', path)).toEqual({
+      ok: false,
+      error: `Could not update model-switch config at ${path}: disk error`,
+    });
+    expect(readFileSync(path, 'utf8')).toBe(content);
+    expect(readdirSync(join(path, '..'))).toEqual(['model-switch.json']);
   });
 });

--- a/packages/model-switch/config.ts
+++ b/packages/model-switch/config.ts
@@ -1,5 +1,16 @@
-import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
 import { getAgentDir } from '@earendil-works/pi-coding-agent';
 
 export interface ModelSwitchSection {
@@ -91,14 +102,21 @@ export function loadModelSwitchConfig(path = modelCycleConfigPath()): ConfigLoad
     return { ok: false, error: `Invalid model-switch config at ${path}: ${message}` };
   }
 
-  if (!value || typeof value !== 'object') {
+  return parseModelSwitchConfig(value, path);
+}
+
+function parseModelSwitchConfig(value: unknown, path: string): ConfigLoadResult {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
     return { ok: false, error: `Invalid model-switch config at ${path}: expected an object` };
   }
 
   const obj = value as Record<string, unknown>;
 
   // Prefer "sections" if present; fall back to legacy "models" as a single section.
-  if ('sections' in obj && obj.sections && typeof obj.sections === 'object') {
+  if ('sections' in obj) {
+    if (!obj.sections || typeof obj.sections !== 'object' || Array.isArray(obj.sections)) {
+      return { ok: false, error: `Invalid model-switch config at ${path}: expected "sections" to be an object` };
+    }
     const sectionsRaw = obj.sections as Record<string, unknown>;
     const sections: ModelSwitchSection[] = [];
 
@@ -128,4 +146,45 @@ export function loadModelSwitchConfig(path = modelCycleConfigPath()): ConfigLoad
     ok: false,
     error: `Invalid model-switch config at ${path}: expected { "sections": { ... } } or { "models": [...] }`,
   };
+}
+
+export function addModelToSection(
+  reference: string,
+  sectionName: string,
+  path = modelCycleConfigPath(),
+): { ok: true; added: boolean } | { ok: false; error: string } {
+  try {
+    // Read again after the dialogs so edits made while they were open are retained.
+    const existing = lstatSync(path, { throwIfNoEntry: false });
+    const target = existing ? realpathSync(path) : path;
+    const value = existing ? JSON.parse(readFileSync(target, 'utf8')) : { sections: { [sectionName]: [] } };
+    const loaded = parseModelSwitchConfig(value, path);
+    if (!loaded.ok) return loaded;
+
+    const section = loaded.config.sections.find((item) => item.name === sectionName);
+    if (!section) {
+      return { ok: false, error: `Section "${sectionName}" no longer exists in ${path}` };
+    }
+    if (section.models.includes(reference)) return { ok: true, added: false };
+
+    const models: string[] = 'sections' in value ? value.sections[sectionName] : value.models;
+    models.push(reference);
+
+    // Replace the file atomically, following config symlinks rather than replacing them.
+    mkdirSync(dirname(target), { recursive: true });
+    const temporaryPath = `${target}.${randomUUID()}.tmp`;
+    try {
+      writeFileSync(temporaryPath, `${JSON.stringify(value, null, 2)}\n`, {
+        flag: 'wx',
+        mode: existing ? statSync(target).mode & 0o777 : 0o600,
+      });
+      renameSync(temporaryPath, target);
+    } finally {
+      rmSync(temporaryPath, { force: true });
+    }
+    return { ok: true, added: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `Could not update model-switch config at ${path}: ${message}` };
+  }
 }

--- a/packages/model-switch/index.test.ts
+++ b/packages/model-switch/index.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
+import { loadModelSwitchConfig, modelCycleConfigPath } from './config.js';
+import { SectionPicker } from './section-picker.js';
 import modelCycle from './index.js';
 
 const tempDirs: string[] = [];
@@ -44,6 +46,9 @@ function harness(
     unauthenticated?: string[];
     switchResult?: boolean;
     customResult?: string | null;
+    selectResult?: string;
+    inputResult?: string | undefined;
+    mode?: ExtensionContext['mode'];
     hasUI?: boolean;
   } = {},
 ) {
@@ -54,6 +59,8 @@ function harness(
   const setModel = vi.fn(async () => options.switchResult ?? true);
   const notify = vi.fn();
   const custom = vi.fn(async () => options.customResult ?? null);
+  const select = vi.fn(async () => options.selectResult);
+  const input = vi.fn(async () => options.inputResult);
   const models = options.models ?? [];
   const byReference = new Map(models.map((item) => [`${item.provider}/${item.id}`, item]));
   const unauthenticated = new Set(options.unauthenticated ?? []);
@@ -71,7 +78,9 @@ function harness(
   const ctx = {
     model: options.current,
     hasUI: options.hasUI ?? true,
+    mode: options.mode ?? 'tui',
     modelRegistry: {
+      getAvailable: () => models.filter((item) => !unauthenticated.has(`${item.provider}/${item.id}`)),
       find(provider: string, modelId: string) {
         return byReference.get(`${provider}/${modelId}`);
       },
@@ -82,11 +91,11 @@ function harness(
           : { ok: true as const, apiKey: 'test' };
       },
     },
-    ui: { notify, custom },
+    ui: { notify, custom, select, input },
   } as unknown as ExtensionContext;
 
   modelCycle(pi);
-  return { shortcuts, commands, setModel, notify, custom, ctx };
+  return { shortcuts, commands, setModel, notify, custom, select, input, ctx };
 }
 
 beforeEach(() => {
@@ -256,5 +265,202 @@ describe('model-switch extension', () => {
     await commands.get('model-switch')!('', ctx);
 
     expect(notify).toHaveBeenCalledWith('Could not switch to provider/target', 'warning');
+  });
+
+  it('picks from available models and appends to the chosen section without switching', async () => {
+    const target = model('provider', 'new');
+    writeConfig({ work: ['provider/old'], personal: [] });
+    const { commands, ctx, custom, select, notify, setModel } = harness({
+      models: [target, model('locked', 'hidden')],
+      unauthenticated: ['locked/hidden'],
+      customResult: 'provider/new',
+      selectResult: 'personal',
+    });
+
+    await commands.get('model-switch')!('add', ctx);
+
+    expect(select).toHaveBeenCalledWith('Add provider/new to section', ['work', 'personal']);
+    expect(loadModelSwitchConfig()).toEqual({
+      ok: true,
+      config: {
+        sections: [
+          { name: 'work', models: ['provider/old'] },
+          { name: 'personal', models: ['provider/new'] },
+        ],
+      },
+    });
+    expect(setModel).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith('Added provider/new to "personal"', 'info');
+
+    // Exercise the actual picker factory, not just the mocked dialog result.
+    const factory = (custom.mock.calls as unknown[][])[0]![0] as Parameters<ExtensionContext['ui']['custom']>[0];
+    const done = vi.fn();
+    const picker = (await factory(
+      {} as never,
+      { fg: (_color: string, text: string) => text, bold: (text: string) => text } as never,
+      {} as never,
+      done,
+    )) as SectionPicker;
+    expect(picker.render(160).join('\n')).not.toContain('locked/hidden');
+    for (const key of 'new') picker.handleInput(key);
+    picker.handleInput('\r');
+    expect(done).toHaveBeenCalledWith('provider/new');
+  });
+
+  it('saves the current model and skips a duplicate on the next invocation', async () => {
+    writeConfig({ work: [] });
+    const { commands, ctx, custom, notify, setModel } = harness({
+      current: model('provider', 'current'),
+      selectResult: 'work',
+    });
+
+    await commands.get('model-switch')!('add-current', ctx);
+    await commands.get('model-switch')!('add-current', ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(setModel).not.toHaveBeenCalled();
+    expect(loadModelSwitchConfig()).toEqual({
+      ok: true,
+      config: { sections: [{ name: 'work', models: ['provider/current'] }] },
+    });
+    expect(notify).toHaveBeenLastCalledWith('provider/current is already in "work"', 'info');
+  });
+
+  it('creates a first section when no config exists', async () => {
+    const { commands, ctx, input } = harness({ current: model('provider', 'current'), inputResult: ' personal ' });
+
+    await commands.get('model-switch')!('add-current', ctx);
+
+    expect(input).toHaveBeenCalled();
+    expect(loadModelSwitchConfig()).toEqual({
+      ok: true,
+      config: { sections: [{ name: 'personal', models: ['provider/current'] }] },
+    });
+  });
+
+  it.each(['add', 'add-current'])('does not write when the section selection is cancelled for %s', async (command) => {
+    writeConfig({ work: [] });
+    const content = readFileSync(modelCycleConfigPath(), 'utf8');
+    const target = model('provider', 'new');
+    const { commands, ctx, notify } = harness({ current: target, models: [target], customResult: 'provider/new' });
+
+    await commands.get('model-switch')!(command, ctx);
+
+    expect(readFileSync(modelCycleConfigPath(), 'utf8')).toBe(content);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('does not ask for a section or write when the catalog picker is cancelled', async () => {
+    const { commands, ctx, select, input } = harness({ models: [model('provider', 'new')] });
+
+    await commands.get('model-switch')!('add', ctx);
+
+    expect(select).not.toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(existsSync(modelCycleConfigPath())).toBe(false);
+  });
+
+  it.each([undefined, '', '   '])('does not create a config without a section name: %s', async (inputResult) => {
+    const { commands, ctx } = harness({ current: model('provider', 'new'), inputResult });
+
+    await commands.get('model-switch')!('add-current', ctx);
+
+    expect(existsSync(modelCycleConfigPath())).toBe(false);
+  });
+
+  it.each(['add', 'add-current'])('does not prompt or write without UI for %s', async (command) => {
+    const target = model('provider', 'new');
+    const { commands, ctx, custom, select, input } = harness({
+      hasUI: false,
+      current: target,
+      models: [target],
+      customResult: 'provider/new',
+      inputResult: 'work',
+    });
+
+    await commands.get('model-switch')!(command, ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+    expect(input).not.toHaveBeenCalled();
+    expect(existsSync(modelCycleConfigPath())).toBe(false);
+  });
+
+  it('warns when no current model or available catalog model exists', async () => {
+    const { commands, ctx, notify, custom, select } = harness();
+
+    await commands.get('model-switch')!('add-current', ctx);
+    expect(notify).toHaveBeenLastCalledWith('No model selected to add', 'warning');
+    await commands.get('model-switch')!('add', ctx);
+    expect(notify).toHaveBeenLastCalledWith(expect.stringContaining('No available models to add'), 'warning');
+    expect(custom).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+    expect(existsSync(modelCycleConfigPath())).toBe(false);
+  });
+
+  it('refuses custom catalog UI in RPC mode', async () => {
+    const { commands, ctx, notify, custom } = harness({ mode: 'rpc' });
+
+    await commands.get('model-switch')!('add', ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith('/model-switch add requires the terminal UI', 'warning');
+  });
+
+  it.each(['add', 'add-current'])('refuses malformed config before prompting for %s', async (command) => {
+    writeConfig({ work: [] });
+    writeFileSync(modelCycleConfigPath(), '{ nope');
+    const { commands, ctx, notify, custom, select } = harness({ current: model('provider', 'new') });
+
+    await commands.get('model-switch')!(command, ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining(modelCycleConfigPath()), 'warning');
+    expect(readFileSync(modelCycleConfigPath(), 'utf8')).toBe('{ nope');
+  });
+
+  it('retains edits made while the section prompt was open', async () => {
+    writeConfig({ work: [] });
+    const { commands, ctx, select } = harness({ current: model('provider', 'new') });
+    select.mockImplementation(async () => {
+      writeFileSync(modelCycleConfigPath(), JSON.stringify({ sections: { work: ['provider/edited'], personal: [] } }));
+      return 'work';
+    });
+
+    await commands.get('model-switch')!('add-current', ctx);
+
+    expect(loadModelSwitchConfig()).toEqual({
+      ok: true,
+      config: {
+        sections: [
+          { name: 'work', models: ['provider/edited', 'provider/new'] },
+          { name: 'personal', models: [] },
+        ],
+      },
+    });
+  });
+
+  it('reports save errors instead of claiming the model was added', async () => {
+    writeConfig({ work: [] });
+    const { commands, ctx, select, notify } = harness({ current: model('provider', 'new') });
+    select.mockImplementation(async () => {
+      writeFileSync(modelCycleConfigPath(), '{ broken during selection');
+      return 'work';
+    });
+
+    await commands.get('model-switch')!('add-current', ctx);
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(expect.stringContaining('Could not update model-switch config'), 'warning');
+  });
+
+  it('shows usage for unknown arguments without opening a picker', async () => {
+    const { commands, ctx, notify, custom } = harness();
+
+    await commands.get('model-switch')!('typo', ctx);
+
+    expect(custom).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith('Usage: /model-switch [add | add-current]', 'warning');
   });
 });

--- a/packages/model-switch/index.ts
+++ b/packages/model-switch/index.ts
@@ -1,7 +1,12 @@
 import type { Api, Model } from '@earendil-works/pi-ai';
 import type { ExtensionAPI, ExtensionContext } from '@earendil-works/pi-coding-agent';
 import type { SelectItem } from '@earendil-works/pi-tui';
-import { loadModelSwitchConfig, loadModelSwitchKeybindings, modelCycleConfigPath } from './config.js';
+import {
+  addModelToSection,
+  loadModelSwitchConfig,
+  loadModelSwitchKeybindings,
+  modelCycleConfigPath,
+} from './config.js';
 import { findActiveSection, resolveAvailableModels, selectCycleTarget, type CycleDirection } from './cycle.js';
 import { SectionPicker, type PickerSection } from './section-picker.js';
 
@@ -88,6 +93,60 @@ async function showModelPicker(pi: ExtensionAPI, ctx: ExtensionContext): Promise
   if (target) await switchModel(pi, ctx, target);
 }
 
+async function addConfiguredModel(ctx: ExtensionContext, useCurrent: boolean): Promise<void> {
+  if (!ctx.hasUI) return;
+  if (!useCurrent && ctx.mode !== 'tui') {
+    ctx.ui.notify('/model-switch add requires the terminal UI', 'warning');
+    return;
+  }
+
+  const loaded = loadModelSwitchConfig();
+  if (!loaded.ok) {
+    ctx.ui.notify(loaded.error, 'warning');
+    return;
+  }
+
+  let target = ctx.model;
+  if (!useCurrent) {
+    const available = ctx.modelRegistry.getAvailable();
+    if (available.length === 0) {
+      ctx.ui.notify('No available models to add. Configure a provider with /login first.', 'warning');
+      return;
+    }
+    const selected = await ctx.ui.custom<string | null>((_tui, theme, _keybindings, done) => {
+      return new SectionPicker([{ name: 'Add a model', items: buildSectionItems(available, ctx.model) }], theme, done);
+    });
+    if (!selected) return;
+    target = available.find((model) => `${model.provider}/${model.id}` === selected);
+  }
+  if (!target) {
+    ctx.ui.notify('No model selected to add', 'warning');
+    return;
+  }
+
+  const reference = `${target.provider}/${target.id}`;
+  const sections = loaded.config.sections.map((section) => section.name);
+  const sectionName =
+    sections.length > 0
+      ? await ctx.ui.select(`Add ${reference} to section`, sections)
+      : (await ctx.ui.input('Name your first model-switch section', 'models'))?.trim();
+  if (sectionName === undefined) return;
+  if (sections.length === 0 && !sectionName) {
+    ctx.ui.notify('Section name must not be empty', 'warning');
+    return;
+  }
+
+  const result = addModelToSection(reference, sectionName);
+  if (!result.ok) {
+    ctx.ui.notify(result.error, 'warning');
+    return;
+  }
+  ctx.ui.notify(
+    result.added ? `Added ${reference} to "${sectionName}"` : `${reference} is already in "${sectionName}"`,
+    'info',
+  );
+}
+
 export default function modelCycle(pi: ExtensionAPI) {
   const keybindings = loadModelSwitchKeybindings();
   type ShortcutKey = Parameters<ExtensionAPI['registerShortcut']>[0];
@@ -108,7 +167,25 @@ export default function modelCycle(pi: ExtensionAPI) {
   });
 
   pi.registerCommand('model-switch', {
-    description: 'Select from configured models',
-    handler: async (_args, ctx) => showModelPicker(pi, ctx),
+    description: 'Select configured models, add a model, or add-current',
+    getArgumentCompletions: (prefix) => {
+      const items = [
+        { value: 'add', label: 'add', description: 'Pick an available model to save' },
+        { value: 'add-current', label: 'add-current', description: 'Save the current model' },
+      ].filter((item) => item.value.startsWith(prefix));
+      return items.length > 0 ? items : null;
+    },
+    handler: async (args, ctx) => {
+      switch (args.trim()) {
+        case '':
+          return showModelPicker(pi, ctx);
+        case 'add':
+          return addConfiguredModel(ctx, false);
+        case 'add-current':
+          return addConfiguredModel(ctx, true);
+        default:
+          ctx.ui.notify('Usage: /model-switch [add | add-current]', 'warning');
+      }
+    },
   });
 }


### PR DESCRIPTION
## Summary

- `/model-switch add` searches available models, then saves the selection to a chosen section.
- `/model-switch add-current` saves the active model without opening the catalog picker.

Both commands skip duplicates within the chosen section and cancel without writing. Saves preserve existing config data and the legacy format, use atomic replacement, and respect symlinks. Includes command completion, documentation, regression tests, and a minor changeset.

## Verification

All 78 model-switch tests passed. Repository typecheck, lint, build, tracked-file formatting, changed-file formatting, and a scratch Pi extension-load smoke test passed. Independent review found no blockers.

The full `pnpm format:check` reports pre-existing formatting issues in 27 ignored `.pi/artifacts` files. Those files are unrelated and untouched.