### PR TITLE
fix(btw,answer,handoff): forward auth env to side-model streams

### DIFF
--- a/.changeset/forward-auth-env.md
+++ b/.changeset/forward-auth-env.md
@@ -1,0 +1,7 @@
+---
+'@nicknisi/pi-btw': patch
+'@nicknisi/pi-answer': patch
+'@nicknisi/pi-handoff': patch
+---
+
+Forward `env` from `getApiKeyAndHeaders()` to the side-model stream so providers that resolve endpoint placeholders from it (Cloudflare AI Gateway, Workers AI) stop 401ing.

--- a/.changeset/forward-auth-env.md
+++ b/.changeset/forward-auth-env.md
@@ -5,3 +5,5 @@
 ---
 
 Forward `env` from `getApiKeyAndHeaders()` to the side-model stream so providers that resolve endpoint placeholders from it (Cloudflare AI Gateway, Workers AI) stop 401ing.
+
+`btw` now builds its side-thread context from `buildContextEntries()` (compaction applied, with the summary carried as a leading message) instead of the raw branch, so long sessions no longer exceed the model window (`400 prompt is too long`).

--- a/packages/answer/index.ts
+++ b/packages/answer/index.ts
@@ -176,7 +176,10 @@ async function selectExtractionModel(
     find: (provider: string, modelId: string) => Model<Api> | undefined;
     getApiKeyAndHeaders: (
       model: Model<Api>,
-    ) => Promise<{ ok: true; apiKey?: string; headers?: Record<string, string | null> } | { ok: false; error: string }>;
+    ) => Promise<
+      | { ok: true; apiKey?: string; headers?: Record<string, string | null>; env?: Record<string, string> }
+      | { ok: false; error: string }
+    >;
   },
   preferences: readonly ModelPreference[],
 ): Promise<Model<Api> | undefined> {
@@ -526,6 +529,7 @@ export default function (pi: ExtensionAPI) {
             {
               ...(auth.apiKey !== undefined && { apiKey: auth.apiKey }),
               ...(auth.headers !== undefined && { headers: auth.headers }),
+              ...(auth.env !== undefined && { env: auth.env }),
               signal: loader.signal,
             },
           )

--- a/packages/btw/index.ts
+++ b/packages/btw/index.ts
@@ -426,11 +426,20 @@ export default function (pi: ExtensionAPI) {
         return;
       }
 
-      // Gather branch messages and convert to LLM format
-      const branch = ctx.sessionManager.getBranch();
-      const agentMessages = branch
-        .filter((e): e is SessionEntry & { type: 'message' } => e.type === 'message')
-        .map((e) => e.message);
+      // Gather the context the main agent actually sees (compaction applied) and convert
+      // to LLM format. `getBranch()` is the raw history and can exceed the model's window
+      // on long sessions; a compaction entry becomes a leading user message carrying its summary.
+      const contextEntries = ctx.sessionManager.buildContextEntries();
+      const agentMessages: Extract<SessionEntry, { type: 'message' }>['message'][] = [];
+      for (const e of contextEntries) {
+        if (e.type === 'message') agentMessages.push(e.message);
+        else if (e.type === 'compaction')
+          agentMessages.push({
+            role: 'user',
+            content: [{ type: 'text', text: `Summary of the conversation so far:\n\n${e.summary}` }],
+            timestamp: Date.now(),
+          });
+      }
       const llmMessages: Message[] = convertToLlm(agentMessages);
 
       // If /btw runs mid-turn, trailing tool calls have no results yet and

--- a/packages/btw/index.ts
+++ b/packages/btw/index.ts
@@ -462,7 +462,7 @@ export default function (pi: ExtensionAPI) {
         ctx.ui.notify(`No API key for ${model.provider}/${model.id}: ${auth.error}`, 'error');
         return;
       }
-      const { apiKey, headers } = auth;
+      const { apiKey, headers, env } = auth;
 
       const modelId = model.id;
       const modelName = `${model.provider}/${modelId}`;
@@ -508,6 +508,7 @@ export default function (pi: ExtensionAPI) {
               {
                 ...(apiKey !== undefined && { apiKey }),
                 ...(headers !== undefined && { headers }),
+                ...(env !== undefined && { env }),
                 ...(reasoning !== undefined && { reasoning }),
                 ...(signal !== undefined && { signal }),
               },

--- a/packages/handoff/index.ts
+++ b/packages/handoff/index.ts
@@ -105,7 +105,7 @@ export default function (pi: ExtensionAPI) {
               error: `No API key for ${ctx.model!.provider}/${ctx.model!.id}: ${auth.error}`,
             };
           }
-          const { apiKey, headers } = auth;
+          const { apiKey, headers, env } = auth;
 
           const userMessage: Message = {
             role: 'user',
@@ -122,7 +122,7 @@ export default function (pi: ExtensionAPI) {
             .stream(
               ctx.model!,
               { systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
-              { apiKey, headers, signal: loader.signal },
+              { apiKey, headers, env, signal: loader.signal },
             )
             .result();
 


### PR DESCRIPTION
`/btw` 401'd for me the first time I tried it: `401 Invalid request path. Expected path prefix /v1/:accountTag/:gatewayId`. I route every model through a Cloudflare AI Gateway, whose model `baseUrl`s carry `{CLOUDFLARE_ACCOUNT_ID}`/`{CLOUDFLARE_GATEWAY_ID}` placeholders that pi-ai fills in from the `env` returned by `getApiKeyAndHeaders()` at stream time. `btw`, `answer` and `handoff` forward `apiKey` and `headers` but drop `env`, so the request goes out with the braces literal. `session-name` already passes `env` through — this brings the other three side-model callers in line.

- `/btw`, `/answer` and `/handoff` work on Cloudflare AI Gateway and Workers AI routes (any provider whose `resolve` returns `env`).
- No change for direct-provider users; `env` is `undefined` for them and is spread conditionally.

Test plan (CI can't reach a gateway):
- Before: `provider.stream(model, …, { apiKey, headers })` against `cloudflare-ai-gateway/claude-*` → `401 Invalid request path`; after adding `env` → `stop`, `"ok"`. Reproduced both in one pi process with a throwaway extension calling the exact btw path.
- Patched the same three lines into my installed `dist/` copies; `/btw` answers through the gateway.

— 🐾 agent of @tribble
